### PR TITLE
use Scala 2.13.8 in examples and tests (was 2.13.6)

### DIFF
--- a/docs/src/modules/java/pages/index.adoc
+++ b/docs/src/modules/java/pages/index.adoc
@@ -60,7 +60,7 @@ Scala::
 [.group-scala]
 [source,scala,subs="attributes+"]
 ----
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin)
 ----

--- a/samples/scala-customer-registry-quickstart/build.sbt
+++ b/samples/scala-customer-registry-quickstart/build.sbt
@@ -4,7 +4,7 @@ organization := "customer"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-doc-snippets/build.sbt
+++ b/samples/scala-doc-snippets/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-eventsourced-counter/build.sbt
+++ b/samples/scala-eventsourced-counter/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-eventsourced-customer-registry/build.sbt
+++ b/samples/scala-eventsourced-customer-registry/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-eventsourced-shopping-cart/build.sbt
+++ b/samples/scala-eventsourced-shopping-cart/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-fibonacci-action/build.sbt
+++ b/samples/scala-fibonacci-action/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-first-service/build.sbt
+++ b/samples/scala-first-service/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.example"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-reliable-timers/build.sbt
+++ b/samples/scala-reliable-timers/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-replicatedentity-examples/build.sbt
+++ b/samples/scala-replicatedentity-examples/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-replicatedentity-shopping-cart/build.sbt
+++ b/samples/scala-replicatedentity-shopping-cart/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-valueentity-counter/build.sbt
+++ b/samples/scala-valueentity-counter/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-valueentity-customer-registry/build.sbt
+++ b/samples/scala-valueentity-customer-registry/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/samples/scala-valueentity-shopping-cart/build.sbt
+++ b/samples/scala-valueentity-shopping-cart/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"

--- a/sbt-plugin/src/sbt-test/sbt-kalix/compile-only/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-kalix/compile-only/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin)
 

--- a/sbt-plugin/src/sbt-test/sbt-kalix/eventsourcedentity/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-kalix/eventsourcedentity/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin)
 

--- a/sbt-plugin/src/sbt-test/sbt-kalix/no-common-pkg-root/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-kalix/no-common-pkg-root/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.8"
 
 enablePlugins(KalixPlugin)
 


### PR DESCRIPTION
we should be recommending current Scala versions just on general principle...

...but one specific reason to merge this is that 2.13.8 is more JDK 17 friendly