### PR TITLE
bump: JUnit 4.13.2 everywhere

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-customer-registry-kafka-quickstart/pom.xml
@@ -310,7 +310,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-customer-registry-quickstart/pom.xml
+++ b/samples/java-customer-registry-quickstart/pom.xml
@@ -310,7 +310,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-customer-registry-views-quickstart/pom.xml
@@ -310,7 +310,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-doc-snippets/pom.xml
+++ b/samples/java-doc-snippets/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-eventsourced-counter/pom.xml
+++ b/samples/java-eventsourced-counter/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-eventsourced-customer-registry/pom.xml
+++ b/samples/java-eventsourced-customer-registry/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -315,7 +315,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/samples/java-fibonacci-action/pom.xml
+++ b/samples/java-fibonacci-action/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-first-service/pom.xml
+++ b/samples/java-first-service/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-replicatedentity-examples/pom.xml
+++ b/samples/java-replicatedentity-examples/pom.xml
@@ -310,7 +310,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-replicatedentity-shopping-cart/pom.xml
@@ -310,7 +310,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-shopping-cart-quickstart/pom.xml
+++ b/samples/java-shopping-cart-quickstart/pom.xml
@@ -311,7 +311,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-valueentity-counter/pom.xml
+++ b/samples/java-valueentity-counter/pom.xml
@@ -323,7 +323,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-valueentity-customer-registry/pom.xml
+++ b/samples/java-valueentity-customer-registry/pom.xml
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -313,7 +313,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
No real problem with JUnit 4.13.1, but other poms already used 4.13.2.
