### PR TITLE
fix: Use an absolute resource path to find user-function.desc on classpath

### DIFF
--- a/sdk/java-sdk/src/main/resources/reference.conf
+++ b/sdk/java-sdk/src/main/resources/reference.conf
@@ -22,7 +22,7 @@ kalix {
     // info for descriptors it sends to the proxy during discovery, since the descriptors compiled into the
     // generated Java source do not include source info. To disable use of such a descriptor for locating
     // source info, set this to "disabled".
-    protobuf-descriptor-with-source-info-path = "protobuf/descriptor-sets/user-function.desc"
+    protobuf-descriptor-with-source-info-path = "/protobuf/descriptor-sets/user-function.desc"
   }
 
   system {


### PR DESCRIPTION
Follow up to #6499