### PR TITLE
chore: more convenient Effect.error API

### DIFF
--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
@@ -105,14 +105,26 @@ object Action {
        *
        * @param description
        *   The description of the error.
-       * @param statusCode
-       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam S
        *   The type of the message that must be returned by this call.
        */
-      def error[S](description: String, statusCode: Option[Status.Code] = None): Action.Effect[S]
+      def error[S](description: String): Action.Effect[S]
+
+      /**
+       * Create an error reply.
+       *
+       * @param description
+       *   The description of the error.
+       * @param statusCode
+       *   A gRPC status code.
+       * @return
+       *   An error reply.
+       * @tparam S
+       *   The type of the message that must be returned by this call.
+       */
+      def error[S](description: String, statusCode: Status.Code): Action.Effect[S]
 
       /**
        * Create a message reply from an async operation result.

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/eventsourcedentity/EventSourcedEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/eventsourcedentity/EventSourcedEntity.scala
@@ -99,14 +99,26 @@ object EventSourcedEntity {
        *
        * @param description
        *   The description of the error.
-       * @param statusCode
-       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam T
        *   The type of the message that must be returned by this call.
        */
-      def error[T](description: String, statusCode: Option[Status.Code] = None): Effect[T]
+      def error[T](description: String): Effect[T]
+
+      /**
+       * Create an error reply.
+       *
+       * @param description
+       *   The description of the error.
+       * @param statusCode
+       *   A gRPC status code.
+       * @return
+       *   An error reply.
+       * @tparam T
+       *   The type of the message that must be returned by this call.
+       */
+      def error[T](description: String, statusCode: Status.Code): Effect[T]
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
@@ -42,11 +42,11 @@ private[scalasdk] final case class EventSourcedEntityEffectImpl[R, S](
   def emitEvents(event: List[_]): EventSourcedEntity.Effect.OnSuccessBuilder[S] =
     EventSourcedEntityEffectImpl(javasdkEffect.emitEvents(event.asJava))
 
-  def error[T](description: String, statusCode: Option[Status.Code]): EventSourcedEntity.Effect[T] =
-    EventSourcedEntityEffectImpl(statusCode match {
-      case Some(code) => javasdkEffect.error[T](description, code)
-      case None       => javasdkEffect.error[T](description)
-    })
+  def error[T](description: String): EventSourcedEntity.Effect[T] =
+    EventSourcedEntityEffectImpl(javasdkEffect.error[T](description))
+
+  def error[T](description: String, statusCode: Status.Code): EventSourcedEntity.Effect[T] =
+    EventSourcedEntityEffectImpl(javasdkEffect.error[T](description, statusCode))
 
   def forward[T](deferredCall: DeferredCall[_, T]): EventSourcedEntity.Effect[T] =
     deferredCall match {

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/replicatedentity/ReplicatedEntityEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/replicatedentity/ReplicatedEntityEffectImpl.scala
@@ -56,11 +56,11 @@ private[scalasdk] final case class ReplicatedEntityEffectImpl[D <: ReplicatedDat
         ReplicatedEntityEffectImpl(javaSdkEffect.forward(javaSdkDeferredCall))
     }
 
-  def error[T](description: String, statusCode: Option[Status.Code]): ReplicatedEntity.Effect[T] =
-    ReplicatedEntityEffectImpl(statusCode match {
-      case Some(code) => javaSdkEffect.error(description, code)
-      case None       => javaSdkEffect.error(description)
-    })
+  def error[T](description: String): ReplicatedEntity.Effect[T] =
+    ReplicatedEntityEffectImpl(javaSdkEffect.error(description))
+
+  def error[T](description: String, statusCode: Status.Code): ReplicatedEntity.Effect[T] =
+    ReplicatedEntityEffectImpl(javaSdkEffect.error(description, statusCode))
 
   override def noReply[T]: ReplicatedEntity.Effect[T] =
     ReplicatedEntityEffectImpl(javaSdkEffect.noReply())

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/valueentity/ValueEntityEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/valueentity/ValueEntityEffectImpl.scala
@@ -40,11 +40,8 @@ private[scalasdk] final case class ValueEntityEffectImpl[S](
   def error[T](description: String): ValueEntity.Effect[T] = new ValueEntityEffectImpl(
     javasdkEffect.error[T](description))
 
-  def error[T](description: String, statusCode: Option[Status.Code]): ValueEntity.Effect[T] =
-    ValueEntityEffectImpl(statusCode match {
-      case Some(code) => javasdkEffect.error(description, code)
-      case None       => javasdkEffect.error(description)
-    })
+  def error[T](description: String, statusCode: Status.Code): ValueEntity.Effect[T] =
+    new ValueEntityEffectImpl(javasdkEffect.error[T](description, statusCode))
 
   def forward[T](deferredCall: kalix.scalasdk.DeferredCall[_, T]): ValueEntity.Effect[T] = {
     deferredCall match {

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/replicatedentity/ReplicatedEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/replicatedentity/ReplicatedEntity.scala
@@ -89,14 +89,26 @@ object ReplicatedEntity {
        *
        * @param description
        *   The description of the error.
-       * @param statusCode
-       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam T
        *   The type of the message that must be returned by this call.
        */
-      def error[T](description: String, statusCode: Option[Status.Code] = None): ReplicatedEntity.Effect[T]
+      def error[T](description: String): ReplicatedEntity.Effect[T]
+
+      /**
+       * Create an error reply.
+       *
+       * @param description
+       *   The description of the error.
+       * @param statusCode
+       *   A gRPC status code.
+       * @return
+       *   An error reply.
+       * @tparam T
+       *   The type of the message that must be returned by this call.
+       */
+      def error[T](description: String, statusCode: Status.Code): ReplicatedEntity.Effect[T]
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/valueentity/ValueEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/valueentity/ValueEntity.scala
@@ -79,14 +79,26 @@ object ValueEntity {
        *
        * @param description
        *   The description of the error.
-       * @param statusCode
-       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam T
        *   The type of the message that must be returned by this call.
        */
-      def error[T](description: String, statusCode: Option[Status.Code] = None): Effect[T]
+      def error[T](description: String): Effect[T]
+
+      /**
+       * Create an error reply.
+       *
+       * @param description
+       *   The description of the error.
+       * @param statusCode
+       *   A gRPC status code.
+       * @return
+       *   An error reply.
+       * @tparam T
+       *   The type of the message that must be returned by this call.
+       */
+      def error[T](description: String, statusCode: Status.Code): Effect[T]
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.


### PR DESCRIPTION
The scala API to report errors is not so convenient because it forces the user to always wrap the status code in a Option. 

It was defined as 

```scala
def error[S](description: String, statusCode: Option[Status.Code] = None):
```

Users use it as:

```scala
error("my error message")
```

or 

```scala
error("my error message", Some(statusCode))
```

So, instead, we should have 


```scala
error("my error message")
error("my error message", statusCode) // no wrapping
```

The optional status code was recently introduced and it was released in a M1. So, probably fine to just change the method signature without deprecation cycle.