### PR TITLE
quickstart: add emptyState in instructions

### DIFF
--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
@@ -182,6 +182,18 @@ include::example$java-customer-registry-quickstart/src/main/java/customer/domain
 The `src/main/java/customer/Main.java` file already contains the required code to start your service and register it with Kalix.
 ====
 
+== Define the initial entity state
+
+To give the domain model a starting point, the initial state for the entity needs to be define.
+
+. Implement the `emptyState` method by returning a default instance of the `CustomerState` class:
++
+[source, java]
+.src/main/java/customer/domain/Customer.java
+----
+include::example$java-customer-registry-quickstart/src/main/java/customer/domain/Customer.java[tag=emptyState]
+----
+
 == Package and deploy your service
 
 To build and publish the container image and then deploy the service, follow these steps:

--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-scala.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-scala.adoc
@@ -188,6 +188,19 @@ include::example$scala-customer-registry-quickstart/src/main/scala/customer/doma
 The `src/main/scala/customer/Main.scala` file already contains the required code to start your service and register it with Kalix.
 ====
 
+
+== Define the initial entity state
+
+To give the domain model a starting point, the initial state for the entity needs to be define.
+
+. Implement the `emptyState` method by returning an instance of the `CustomerState` case class:
++
+[source, scala]
+.src/main/scala/customer/domain/Customer.scala
+----
+include::example$scala-customer-registry-quickstart/src/main/scala/customer/domain/Customer.scala[tag=emptyState]
+----
+
 == Package and deploy your service
 
 To build and publish the container image and then deploy the service, follow these steps:

--- a/samples/java-customer-registry-quickstart/src/main/java/customer/domain/Customer.java
+++ b/samples/java-customer-registry-quickstart/src/main/java/customer/domain/Customer.java
@@ -28,10 +28,12 @@ public class Customer extends AbstractCustomer {
     this.entityId = context.entityId();
   }
 
+  // tag::emptyState[]
   @Override
   public CustomerDomain.CustomerState emptyState() {
     return CustomerDomain.CustomerState.getDefaultInstance();
   }
+  // end::emptyState[]
 
   // tag::create[]
   @Override

--- a/samples/scala-customer-registry-quickstart/src/main/scala/customer/domain/Customer.scala
+++ b/samples/scala-customer-registry-quickstart/src/main/scala/customer/domain/Customer.scala
@@ -12,7 +12,9 @@ import customer.api
 
 class Customer(context: ValueEntityContext) extends AbstractCustomer {
 
+  // tag::emptyState[]
   override def emptyState: CustomerState = CustomerState()
+  // end::emptyState[]
 
   // tag::create[]
   override def create(currentState: CustomerState, customer: api.Customer): ValueEntity.Effect[Empty] = {


### PR DESCRIPTION
Cover adding the `emptyState` implementation in the Customer Registry quickstart instructions for Java and Scala.