### PR TITLE
fix: Include build timestamp in image tag, #934

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,8 @@
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${D}{project.artifactId}</dockerImage>
-    <dockerTag>${D}{project.version}</dockerTag>
+    <dockerTag>${D}{project.version}-${D}{build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>${package}.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,8 @@
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${D}{project.artifactId}</dockerImage>
-    <dockerTag>${D}{project.version}</dockerTag>
+    <dockerTag>${D}{project.version}-${D}{build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>${package}.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-customer-registry-kafka-quickstart/pom.xml
@@ -12,7 +12,8 @@
   <properties>
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>customer.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-customer-registry-quickstart/pom.xml
+++ b/samples/java-customer-registry-quickstart/pom.xml
@@ -12,7 +12,8 @@
   <properties>
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>customer.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-customer-registry-views-quickstart/pom.xml
@@ -12,7 +12,8 @@
   <properties>
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>customer.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-doc-snippets/pom.xml
+++ b/samples/java-doc-snippets/pom.xml
@@ -12,7 +12,8 @@
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>com.example.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-eventsourced-counter/pom.xml
+++ b/samples/java-eventsourced-counter/pom.xml
@@ -12,7 +12,8 @@
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>com.example.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-eventsourced-customer-registry/pom.xml
+++ b/samples/java-eventsourced-customer-registry/pom.xml
@@ -12,7 +12,8 @@
   <properties>
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>customer.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -13,7 +13,8 @@
     <properties>
         <!-- TODO Update to your own Docker repository or Docker Hub scope -->
         <dockerImage>gcr.io/kalix-public/samples-java-eventsourced-shopping-cart</dockerImage>
-        <dockerTag>${project.version}</dockerTag>
+        <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+        <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <mainClass>com.example.shoppingcart.Main</mainClass>
 
         <jdk.target>11</jdk.target>

--- a/samples/java-fibonacci-action/pom.xml
+++ b/samples/java-fibonacci-action/pom.xml
@@ -12,7 +12,8 @@
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>com.example.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-first-service/pom.xml
+++ b/samples/java-first-service/pom.xml
@@ -12,7 +12,8 @@
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>com.example.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-replicatedentity-examples/pom.xml
+++ b/samples/java-replicatedentity-examples/pom.xml
@@ -13,7 +13,8 @@
     <properties>
       <!-- TODO Update to your own Docker repository or Docker Hub scope -->
       <dockerImage>gcr.io/kalix-public/samples-java-replicated-entity-examples</dockerImage>
-      <dockerTag>${project.version}</dockerTag>
+      <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+      <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
       <mainClass>com.example.replicated.Main</mainClass>
 
       <jdk.target>11</jdk.target>

--- a/samples/java-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-replicatedentity-shopping-cart/pom.xml
@@ -13,7 +13,8 @@
     <properties>
       <!-- TODO Update to your own Docker repository or Docker Hub scope -->
       <dockerImage>gcr.io/kalix-public/samples-java-replicated-entity-shopping-cart</dockerImage>
-      <dockerTag>${project.version}</dockerTag>
+      <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+      <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
       <mainClass>com.example.shoppingcart.Main</mainClass>
 
       <jdk.target>11</jdk.target>

--- a/samples/java-shopping-cart-quickstart/pom.xml
+++ b/samples/java-shopping-cart-quickstart/pom.xml
@@ -12,7 +12,8 @@
   <properties>
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>shopping.cart.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-valueentity-counter/pom.xml
+++ b/samples/java-valueentity-counter/pom.xml
@@ -13,7 +13,8 @@
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>com.example.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-valueentity-customer-registry/pom.xml
+++ b/samples/java-valueentity-customer-registry/pom.xml
@@ -12,7 +12,8 @@
   <properties>
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
     <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
-    <dockerTag>${project.version}</dockerTag>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>customer.Main</mainClass>
 
     <jdk.target>11</jdk.target>

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -13,7 +13,8 @@
     <properties>
       <!-- TODO Update to your own Docker repository or Docker Hub scope -->
       <dockerImage>gcr.io/kalix-public/samples-java-value-entity-shopping-cart</dockerImage>
-      <dockerTag>${project.version}</dockerTag>
+      <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+      <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
       <mainClass>com.example.shoppingcart.Main</mainClass>
 
       <jdk.target>11</jdk.target>


### PR DESCRIPTION
* so that each deploy will update the service, without having to
  change the version in the pom.xml

If we agree this is the right approach I will update all samples and archetypes.

I considered using https://github.com/git-commit-id/git-commit-id-maven-plugin but two concerns with that:
* it requires a git repository, and doesn't have a fallback if not in git
* LGPL license may be scary

For sbt we already use sbt-dynver for the version number.

Fixes #934