### PR TITLE
feat: implicitly available ExecutionContext for Actions in Scala

### DIFF
--- a/samples/scala-fibonacci-action/src/main/scala/com/example/fibonacci/FibonacciAction.scala
+++ b/samples/scala-fibonacci-action/src/main/scala/com/example/fibonacci/FibonacciAction.scala
@@ -45,7 +45,6 @@ class FibonacciAction(creationContext: ActionCreationContext) extends AbstractFi
   override def nextNumberOfSum(numberSrc: Source[Number, NotUsed]): Action.Effect[Number] = {
     // contrived but just to stay in fibonacci land with a streamed in call
     implicit val materializer = actionContext.materializer()
-    import scala.concurrent.ExecutionContext.Implicits.global
     val futureEffect = numberSrc.runFold(0L)((acc, number) => acc + number.value)
       .map { sum =>
         if (!isFibonacci(sum)) effects.error(s"Input sum is not a Fibonacci number, received '$sum'")

--- a/samples/scala-valueentity-shopping-cart/src/main/scala/com/example/shoppingcart/ShoppingCartActionImpl.scala
+++ b/samples/scala-valueentity-shopping-cart/src/main/scala/com/example/shoppingcart/ShoppingCartActionImpl.scala
@@ -5,7 +5,6 @@ import kalix.scalasdk.action.ActionCreationContext
 import com.google.protobuf.empty.Empty
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 // This class was initially generated based on the .proto definition by Kalix tooling.
@@ -77,4 +76,3 @@ class ShoppingCartActionImpl(creationContext: ActionCreationContext) extends Abs
 
 
 }
-

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
@@ -158,7 +158,7 @@ abstract class Action {
    * Note that this ExecutionContext is only available when handling a message. It will throw an exception if accessed
    * from constructor.
    */
-  implicit final def executionContext: ExecutionContext = {
+  implicit lazy val executionContext: ExecutionContext = {
     actionContext("ExecutionContext is only available when handling a message") match {
       case ScalaActionContextAdapter(actionContext: ActionContextImpl) => actionContext.system.dispatcher
       // should not happen as we always need to pass ScalaActionContextAdapter(ActionContextImpl)

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/action/Action.scala
@@ -17,10 +17,14 @@
 package kalix.scalasdk.action
 
 import scala.collection.immutable.Seq
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+
 import kalix.scalasdk.{ DeferredCall, Metadata, SideEffect }
 import kalix.scalasdk.impl.action.ActionEffectImpl
 import io.grpc.Status
+import kalix.javasdk.impl.action.ActionContextImpl
+import kalix.scalasdk.impl.action.ScalaActionContextAdapter
 
 object Action {
 
@@ -143,14 +147,31 @@ object Action {
     }
   }
 }
+
 abstract class Action {
   @volatile
   private var _actionContext: Option[ActionContext] = None
 
   /**
+   * An ExecutionContext to use when composing Futures inside Actions.
+   *
+   * Note that this ExecutionContext is only available when handling a message. It will throw an exception if accessed
+   * from constructor.
+   */
+  implicit final def executionContext: ExecutionContext = {
+    actionContext("ExecutionContext is only available when handling a message") match {
+      case ScalaActionContextAdapter(actionContext: ActionContextImpl) => actionContext.system.dispatcher
+      // should not happen as we always need to pass ScalaActionContextAdapter(ActionContextImpl)
+      case other =>
+        throw new RuntimeException(
+          s"Incompatible ActionContext instance. Found ${other.getClass}, expecting ${classOf[ActionContextImpl].getName}")
+    }
+  }
+
+  /**
    * Additional context and metadata for a message handler.
    *
-   * <p>It will throw an exception if accessed from constructor.
+   * It will throw an exception if accessed from constructor.
    */
   protected final def actionContext: ActionContext =
     actionContext("ActionContext is only available when handling a message.")

--- a/tck/scala-tck/src/main/scala/kalix/tck/model/action/ActionTckModelImpl.scala
+++ b/tck/scala-tck/src/main/scala/kalix/tck/model/action/ActionTckModelImpl.scala
@@ -23,7 +23,6 @@ import kalix.scalasdk.action.ActionCreationContext
 
 class ActionTckModelImpl(ctx: ActionCreationContext) extends AbstractActionTckModelAction {
   private implicit val mat = ctx.materializer
-  import mat.executionContext
 
   override def processUnary(request: Request): Action.Effect[Response] =
     response(request.groups)


### PR DESCRIPTION
As discussed in https://github.com/lightbend/kalix-jvm-sdk/pull/921#discussion_r862790158

This makes Akka's default dispatcher implicitly available inside Action. The drawback is that we can only access it when handling message as it depends on `actionContext`.

References #942 