### PR TITLE
chore: add some missing 'final' modifiers

### DIFF
--- a/sdk/java-sdk/src/main/java/kalix/javasdk/replicatedentity/ReplicatedEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/replicatedentity/ReplicatedEntity.java
@@ -48,7 +48,7 @@ public abstract class ReplicatedEntity<D extends ReplicatedData> {
    *
    * <p>It will throw an exception if accessed from the entity constructor.
    */
-  protected CommandContext commandContext() {
+  protected final CommandContext commandContext() {
     return commandContext.orElseThrow(
         () ->
             new IllegalStateException("CommandContext is only available when handling a command."));
@@ -59,7 +59,7 @@ public abstract class ReplicatedEntity<D extends ReplicatedData> {
     commandContext = context;
   }
 
-  protected <R> Effect.Builder<D> effects() {
+  protected final <R> Effect.Builder<D> effects() {
     return new ReplicatedEntityEffectImpl<D, R>();
   }
 

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -45,7 +45,7 @@ public abstract class ValueEntity<S> {
    *
    * <p>It will throw an exception if accessed from constructor.
    */
-  protected CommandContext commandContext() {
+  protected final CommandContext commandContext() {
     return commandContext.orElseThrow(
         () ->
             new IllegalStateException("CommandContext is only available when handling a command."));
@@ -56,7 +56,7 @@ public abstract class ValueEntity<S> {
     commandContext = context;
   }
 
-  protected Effect.Builder<S> effects() {
+  protected final Effect.Builder<S> effects() {
     return new ValueEntityEffectImpl<S>();
   }
 

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
@@ -150,15 +150,15 @@ abstract class Action {
    *
    * <p>It will throw an exception if accessed from constructor.
    */
-  protected def actionContext: ActionContext =
+  protected final def actionContext: ActionContext =
     _actionContext.getOrElse(
       throw new IllegalStateException("ActionContext is only available when handling a message."))
 
   /** INTERNAL API */
-  def _internalSetActionContext(context: Option[ActionContext]): Unit = {
+  final def _internalSetActionContext(context: Option[ActionContext]): Unit = {
     _actionContext = context
   }
 
-  protected def effects[T]: Action.Effect.Builder =
+  protected final def effects[T]: Action.Effect.Builder =
     ActionEffectImpl.builder()
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/eventsourcedentity/EventSourcedEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/eventsourcedentity/EventSourcedEntity.scala
@@ -206,7 +206,7 @@ abstract class EventSourcedEntity[S] {
    *
    * <p>It will throw an exception if accessed from constructor.
    */
-  protected def commandContext(): CommandContext = {
+  protected final def commandContext(): CommandContext = {
     try {
       _commandContext.get
     } catch {
@@ -216,7 +216,7 @@ abstract class EventSourcedEntity[S] {
   }
 
   /** INTERNAL API */
-  def _internalSetCommandContext(context: Option[CommandContext]): Unit = {
+  final def _internalSetCommandContext(context: Option[CommandContext]): Unit = {
     _commandContext = context
   }
 
@@ -225,7 +225,7 @@ abstract class EventSourcedEntity[S] {
    *
    * <p>It will throw an exception if accessed from constructor.
    */
-  protected def eventContext(): EventContext = {
+  protected final def eventContext(): EventContext = {
     try {
       _eventContext.get
     } catch {
@@ -235,11 +235,11 @@ abstract class EventSourcedEntity[S] {
   }
 
   /** INTERNAL API */
-  def _internalSetEventContext(context: Option[EventContext]): Unit = {
+  final def _internalSetEventContext(context: Option[EventContext]): Unit = {
     _eventContext = context
   }
 
-  protected def effects: EventSourcedEntity.Effect.Builder[S] =
+  protected final def effects: EventSourcedEntity.Effect.Builder[S] =
     EventSourcedEntityEffectImpl[Any, S]()
 
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/replicatedentity/ReplicatedEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/replicatedentity/ReplicatedEntity.scala
@@ -207,14 +207,14 @@ abstract class ReplicatedEntity[D <: ReplicatedData] {
    *
    * It will throw an exception if accessed from constructor.
    */
-  protected def commandContext(): CommandContext =
+  protected final def commandContext(): CommandContext =
     _commandContext.getOrElse(
       throw new IllegalStateException("CommandContext is only available when handling a command."))
 
   /** INTERNAL API */
-  def _internalSetCommandContext(context: Option[CommandContext]): Unit =
+  final def _internalSetCommandContext(context: Option[CommandContext]): Unit =
     _commandContext = context
 
-  protected def effects: ReplicatedEntity.Effect.Builder[D] =
+  protected final def effects: ReplicatedEntity.Effect.Builder[D] =
     ReplicatedEntityEffectImpl()
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/valueentity/ValueEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/valueentity/ValueEntity.scala
@@ -195,7 +195,7 @@ abstract class ValueEntity[S] {
    *
    * <p>It will throw an exception if accessed from constructor.
    */
-  protected def commandContext(): CommandContext = {
+  protected final def commandContext(): CommandContext = {
     try {
       _commandContext.get
     } catch {
@@ -205,11 +205,11 @@ abstract class ValueEntity[S] {
   }
 
   /** INTERNAL API */
-  def _internalSetCommandContext(context: Option[CommandContext]): Unit = {
+  final def _internalSetCommandContext(context: Option[CommandContext]): Unit = {
     _commandContext = context
   }
 
-  protected def effects: ValueEntity.Effect.Builder[S] =
+  protected final def effects: ValueEntity.Effect.Builder[S] =
     ValueEntityEffectImpl[S]()
 
 }


### PR DESCRIPTION
Found out some methods that should be marked as final. 

Unfortunately, the `_internalSet*Context` in Java API can't be marked as final as we override them in the Java to Scala adapters. 