### PR TITLE
Codegen: Mark JUnit tests as ignored

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
@@ -99,6 +99,7 @@ object ActionTestKitGenerator {
         s"${packageName}.${className}TestKit",
         "akka.stream.javadsl.Source",
         "kalix.javasdk.testkit.ActionResult",
+        "org.junit.Ignore",
         "org.junit.Test",
         "static org.junit.Assert.*")
         ++ commandStreamedTypes(service.commands))
@@ -114,6 +115,7 @@ object ActionTestKitGenerator {
         |public class $testClassName {
         |
         |  @Test
+        |  @Ignore("to be implemented")
         |  public void exampleTest() {
         |    ${className}TestKit testKit = ${className}TestKit.of($className::new);
         |    // use the testkit to execute a command
@@ -149,6 +151,7 @@ object ActionTestKitGenerator {
     service.commands
       .map { command =>
         s"""|@Test
+            |@Ignore("to be implemented")
             |public void ${lowerFirst(command.name)}Test() {
             |  ${service.className}TestKit testKit = ${service.className}TestKit.of(${service.className}::new);""".stripMargin +
         (if (command.isUnary || command.isStreamOut) {

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntityTestKitGenerator.scala
@@ -165,6 +165,7 @@ object EventSourcedEntityTestKitGenerator {
         "kalix.javasdk.eventsourcedentity.EventSourcedEntity",
         "kalix.javasdk.eventsourcedentity.EventSourcedEntityContext",
         "kalix.javasdk.testkit.EventSourcedResult",
+        "org.junit.Ignore",
         "org.junit.Test"))
 
     val entityClassName = entity.messageType.name
@@ -172,6 +173,7 @@ object EventSourcedEntityTestKitGenerator {
 
     val dummyTestCases = service.commands.map { command =>
       s"""|@Test
+          |@Ignore("to be implemented")
           |public void ${lowerFirst(command.name)}Test() {
           |  $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
           |  // EventSourcedResult<${command.outputType.name}> result = testKit.${lowerFirst(command.name)}(${command.inputType.name}.newBuilder()...build());
@@ -191,6 +193,7 @@ object EventSourcedEntityTestKitGenerator {
       |public class ${entityClassName}Test {
       |
       |  @Test
+      |  @Ignore("to be implemented")
       |  public void exampleTest() {
       |    $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
       |    // use the testkit to execute a command

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
@@ -155,6 +155,7 @@ object ValueEntityTestKitGenerator {
         "com.google.protobuf.Empty",
         "kalix.javasdk.valueentity.ValueEntity",
         "kalix.javasdk.testkit.ValueEntityResult",
+        "org.junit.Ignore",
         "org.junit.Test"))
 
     val entityClassName = entity.messageType.name
@@ -162,6 +163,7 @@ object ValueEntityTestKitGenerator {
 
     val dummyTestCases = service.commands.map { command =>
       s"""|@Test
+          |@Ignore("to be implemented")
           |public void ${lowerFirst(command.name)}Test() {
           |  $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
           |  // ValueEntityResult<${command.outputType.name}> result = testKit.${lowerFirst(command.name)}(${command.inputType.name}.newBuilder()...build());
@@ -181,6 +183,7 @@ object ValueEntityTestKitGenerator {
        |public class ${entityClassName}Test {
        |
        |  @Test
+       |  @Ignore("to be implemented")
        |  public void exampleTest() {
        |    $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
        |    // use the testkit to execute a command

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-unmanaged/org/example/service/MyServiceNamedActionTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-unmanaged/org/example/service/MyServiceNamedActionTest.java
@@ -7,6 +7,7 @@ import kalix.javasdk.testkit.ActionResult;
 import org.example.service.MyServiceNamedAction;
 import org.example.service.MyServiceNamedActionTestKit;
 import org.example.service.ServiceOuterClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -18,6 +19,7 @@ import static org.junit.Assert.*;
 public class MyServiceNamedActionTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     MyServiceNamedActionTestKit testKit = MyServiceNamedActionTestKit.of(MyServiceNamedAction::new);
     // use the testkit to execute a command
@@ -28,24 +30,28 @@ public class MyServiceNamedActionTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void simpleMethodTest() {
     MyServiceNamedActionTestKit testKit = MyServiceNamedActionTestKit.of(MyServiceNamedAction::new);
     // ActionResult<Empty> result = testKit.simpleMethod(ServiceOuterClass.MyRequest.newBuilder()...build());
   }
 
   @Test
+  @Ignore("to be implemented")
   public void streamedOutputMethodTest() {
     MyServiceNamedActionTestKit testKit = MyServiceNamedActionTestKit.of(MyServiceNamedAction::new);
     // Source<ActionResult<Empty>, akka.NotUsed> result = testKit.streamedOutputMethod(ServiceOuterClass.MyRequest.newBuilder()...build());
   }
 
   @Test
+  @Ignore("to be implemented")
   public void streamedInputMethodTest() {
     MyServiceNamedActionTestKit testKit = MyServiceNamedActionTestKit.of(MyServiceNamedAction::new);
     // ActionResult<Empty> result = testKit.streamedInputMethod(Source.single(ServiceOuterClass.MyRequest.newBuilder()...build()));
   }
 
   @Test
+  @Ignore("to be implemented")
   public void fullStreamedMethodTest() {
     MyServiceNamedActionTestKit testKit = MyServiceNamedActionTestKit.of(MyServiceNamedAction::new);
     // Source<ActionResult<Empty>, akka.NotUsed> result = testKit.fullStreamedMethod(Source.single(ServiceOuterClass.MyRequest.newBuilder()...build()));

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
@@ -7,6 +7,7 @@ import org.example.service.MyServiceAction;
 import org.example.service.MyServiceActionTestKit;
 import org.example.service.ServiceOuterClass;
 import org.external.ExternalDomain;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -18,6 +19,7 @@ import static org.junit.Assert.*;
 public class MyServiceActionTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // use the testkit to execute a command
@@ -28,24 +30,28 @@ public class MyServiceActionTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void simpleMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // ActionResult<ExternalDomain.Empty> result = testKit.simpleMethod(ServiceOuterClass.MyRequest.newBuilder()...build());
   }
 
   @Test
+  @Ignore("to be implemented")
   public void streamedOutputMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> result = testKit.streamedOutputMethod(ServiceOuterClass.MyRequest.newBuilder()...build());
   }
 
   @Test
+  @Ignore("to be implemented")
   public void streamedInputMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // ActionResult<ExternalDomain.Empty> result = testKit.streamedInputMethod(Source.single(ServiceOuterClass.MyRequest.newBuilder()...build()));
   }
 
   @Test
+  @Ignore("to be implemented")
   public void fullStreamedMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> result = testKit.fullStreamedMethod(Source.single(ServiceOuterClass.MyRequest.newBuilder()...build()));

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
@@ -7,6 +7,7 @@ import org.example.service.MyServiceAction;
 import org.example.service.MyServiceActionTestKit;
 import org.example.service.ServiceOuterClass;
 import org.external.ExternalDomain;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -18,6 +19,7 @@ import static org.junit.Assert.*;
 public class MyServiceActionTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // use the testkit to execute a command
@@ -28,24 +30,28 @@ public class MyServiceActionTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void simpleMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // ActionResult<ExternalDomain.Empty> result = testKit.simpleMethod(ServiceOuterClass.MyRequest.newBuilder()...build());
   }
 
   @Test
+  @Ignore("to be implemented")
   public void streamedOutputMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> result = testKit.streamedOutputMethod(ServiceOuterClass.MyRequest.newBuilder()...build());
   }
 
   @Test
+  @Ignore("to be implemented")
   public void streamedInputMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // ActionResult<ExternalDomain.Empty> result = testKit.streamedInputMethod(Source.single(ServiceOuterClass.MyRequest.newBuilder()...build()));
   }
 
   @Test
+  @Ignore("to be implemented")
   public void fullStreamedMethodTest() {
     MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
     // Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> result = testKit.fullStreamedMethod(Source.single(ServiceOuterClass.MyRequest.newBuilder()...build()));

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-unmanaged/org/example/service/MyServiceActionImplTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-unmanaged/org/example/service/MyServiceActionImplTest.java
@@ -6,6 +6,7 @@ import kalix.javasdk.testkit.ActionResult;
 import org.example.service.MyServiceActionImpl;
 import org.example.service.MyServiceActionImplTestKit;
 import org.example.service.ServiceOuterClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -17,6 +18,7 @@ import static org.junit.Assert.*;
 public class MyServiceActionImplTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     MyServiceActionImplTestKit testKit = MyServiceActionImplTestKit.of(MyServiceActionImpl::new);
     // use the testkit to execute a command
@@ -27,6 +29,7 @@ public class MyServiceActionImplTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void simpleMethodTest() {
     MyServiceActionImplTestKit testKit = MyServiceActionImplTestKit.of(MyServiceActionImpl::new);
     // ActionResult<Empty> result = testKit.simpleMethod(ServiceOuterClass.MyRequest.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
@@ -7,6 +7,7 @@ import kalix.javasdk.testkit.EventSourcedResult;
 import org.example.events.OuterCounterEvents;
 import org.example.eventsourcedentity.CounterApi;
 import org.example.state.OuterCounterState;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -19,6 +20,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -35,6 +37,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -42,6 +45,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-unmanaged/org/example/eventsourcedentity/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-unmanaged/org/example/eventsourcedentity/CounterTest.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Empty;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import kalix.javasdk.testkit.EventSourcedResult;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -16,6 +17,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -32,6 +34,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -39,6 +42,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -5,6 +5,7 @@ import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import kalix.javasdk.testkit.EventSourcedResult;
 import org.example.eventsourcedentity.CounterApi;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -17,6 +18,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -33,6 +35,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -40,6 +43,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -5,6 +5,7 @@ import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import kalix.javasdk.testkit.EventSourcedResult;
 import org.example.eventsourcedentity.CounterApi;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -17,6 +18,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -33,6 +35,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -40,6 +43,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -7,6 +7,7 @@ import kalix.javasdk.testkit.EventSourcedResult;
 import org.example.eventsourcedentity.CounterApi;
 import org.example.eventsourcedentity.events.OuterCounterEvents;
 import org.example.eventsourcedentity.state.OuterCounterState;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -19,6 +20,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -35,6 +37,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -42,6 +45,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-unmanaged/org/example/eventsourcedentity/CounterServiceEntityTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-unmanaged/org/example/eventsourcedentity/CounterServiceEntityTest.java
@@ -5,6 +5,7 @@ import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import kalix.javasdk.testkit.EventSourcedResult;
 import org.example.eventsourcedentity.domain.CounterDomain;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -17,6 +18,7 @@ import static org.junit.Assert.*;
 public class CounterServiceEntityTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
     // use the testkit to execute a command
@@ -33,6 +35,7 @@ public class CounterServiceEntityTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
     // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -40,6 +43,7 @@ public class CounterServiceEntityTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
     // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
@@ -5,6 +5,7 @@ import kalix.javasdk.testkit.ValueEntityResult;
 import kalix.javasdk.valueentity.ValueEntity;
 import org.example.state.OuterCounterState;
 import org.example.valueentity.CounterApi;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -17,6 +18,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -30,6 +32,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -37,6 +40,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-unmanaged/org/example/valueentity/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-unmanaged/org/example/valueentity/CounterTest.java
@@ -3,6 +3,7 @@ package org.example.valueentity;
 import com.google.protobuf.Empty;
 import kalix.javasdk.testkit.ValueEntityResult;
 import kalix.javasdk.valueentity.ValueEntity;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -15,6 +16,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -28,6 +30,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -35,6 +38,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Empty;
 import kalix.javasdk.testkit.ValueEntityResult;
 import kalix.javasdk.valueentity.ValueEntity;
 import org.example.valueentity.CounterApi;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -16,6 +17,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -29,6 +31,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -36,6 +39,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
@@ -5,6 +5,7 @@ import kalix.javasdk.testkit.ValueEntityResult;
 import kalix.javasdk.valueentity.ValueEntity;
 import org.example.valueentity.CounterApi;
 import org.example.valueentity.state.OuterCounterState;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -17,6 +18,7 @@ import static org.junit.Assert.*;
 public class CounterTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // use the testkit to execute a command
@@ -30,6 +32,7 @@ public class CounterTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -37,6 +40,7 @@ public class CounterTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterTestKit testKit = CounterTestKit.of(Counter::new);
     // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());

--- a/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-unmanaged/org/example/valueentity/CounterServiceEntityTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-unmanaged/org/example/valueentity/CounterServiceEntityTest.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Empty;
 import kalix.javasdk.testkit.ValueEntityResult;
 import kalix.javasdk.valueentity.ValueEntity;
 import org.example.valueentity.domain.CounterDomain;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -16,6 +17,7 @@ import static org.junit.Assert.*;
 public class CounterServiceEntityTest {
 
   @Test
+  @Ignore("to be implemented")
   public void exampleTest() {
     CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
     // use the testkit to execute a command
@@ -29,6 +31,7 @@ public class CounterServiceEntityTest {
   }
 
   @Test
+  @Ignore("to be implemented")
   public void increaseTest() {
     CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
     // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
@@ -36,6 +39,7 @@ public class CounterServiceEntityTest {
 
 
   @Test
+  @Ignore("to be implemented")
   public void decreaseTest() {
     CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
     // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());


### PR DESCRIPTION
Marks the unimplemented JUnit test methods with `@Ignored` so they get reported as "skipped", instead of as "success".

References https://github.com/lightbend/kalix/issues/6600