### PR TITLE
sbt 1.6.2 (was: assorted older versions)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   // changing the Scala version of the Java SDK affects end users
   val ScalaVersion = "2.13.8"
-  val ScalaVersionForSbtPlugin = "2.12.14"
+  val ScalaVersionForSbtPlugin = "2.12.15"
   val ScalaVersionForCodegen = Seq(ScalaVersionForSbtPlugin)
 
   val ProtobufVersion = akka.grpc.gen.BuildInfo.googleProtobufVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
 
   val AkkaVersion = "2.6.19"
   val AkkaHttpVersion = "10.2.9" // Note: should at least the Akka HTTP version required by Akka gRPC
-  val ScalaTestVersion = "3.2.7"
+  val ScalaTestVersion = "3.2.12"
   val JacksonVersion = "2.13.2"
   val JacksonDatabindVersion = "2.13.2.2"
   val DockerBaseImageVersion = "adoptopenjdk/openjdk11:debianslim-jre"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.6.2

--- a/samples/scala-customer-registry-quickstart/build.sbt
+++ b/samples/scala-customer-registry-quickstart/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-customer-registry-quickstart/project/build.properties
+++ b/samples/scala-customer-registry-quickstart/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-doc-snippets/build.sbt
+++ b/samples/scala-doc-snippets/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-doc-snippets/project/build.properties
+++ b/samples/scala-doc-snippets/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-eventsourced-counter/build.sbt
+++ b/samples/scala-eventsourced-counter/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-eventsourced-counter/project/build.properties
+++ b/samples/scala-eventsourced-counter/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-eventsourced-customer-registry/build.sbt
+++ b/samples/scala-eventsourced-customer-registry/build.sbt
@@ -44,4 +44,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-eventsourced-customer-registry/project/build.properties
+++ b/samples/scala-eventsourced-customer-registry/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-eventsourced-shopping-cart/build.sbt
+++ b/samples/scala-eventsourced-shopping-cart/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-eventsourced-shopping-cart/project/build.properties
+++ b/samples/scala-eventsourced-shopping-cart/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-fibonacci-action/build.sbt
+++ b/samples/scala-fibonacci-action/build.sbt
@@ -37,4 +37,4 @@ Test / logBuffered := false
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-fibonacci-action/project/build.properties
+++ b/samples/scala-fibonacci-action/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-first-service/build.sbt
+++ b/samples/scala-first-service/build.sbt
@@ -27,5 +27,5 @@ Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-param
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.7" % Test
+  "org.scalatest" %% "scalatest" % "3.2.12" % Test
 )

--- a/samples/scala-first-service/project/build.properties
+++ b/samples/scala-first-service/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/samples/scala-reliable-timers/build.sbt
+++ b/samples/scala-reliable-timers/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-reliable-timers/project/build.properties
+++ b/samples/scala-reliable-timers/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-replicatedentity-examples/build.sbt
+++ b/samples/scala-replicatedentity-examples/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-replicatedentity-examples/project/build.properties
+++ b/samples/scala-replicatedentity-examples/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-replicatedentity-shopping-cart/build.sbt
+++ b/samples/scala-replicatedentity-shopping-cart/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-replicatedentity-shopping-cart/project/build.properties
+++ b/samples/scala-replicatedentity-shopping-cart/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-valueentity-counter/build.sbt
+++ b/samples/scala-valueentity-counter/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-valueentity-counter/project/build.properties
+++ b/samples/scala-valueentity-counter/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-valueentity-customer-registry/build.sbt
+++ b/samples/scala-valueentity-customer-registry/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-valueentity-customer-registry/project/build.properties
+++ b/samples/scala-valueentity-customer-registry/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/samples/scala-valueentity-shopping-cart/build.sbt
+++ b/samples/scala-valueentity-shopping-cart/build.sbt
@@ -42,4 +42,4 @@ Compile / run := {
 run / fork := false
 Global / cancelable := false // ctrl-c
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-valueentity-shopping-cart/project/build.properties
+++ b/samples/scala-valueentity-shopping-cart/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/sbt-plugin/src/sbt-test/sbt-kalix/compile-only/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-kalix/compile-only/build.sbt
@@ -2,4 +2,4 @@ scalaVersion := "2.13.6"
 
 enablePlugins(KalixPlugin)
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/sbt-plugin/src/sbt-test/sbt-kalix/eventsourcedentity/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-kalix/eventsourcedentity/build.sbt
@@ -11,4 +11,4 @@ testOptions ++=(
     Nil
 )
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/sbt-plugin/src/sbt-test/sbt-kalix/no-common-pkg-root/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-kalix/no-common-pkg-root/build.sbt
@@ -2,4 +2,4 @@ scalaVersion := "2.13.6"
 
 enablePlugins(KalixPlugin)
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.7" % Test)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)


### PR DESCRIPTION
one reason to merge this is that for users on JDK 17, old sbt versions print alarming looking warnings