### PR TITLE
fix: better names in suggested Java test code

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
@@ -117,12 +117,13 @@ object ActionTestKitGenerator {
         |  @Test
         |  @Ignore("to be implemented")
         |  public void exampleTest() {
-        |    ${className}TestKit testKit = ${className}TestKit.of($className::new);
-        |    // use the testkit to execute a command
-        |    // ActionResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-        |    // verify the response
-        |    // SomeResponse actualResponse = result.getReply();
-        |    // assertEquals(expectedResponse, actualResponse);
+        |    ${className}TestKit service = ${className}TestKit.of($className::new);
+        |    // // use the testkit to execute a command
+        |    // SomeCommand command = SomeCommand.newBuilder()...build();
+        |    // ActionResult<SomeResponse> result = service.someOperation(command);
+        |    // // verify the reply
+        |    // SomeReply reply = result.getReply();
+        |    // assertEquals(expectedReply, reply);
         |  }
         |
         |  ${Format.indent(generateTestingServices(service), 2)}

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntityTestKitGenerator.scala
@@ -175,8 +175,9 @@ object EventSourcedEntityTestKitGenerator {
       s"""|@Test
           |@Ignore("to be implemented")
           |public void ${lowerFirst(command.name)}Test() {
-          |  $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
-          |  // EventSourcedResult<${command.outputType.name}> result = testKit.${lowerFirst(command.name)}(${command.inputType.name}.newBuilder()...build());
+          |  $testkitClassName service = $testkitClassName.of(${entityClassName}::new);
+          |  // ${command.inputType.name} command = ${command.inputType.name}.newBuilder()...build();
+          |  // EventSourcedResult<${command.outputType.name}> result = service.${lowerFirst(command.name)}(command);
           |}
           |
           |""".stripMargin
@@ -195,18 +196,19 @@ object EventSourcedEntityTestKitGenerator {
       |  @Test
       |  @Ignore("to be implemented")
       |  public void exampleTest() {
-      |    $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
-      |    // use the testkit to execute a command
-      |    // of events emitted, or a final updated state:
-      |    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-      |    // verify the emitted events
+      |    $testkitClassName service = $testkitClassName.of(${entityClassName}::new);
+      |    // // use the testkit to execute a command
+      |    // // of events emitted, or a final updated state:
+      |    // SomeCommand command = SomeCommand.newBuilder()...build();
+      |    // EventSourcedResult<SomeResponse> result = service.someOperation(command);
+      |    // // verify the emitted events
       |    // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
-      |    // assertEquals(expectedEvent, actualEvent)
-      |    // verify the final state after applying the events
-      |    // assertEquals(expectedState, testKit.getState());
-      |    // verify the response
-      |    // SomeResponse actualResponse = result.getReply();
-      |    // assertEquals(expectedResponse, actualResponse);
+      |    // assertEquals(expectedEvent, actualEvent);
+      |    // // verify the final state after applying the events
+      |    // assertEquals(expectedState, service.getState());
+      |    // // verify the reply
+      |    // SomeReply reply = result.getReply();
+      |    // assertEquals(expectedReply, reply);
       |  }
       |
       |  ${Format.indent(dummyTestCases, 2)}

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
@@ -165,8 +165,9 @@ object ValueEntityTestKitGenerator {
       s"""|@Test
           |@Ignore("to be implemented")
           |public void ${lowerFirst(command.name)}Test() {
-          |  $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
-          |  // ValueEntityResult<${command.outputType.name}> result = testKit.${lowerFirst(command.name)}(${command.inputType.name}.newBuilder()...build());
+          |  $testkitClassName service = $testkitClassName.of(${entityClassName}::new);
+          |  // ${command.inputType.name} command = ${command.inputType.name}.newBuilder()...build();
+          |  // ValueEntityResult<${command.outputType.name}> result = service.${lowerFirst(command.name)}(command);
           |}
           |
           |""".stripMargin
@@ -185,15 +186,16 @@ object ValueEntityTestKitGenerator {
        |  @Test
        |  @Ignore("to be implemented")
        |  public void exampleTest() {
-       |    $testkitClassName testKit = $testkitClassName.of(${entityClassName}::new);
-       |    // use the testkit to execute a command
-       |    // of events emitted, or a final updated state:
-       |    // ValueEntityResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-       |    // verify the response
-       |    // SomeResponse actualResponse = result.getReply();
-       |    // assertEquals(expectedResponse, actualResponse);
-       |    // verify the final state after the command
-       |    // assertEquals(expectedState, testKit.getState());
+       |    $testkitClassName service = $testkitClassName.of(${entityClassName}::new);
+       |    // // use the testkit to execute a command
+       |    // // of events emitted, or a final updated state:
+       |    // SomeCommand command = SomeCommand.newBuilder()...build();
+       |    // ValueEntityResult<SomeResponse> result = service.someOperation(command);
+       |    // // verify the reply
+       |    // SomeReply reply = result.getReply();
+       |    // assertEquals(expectedReply, reply);
+       |    // // verify the final state after the command
+       |    // assertEquals(expectedState, service.getState());
        |  }
        |
        |  ${Format.indent(dummyTestCases, 2)}

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-unmanaged/org/example/service/MyServiceNamedActionTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-unmanaged/org/example/service/MyServiceNamedActionTest.java
@@ -21,12 +21,13 @@ public class MyServiceNamedActionTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    MyServiceNamedActionTestKit testKit = MyServiceNamedActionTestKit.of(MyServiceNamedAction::new);
-    // use the testkit to execute a command
-    // ActionResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    MyServiceNamedActionTestKit service = MyServiceNamedActionTestKit.of(MyServiceNamedAction::new);
+    // // use the testkit to execute a command
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ActionResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
@@ -21,12 +21,13 @@ public class MyServiceActionTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
-    // use the testkit to execute a command
-    // ActionResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    MyServiceActionTestKit service = MyServiceActionTestKit.of(MyServiceAction::new);
+    // // use the testkit to execute a command
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ActionResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-unmanaged/org/example/service/MyServiceActionTest.java
@@ -21,12 +21,13 @@ public class MyServiceActionTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    MyServiceActionTestKit testKit = MyServiceActionTestKit.of(MyServiceAction::new);
-    // use the testkit to execute a command
-    // ActionResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    MyServiceActionTestKit service = MyServiceActionTestKit.of(MyServiceAction::new);
+    // // use the testkit to execute a command
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ActionResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-unmanaged/org/example/service/MyServiceActionImplTest.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-unmanaged/org/example/service/MyServiceActionImplTest.java
@@ -20,12 +20,13 @@ public class MyServiceActionImplTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    MyServiceActionImplTestKit testKit = MyServiceActionImplTestKit.of(MyServiceActionImpl::new);
-    // use the testkit to execute a command
-    // ActionResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    MyServiceActionImplTestKit service = MyServiceActionImplTestKit.of(MyServiceActionImpl::new);
+    // // use the testkit to execute a command
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ActionResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
@@ -22,33 +22,36 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the emitted events
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // EventSourcedResult<SomeResponse> result = service.someOperation(command);
+    // // verify the emitted events
     // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
-    // assertEquals(expectedEvent, actualEvent)
-    // verify the final state after applying the events
-    // assertEquals(expectedState, testKit.getState());
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedEvent, actualEvent);
+    // // verify the final state after applying the events
+    // assertEquals(expectedState, service.getState());
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-unmanaged/org/example/eventsourcedentity/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-unmanaged/org/example/eventsourcedentity/CounterTest.java
@@ -19,33 +19,36 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the emitted events
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // EventSourcedResult<SomeResponse> result = service.someOperation(command);
+    // // verify the emitted events
     // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
-    // assertEquals(expectedEvent, actualEvent)
-    // verify the final state after applying the events
-    // assertEquals(expectedState, testKit.getState());
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedEvent, actualEvent);
+    // // verify the final state after applying the events
+    // assertEquals(expectedState, service.getState());
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -20,33 +20,36 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the emitted events
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // EventSourcedResult<SomeResponse> result = service.someOperation(command);
+    // // verify the emitted events
     // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
-    // assertEquals(expectedEvent, actualEvent)
-    // verify the final state after applying the events
-    // assertEquals(expectedState, testKit.getState());
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedEvent, actualEvent);
+    // // verify the final state after applying the events
+    // assertEquals(expectedState, service.getState());
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -20,33 +20,36 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the emitted events
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // EventSourcedResult<SomeResponse> result = service.someOperation(command);
+    // // verify the emitted events
     // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
-    // assertEquals(expectedEvent, actualEvent)
-    // verify the final state after applying the events
-    // assertEquals(expectedState, testKit.getState());
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedEvent, actualEvent);
+    // // verify the final state after applying the events
+    // assertEquals(expectedState, service.getState());
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -22,33 +22,36 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the emitted events
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // EventSourcedResult<SomeResponse> result = service.someOperation(command);
+    // // verify the emitted events
     // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
-    // assertEquals(expectedEvent, actualEvent)
-    // verify the final state after applying the events
-    // assertEquals(expectedState, testKit.getState());
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedEvent, actualEvent);
+    // // verify the final state after applying the events
+    // assertEquals(expectedState, service.getState());
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-unmanaged/org/example/eventsourcedentity/CounterServiceEntityTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-unmanaged/org/example/eventsourcedentity/CounterServiceEntityTest.java
@@ -20,33 +20,36 @@ public class CounterServiceEntityTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the emitted events
+    CounterServiceEntityTestKit service = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // EventSourcedResult<SomeResponse> result = service.someOperation(command);
+    // // verify the emitted events
     // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
-    // assertEquals(expectedEvent, actualEvent)
-    // verify the final state after applying the events
-    // assertEquals(expectedState, testKit.getState());
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedEvent, actualEvent);
+    // // verify the final state after applying the events
+    // assertEquals(expectedState, service.getState());
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
-    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterServiceEntityTestKit service = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
-    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterServiceEntityTestKit service = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // EventSourcedResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
@@ -20,30 +20,33 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // ValueEntityResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
-    // verify the final state after the command
-    // assertEquals(expectedState, testKit.getState());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ValueEntityResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
+    // // verify the final state after the command
+    // assertEquals(expectedState, service.getState());
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-unmanaged/org/example/valueentity/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-unmanaged/org/example/valueentity/CounterTest.java
@@ -18,30 +18,33 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // ValueEntityResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
-    // verify the final state after the command
-    // assertEquals(expectedState, testKit.getState());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ValueEntityResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
+    // // verify the final state after the command
+    // assertEquals(expectedState, service.getState());
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
@@ -19,30 +19,33 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // ValueEntityResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
-    // verify the final state after the command
-    // assertEquals(expectedState, testKit.getState());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ValueEntityResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
+    // // verify the final state after the command
+    // assertEquals(expectedState, service.getState());
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/valueentity/domain/CounterTest.java
@@ -20,30 +20,33 @@ public class CounterTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // ValueEntityResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
-    // verify the final state after the command
-    // assertEquals(expectedState, testKit.getState());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ValueEntityResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
+    // // verify the final state after the command
+    // assertEquals(expectedState, service.getState());
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterTestKit testKit = CounterTestKit.of(Counter::new);
-    // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterTestKit service = CounterTestKit.of(Counter::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.decrease(command);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-unmanaged/org/example/valueentity/CounterServiceEntityTest.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-unmanaged/org/example/valueentity/CounterServiceEntityTest.java
@@ -19,30 +19,33 @@ public class CounterServiceEntityTest {
   @Test
   @Ignore("to be implemented")
   public void exampleTest() {
-    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
-    // use the testkit to execute a command
-    // of events emitted, or a final updated state:
-    // ValueEntityResult<SomeResponse> result = testKit.someOperation(SomeRequest);
-    // verify the response
-    // SomeResponse actualResponse = result.getReply();
-    // assertEquals(expectedResponse, actualResponse);
-    // verify the final state after the command
-    // assertEquals(expectedState, testKit.getState());
+    CounterServiceEntityTestKit service = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // // use the testkit to execute a command
+    // // of events emitted, or a final updated state:
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ValueEntityResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
+    // // verify the final state after the command
+    // assertEquals(expectedState, service.getState());
   }
 
   @Test
   @Ignore("to be implemented")
   public void increaseTest() {
-    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
-    // ValueEntityResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+    CounterServiceEntityTestKit service = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // IncreaseValue command = IncreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.increase(command);
   }
 
 
   @Test
   @Ignore("to be implemented")
   public void decreaseTest() {
-    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
-    // ValueEntityResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+    CounterServiceEntityTestKit service = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // DecreaseValue command = DecreaseValue.newBuilder()...build();
+    // ValueEntityResult<Empty> result = service.decrease(command);
   }
 
 }


### PR DESCRIPTION
When working with the Maven archetype, I found the suggested variable names inconsistent with what things are called in other places.
I believe this makes the generated unit test code easier applicable.