### PR TITLE
chore: more clear error message when accessing 'components'

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionServiceSourceGenerator.scala
@@ -162,7 +162,7 @@ object ActionServiceSourceGenerator {
         |public abstract class ${service.abstractActionName} extends kalix.javasdk.action.Action {
         |
         |  protected final Components components() {
-        |    return new ComponentsImpl(actionContext());
+        |    return new ComponentsImpl(contextForComponents());
         |  }
         |
         |  ${Format.indent(methods, 2)}

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/AbstractMyServiceNamedAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/AbstractMyServiceNamedAction.java
@@ -13,7 +13,7 @@ import org.example.ComponentsImpl;
 public abstract class AbstractMyServiceNamedAction extends kalix.javasdk.action.Action {
 
   protected final Components components() {
-    return new ComponentsImpl(actionContext());
+    return new ComponentsImpl(contextForComponents());
   }
 
   public abstract Effect<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest);

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/AbstractMyServiceAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/AbstractMyServiceAction.java
@@ -13,7 +13,7 @@ import org.external.ExternalDomain;
 public abstract class AbstractMyServiceAction extends kalix.javasdk.action.Action {
 
   protected final Components components() {
-    return new ComponentsImpl(actionContext());
+    return new ComponentsImpl(contextForComponents());
   }
 
   public abstract Effect<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest);

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/AbstractMyServiceAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/AbstractMyServiceAction.java
@@ -13,7 +13,7 @@ import org.external.ExternalDomain;
 public abstract class AbstractMyServiceAction extends kalix.javasdk.action.Action {
 
   protected final Components components() {
-    return new ComponentsImpl(actionContext());
+    return new ComponentsImpl(contextForComponents());
   }
 
   public abstract Effect<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest);

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/AbstractMyServiceAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/AbstractMyServiceAction.java
@@ -11,7 +11,7 @@ import org.example.ComponentsImpl;
 public abstract class AbstractMyServiceAction extends kalix.javasdk.action.Action {
 
   protected final Components components() {
-    return new ComponentsImpl(actionContext());
+    return new ComponentsImpl(contextForComponents());
   }
 
   public abstract Effect<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest);

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ActionServiceSourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ActionServiceSourceGenerator.scala
@@ -135,7 +135,7 @@ object ActionServiceSourceGenerator {
           |abstract class ${service.abstractActionName} extends $Action {
           |
           |  def components: $Components =
-          |    new ${ComponentsImpl}(actionContext)
+          |    new ${ComponentsImpl}(contextForComponents)
           |
           |  $methods
           |}

--- a/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/AbstractMyServiceNamedAction.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/AbstractMyServiceNamedAction.scala
@@ -14,7 +14,7 @@ import org.example.ComponentsImpl
 abstract class AbstractMyServiceNamedAction extends Action {
 
   def components: Components =
-    new ComponentsImpl(actionContext)
+    new ComponentsImpl(contextForComponents)
 
   def simpleMethod(myRequest: MyRequest): Action.Effect[Empty]
 

--- a/codegen/scala-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/AbstractMyServiceAction.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/AbstractMyServiceAction.scala
@@ -14,7 +14,7 @@ import org.external.Empty
 abstract class AbstractMyServiceAction extends Action {
 
   def components: Components =
-    new ComponentsImpl(actionContext)
+    new ComponentsImpl(contextForComponents)
 
   def simpleMethod(myRequest: MyRequest): Action.Effect[Empty]
 

--- a/codegen/scala-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/AbstractMyServiceAction.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/AbstractMyServiceAction.scala
@@ -14,7 +14,7 @@ import org.external.Empty
 abstract class AbstractMyServiceAction extends Action {
 
   def components: Components =
-    new ComponentsImpl(actionContext)
+    new ComponentsImpl(contextForComponents)
 
   def simpleMethod(myRequest: MyRequest): Action.Effect[Empty]
 

--- a/codegen/scala-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/AbstractMyServiceAction.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/AbstractMyServiceAction.scala
@@ -12,7 +12,7 @@ import org.example.ComponentsImpl
 abstract class AbstractMyServiceAction extends Action {
 
   def components: Components =
-    new ComponentsImpl(actionContext)
+    new ComponentsImpl(contextForComponents)
 
   def simpleMethod(myRequest: MyRequest): Action.Effect[Empty]
 }

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/action/Action.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/action/Action.java
@@ -42,16 +42,14 @@ public abstract class Action {
   /**
    * INTERNAL API
    *
-   * Same as actionContext, but if specific error message when accessing components.
+   * <p>Same as actionContext, but if specific error message when accessing components.
    */
   protected final ActionContext contextForComponents() {
     return actionContext("Components can only be accessed when handling a message.");
   }
 
   private ActionContext actionContext(String errorMessage) {
-    return actionContext.orElseThrow(
-        () ->
-            new IllegalStateException(errorMessage));
+    return actionContext.orElseThrow(() -> new IllegalStateException(errorMessage));
   }
 
   /** INTERNAL API */

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/action/Action.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/action/Action.java
@@ -36,9 +36,22 @@ public abstract class Action {
    * <p>It will throw an exception if accessed from constructor.
    */
   protected final ActionContext actionContext() {
+    return actionContext("ActionContext is only available when handling a message.");
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * Same as actionContext, but if specific error message when accessing components.
+   */
+  protected final ActionContext contextForComponents() {
+    return actionContext("Components can only be accessed when handling a message.");
+  }
+
+  private ActionContext actionContext(String errorMessage) {
     return actionContext.orElseThrow(
         () ->
-            new IllegalStateException("ActionContext is only available when handling a message."));
+            new IllegalStateException(errorMessage));
   }
 
   /** INTERNAL API */

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
@@ -151,8 +151,18 @@ abstract class Action {
    * <p>It will throw an exception if accessed from constructor.
    */
   protected final def actionContext: ActionContext =
-    _actionContext.getOrElse(
-      throw new IllegalStateException("ActionContext is only available when handling a message."))
+    actionContext("ActionContext is only available when handling a message.")
+
+  /**
+   * INTERNAL API
+   *
+   * Same as actionContext, but if specific error message when accessing components.
+   */
+  protected final def contextForComponents: ActionContext =
+    actionContext("Components can only be accessed when handling a message.")
+
+  private def actionContext(errorMessage: String): ActionContext =
+    _actionContext.getOrElse(throw new IllegalStateException(errorMessage))
 
   /** INTERNAL API */
   final def _internalSetActionContext(context: Option[ActionContext]): Unit = {


### PR DESCRIPTION
This came to the surface when working on the Timers API. 

If a user calls `components()` from outside a command handler, they get an exception with message: "ActionContext is only available when handling a message."

Not so helpful since the user don't see they are accessing the `actionContext`. 

(sending in separated PR to not clutter the Timers API PR)