### PR TITLE
fix: More restrictive ACLs by default in quickstarts

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
@@ -43,6 +43,7 @@ service CounterService {
         "${package}.domain.ValueReset"]
     }
   };
+  option (kalix.service).acl.allow = { principal: ALL };
 
   rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
   rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/kalix_policy.proto
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 syntax = "proto3";
 
 package $package;
@@ -8,6 +8,7 @@ import "kalix/annotations.proto";
 // Allow all other Kalix services deployed in the same project to access the components of this
 // Kalix service, but disallow access from the internet. This can be overridden explicitly
 // per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
 option (kalix.file).acl = {
   allow: { service: "*" }
 };

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
@@ -39,6 +39,7 @@ service CounterService {
       state: "${package}.domain.CounterState"
     }
   };
+  option (kalix.service).acl.allow = { principal: ALL };
 
   rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
   rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/kalix_policy.proto
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 syntax = "proto3";
 
 package $package;
@@ -8,6 +8,7 @@ import "kalix/annotations.proto";
 // Allow all other Kalix services deployed in the same project to access the components of this
 // Kalix service, but disallow access from the internet. This can be overridden explicitly
 // per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
 option (kalix.file).acl = {
   allow: { service: "*" }
 };

--- a/samples/java-customer-registry-kafka-quickstart/src/main/proto/customer/api/customer_api.proto
+++ b/samples/java-customer-registry-kafka-quickstart/src/main/proto/customer/api/customer_api.proto
@@ -60,6 +60,9 @@ service CustomerService {
       state: "customer.domain.CustomerState"
     }
   };
+  // end::service[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::service[]
 
   rpc Create(Customer) returns (google.protobuf.Empty) {}
   rpc GetCustomer(GetCustomerRequest) returns (Customer) {}

--- a/samples/java-customer-registry-kafka-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/java-customer-registry-kafka-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 syntax = "proto3";
 
 package customer;
@@ -8,6 +8,7 @@ import "kalix/annotations.proto";
 // Allow all other Kalix services deployed in the same project to access the components of this
 // Kalix service, but disallow access from the internet. This can be overridden explicitly
 // per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
 option (kalix.file).acl = {
   allow: { service: "*" }
 };

--- a/samples/java-customer-registry-kafka-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/java-customer-registry-kafka-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,0 +1,13 @@
+// This is the default ACLs for all components of this Kalix Service
+syntax = "proto3";
+
+package customer;
+
+import "kalix/annotations.proto";
+
+// Allow all other Kalix services deployed in the same project to access the components of this
+// Kalix service, but disallow access from the internet. This can be overridden explicitly
+// per component or method using annotations.
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/samples/java-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto
+++ b/samples/java-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto
@@ -60,6 +60,9 @@ service CustomerService {
       state: "customer.domain.CustomerState"
     }
   };
+  // end::service[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::service[]
 
   rpc Create(Customer) returns (google.protobuf.Empty) {}
   rpc GetCustomer(GetCustomerRequest) returns (Customer) {}

--- a/samples/java-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/java-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 syntax = "proto3";
 
 package customer;
@@ -8,6 +8,7 @@ import "kalix/annotations.proto";
 // Allow all other Kalix services deployed in the same project to access the components of this
 // Kalix service, but disallow access from the internet. This can be overridden explicitly
 // per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
 option (kalix.file).acl = {
   allow: { service: "*" }
 };

--- a/samples/java-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/java-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,0 +1,13 @@
+// This is the default ACLs for all components of this Kalix Service
+syntax = "proto3";
+
+package customer;
+
+import "kalix/annotations.proto";
+
+// Allow all other Kalix services deployed in the same project to access the components of this
+// Kalix service, but disallow access from the internet. This can be overridden explicitly
+// per component or method using annotations.
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/samples/java-customer-registry-views-quickstart/src/main/proto/customer/api/customer_api.proto
+++ b/samples/java-customer-registry-views-quickstart/src/main/proto/customer/api/customer_api.proto
@@ -53,6 +53,7 @@ service CustomerService {
       state: "customer.domain.CustomerState"
     }
   };
+  option (kalix.service).acl.allow = { principal: ALL };
 
   rpc Create(Customer) returns (google.protobuf.Empty) {}
   rpc GetCustomer(GetCustomerRequest) returns (Customer) {}

--- a/samples/java-customer-registry-views-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/java-customer-registry-views-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 syntax = "proto3";
 
 package customer;
@@ -8,6 +8,7 @@ import "kalix/annotations.proto";
 // Allow all other Kalix services deployed in the same project to access the components of this
 // Kalix service, but disallow access from the internet. This can be overridden explicitly
 // per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
 option (kalix.file).acl = {
   allow: { service: "*" }
 };

--- a/samples/java-customer-registry-views-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/java-customer-registry-views-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,0 +1,13 @@
+// This is the default ACLs for all components of this Kalix Service
+syntax = "proto3";
+
+package customer;
+
+import "kalix/annotations.proto";
+
+// Allow all other Kalix services deployed in the same project to access the components of this
+// Kalix service, but disallow access from the internet. This can be overridden explicitly
+// per component or method using annotations.
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/samples/java-customer-registry-views-quickstart/src/main/proto/customer/view/customer_view.proto
+++ b/samples/java-customer-registry-views-quickstart/src/main/proto/customer/view/customer_view.proto
@@ -28,6 +28,9 @@ service CustomerByEmail { // <1>
   option (kalix.codegen) = { // <2>
     view: {}
   };
+  // end::CustomerByEmail[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::CustomerByEmail[]
 
   rpc UpdateCustomer(domain.CustomerState) returns (domain.CustomerState) { // <3>
     option (kalix.method).eventing.in = { // <4>
@@ -55,6 +58,9 @@ service CustomerByName {
   option (kalix.codegen) = {
     view: {}
   };
+  // end::CustomerByName[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::CustomerByName[]
 
   rpc UpdateCustomer(domain.CustomerState) returns (CustomerViewState) { // <1>
     option (kalix.method).eventing.in = {

--- a/samples/java-doc-snippets/src/main/proto/com/example/kalix_policy.proto
+++ b/samples/java-doc-snippets/src/main/proto/com/example/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 // tag::default[]
 syntax = "proto3";
 

--- a/samples/java-shopping-cart-quickstart/src/main/proto/shopping/cart/api/shopping_cart_api.proto
+++ b/samples/java-shopping-cart-quickstart/src/main/proto/shopping/cart/api/shopping_cart_api.proto
@@ -68,6 +68,9 @@ service ShoppingCart {
         "shopping.cart.domain.ItemRemoved"]
     }
   };
+  // end::service[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::service[]
 
   rpc AddItem(AddLineItem) returns (google.protobuf.Empty) {
     option (google.api.http) = {

--- a/samples/java-shopping-cart-quickstart/src/main/proto/shopping/cart/kalix_policy.proto
+++ b/samples/java-shopping-cart-quickstart/src/main/proto/shopping/cart/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 syntax = "proto3";
 
 package shopping.cart;
@@ -8,6 +8,7 @@ import "kalix/annotations.proto";
 // Allow all other Kalix services deployed in the same project to access the components of this
 // Kalix service, but disallow access from the internet. This can be overridden explicitly
 // per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
 option (kalix.file).acl = {
   allow: { service: "*" }
 };

--- a/samples/java-shopping-cart-quickstart/src/main/proto/shopping/cart/kalix_policy.proto
+++ b/samples/java-shopping-cart-quickstart/src/main/proto/shopping/cart/kalix_policy.proto
@@ -1,0 +1,13 @@
+// This is the default ACLs for all components of this Kalix Service
+syntax = "proto3";
+
+package shopping.cart;
+
+import "kalix/annotations.proto";
+
+// Allow all other Kalix services deployed in the same project to access the components of this
+// Kalix service, but disallow access from the internet. This can be overridden explicitly
+// per component or method using annotations.
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/samples/scala-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto
+++ b/samples/scala-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto
@@ -58,6 +58,9 @@ service CustomerService {
       state: "customer.domain.CustomerState"
     }
   };
+  // end::service[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::service[]
 
   rpc Create(Customer) returns (google.protobuf.Empty) {}
 

--- a/samples/scala-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/scala-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 syntax = "proto3";
 
 package customer;
@@ -8,6 +8,7 @@ import "kalix/annotations.proto";
 // Allow all other Kalix services deployed in the same project to access the components of this
 // Kalix service, but disallow access from the internet. This can be overridden explicitly
 // per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
 option (kalix.file).acl = {
   allow: { service: "*" }
 };

--- a/samples/scala-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
+++ b/samples/scala-customer-registry-quickstart/src/main/proto/customer/kalix_policy.proto
@@ -1,0 +1,13 @@
+// This is the default ACLs for all components of this Kalix Service
+syntax = "proto3";
+
+package customer;
+
+import "kalix/annotations.proto";
+
+// Allow all other Kalix services deployed in the same project to access the components of this
+// Kalix service, but disallow access from the internet. This can be overridden explicitly
+// per component or method using annotations.
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/samples/scala-customer-registry-quickstart/src/main/proto/customer/view/customer_view.proto
+++ b/samples/scala-customer-registry-quickstart/src/main/proto/customer/view/customer_view.proto
@@ -26,6 +26,9 @@ service CustomerByName {
   option (kalix.codegen) = {
     view: {}
   };
+  // end::name[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::name[]
 
   rpc UpdateCustomer(domain.CustomerState) returns (domain.CustomerState) {
     option (kalix.method).eventing.in = {
@@ -53,6 +56,9 @@ service CustomerByEmail {
   option (kalix.codegen) = {
     view: {}
   };
+  // end::email[]
+  option (kalix.service).acl.allow = { principal: ALL };
+  // tag::email[]
 
   rpc UpdateCustomer(domain.CustomerState) returns (domain.CustomerState) {
     option (kalix.method).eventing.in = {

--- a/samples/scala-doc-snippets/src/main/proto/com/example/kalix_policy.proto
+++ b/samples/scala-doc-snippets/src/main/proto/com/example/kalix_policy.proto
@@ -1,4 +1,4 @@
-// This is the default ACLs for all components of this Kalix Service
+// This is the default Access Control List (ACL) for all components of this Kalix Service
 // tag::default[]
 syntax = "proto3";
 


### PR DESCRIPTION
Docs already claim this but it wasn't completely added to all archetypes and quickstarts

This puts a default ACL allowing cross-service calls but not access from the outside, and then specifically opens up individual gRPC services to public access

References https://github.com/lightbend/kalix/issues/6808