### PR TITLE
chore: specific spring sdk components

### DIFF
--- a/samples/spring-java-fibonacci-action/src/main/java/com/example/fibonacci/FibonacciAction.java
+++ b/samples/spring-java-fibonacci-action/src/main/java/com/example/fibonacci/FibonacciAction.java
@@ -1,6 +1,6 @@
 package com.example.fibonacci;
 
-import kalix.javasdk.action.Action;
+import kalix.springsdk.action.Action;
 
 import java.util.function.Predicate;
 

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -30,6 +30,8 @@ public abstract class ValueEntity<S> {
 
   private Optional<CommandContext> commandContext = Optional.empty();
 
+  private Optional<S> currentState = Optional.empty();
+
   /**
    * Implement by returning the initial empty state object. This object will be passed into the
    * command handlers, until a new state replaces it.
@@ -54,6 +56,17 @@ public abstract class ValueEntity<S> {
   /** INTERNAL API */
   public void _internalSetCommandContext(Optional<CommandContext> context) {
     commandContext = context;
+  }
+
+  /** INTERNAL API */
+  public void _internalSetCurrentState(S state) {
+    currentState = Optional.ofNullable(state);
+  }
+
+  protected final S currentState() {
+    return currentState.orElseThrow(
+        () ->
+            new IllegalStateException("Current state can only available when handling a command."));
   }
 
   protected final Effect.Builder<S> effects() {
@@ -83,8 +96,8 @@ public abstract class ValueEntity<S> {
        * Create a message reply.
        *
        * @param message The payload of the reply.
-       * @return A message reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return A message reply.
        */
       <T> Effect<T> reply(T message);
 
@@ -93,8 +106,8 @@ public abstract class ValueEntity<S> {
        *
        * @param message The payload of the reply.
        * @param metadata The metadata for the message.
-       * @return A message reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return A message reply.
        */
       <T> Effect<T> reply(T message, Metadata metadata);
 
@@ -102,8 +115,8 @@ public abstract class ValueEntity<S> {
        * Create a forward reply.
        *
        * @param serviceCall The service call representing the forward.
-       * @return A forward reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return A forward reply.
        */
       <T> Effect<T> forward(DeferredCall<? extends Object, T> serviceCall);
 
@@ -111,8 +124,8 @@ public abstract class ValueEntity<S> {
        * Create an error reply.
        *
        * @param description The description of the error.
-       * @return An error reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return An error reply.
        */
       <T> Effect<T> error(String description);
 
@@ -121,8 +134,8 @@ public abstract class ValueEntity<S> {
        *
        * @param description The description of the error.
        * @param statusCode A custom gRPC status code.
-       * @return An error reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return An error reply.
        */
       <T> Effect<T> error(String description, Status.Code statusCode);
     }
@@ -133,8 +146,8 @@ public abstract class ValueEntity<S> {
        * Reply after for example <code>updateState</code>.
        *
        * @param message The payload of the reply.
-       * @return A message reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return A message reply.
        */
       <T> Effect<T> thenReply(T message);
 
@@ -143,8 +156,8 @@ public abstract class ValueEntity<S> {
        *
        * @param message The payload of the reply.
        * @param metadata The metadata for the message.
-       * @return A message reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return A message reply.
        */
       <T> Effect<T> thenReply(T message, Metadata metadata);
 
@@ -152,8 +165,8 @@ public abstract class ValueEntity<S> {
        * Create a forward reply after for example <code>updateState</code>.
        *
        * @param serviceCall The service call representing the forward.
-       * @return A forward reply.
        * @param <T> The type of the message that must be returned by this call.
+       * @return A forward reply.
        */
       <T> Effect<T> thenForward(DeferredCall<? extends Object, T> serviceCall);
     }

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -68,11 +68,11 @@ public abstract class ValueEntity<S> {
   /**
    * Returns the state as currently stored by Kalix.
    *
-   * Note that modifying the state directly will not update it in storage.
-   * To save the state, one must call {{@code effects().updateState()}}.
+   * <p>Note that modifying the state directly will not update it in storage. To save the state, one
+   * must call {{@code effects().updateState()}}.
    *
-   * This method can only be called when handling a command. Calling it outside a method (eg: in the constructor) will
-   * raise a IllegalStateException exception.
+   * <p>This method can only be called when handling a command. Calling it outside a method (eg: in
+   * the constructor) will raise a IllegalStateException exception.
    *
    * @throws IllegalStateException if accessed outside a handler method
    */

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -46,6 +46,8 @@ public abstract class ValueEntity<S> {
    * Additional context and metadata for a command handler.
    *
    * <p>It will throw an exception if accessed from constructor.
+   *
+   * @throws IllegalStateException if accessed outside a handler method
    */
   protected final CommandContext commandContext() {
     return commandContext.orElseThrow(
@@ -63,6 +65,17 @@ public abstract class ValueEntity<S> {
     currentState = Optional.ofNullable(state);
   }
 
+  /**
+   * Returns the state as currently stored by Kalix.
+   *
+   * Note that modifying the state directly will not update it in storage.
+   * To save the state, one must call {{@code effects().updateState()}}.
+   *
+   * This method can only be called when handling a command. Calling it outside a method (eg: in the constructor) will
+   * raise a IllegalStateException exception.
+   *
+   * @throws IllegalStateException if accessed outside a handler method
+   */
   protected final S currentState() {
     return currentState.orElseThrow(
         () ->

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -30,8 +30,6 @@ public abstract class ValueEntity<S> {
 
   private Optional<CommandContext> commandContext = Optional.empty();
 
-  private Optional<S> currentState = Optional.empty();
-
   /**
    * Implement by returning the initial empty state object. This object will be passed into the
    * command handlers, until a new state replaces it.
@@ -58,28 +56,6 @@ public abstract class ValueEntity<S> {
   /** INTERNAL API */
   public void _internalSetCommandContext(Optional<CommandContext> context) {
     commandContext = context;
-  }
-
-  /** INTERNAL API */
-  public void _internalSetCurrentState(S state) {
-    currentState = Optional.ofNullable(state);
-  }
-
-  /**
-   * Returns the state as currently stored by Kalix.
-   *
-   * <p>Note that modifying the state directly will not update it in storage. To save the state, one
-   * must call {{@code effects().updateState()}}.
-   *
-   * <p>This method can only be called when handling a command. Calling it outside a method (eg: in
-   * the constructor) will raise a IllegalStateException exception.
-   *
-   * @throws IllegalStateException if accessed outside a handler method
-   */
-  protected final S currentState() {
-    return currentState.orElseThrow(
-        () ->
-            new IllegalStateException("Current state can only available when handling a command."));
   }
 
   protected final Effect.Builder<S> effects() {

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntityProvider.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntityProvider.java
@@ -17,8 +17,11 @@
 package kalix.javasdk.valueentity;
 
 import kalix.javasdk.Kalix;
+import kalix.javasdk.impl.MessageCodec;
 import kalix.javasdk.impl.valueentity.ValueEntityRouter;
 import com.google.protobuf.Descriptors;
+
+import java.util.Optional;
 
 /**
  * Register a value based entity in {@link Kalix} using a <code>
@@ -36,4 +39,8 @@ public interface ValueEntityProvider<S, E extends ValueEntity<S>> {
   ValueEntityRouter<S, E> newRouter(ValueEntityContext context);
 
   Descriptors.FileDescriptor[] additionalDescriptors();
+
+  default Optional<MessageCodec> alternativeCodec() {
+    return Optional.empty();
+  }
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/AnySupport.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/AnySupport.scala
@@ -489,4 +489,5 @@ private[kalix] object ByteStringEncoding {
 trait MessageCodec {
   def decodeMessage(any: ScalaPbAny): Any
   def encodeScala(value: Any): ScalaPbAny
+  def encodeJava(value: Any): JavaPbAny
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/effect/SecondaryEffectImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/effect/SecondaryEffectImpl.scala
@@ -16,24 +16,25 @@
 
 package kalix.javasdk.impl.effect
 
-import kalix.javasdk.{ DeferredCall, Metadata, SideEffect }
-import kalix.javasdk.impl.AnySupport
-import kalix.javasdk.impl.DeferredCallImpl
-import kalix.javasdk.impl.effect
-import kalix.protocol.component.ClientAction
 import com.google.protobuf.{ Any => JavaPbAny }
 import io.grpc.Status
+import kalix.javasdk.impl.MessageCodec
+import kalix.javasdk.impl.effect
+import kalix.javasdk.DeferredCall
+import kalix.javasdk.Metadata
+import kalix.javasdk.SideEffect
+import kalix.protocol.component.ClientAction
 
 sealed trait SecondaryEffectImpl {
   def sideEffects: Vector[SideEffect]
   def addSideEffects(sideEffects: Iterable[SideEffect]): SecondaryEffectImpl
 
-  final def replyToClientAction(anySupport: AnySupport, commandId: Long): Option[ClientAction] = {
+  final def replyToClientAction(messageCodec: MessageCodec, commandId: Long): Option[ClientAction] = {
     this match {
       case message: effect.MessageReplyImpl[JavaPbAny] @unchecked =>
         Some(ClientAction(ClientAction.Action.Reply(EffectSupport.asProtocol(message))))
       case forward: effect.ForwardReplyImpl[JavaPbAny] @unchecked =>
-        Some(ClientAction(ClientAction.Action.Forward(EffectSupport.asProtocol(anySupport, forward))))
+        Some(ClientAction(ClientAction.Action.Forward(EffectSupport.asProtocol(messageCodec, forward))))
       case failure: effect.ErrorReplyImpl[JavaPbAny] @unchecked =>
         Some(
           ClientAction(

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -18,19 +18,17 @@ package kalix.javasdk.impl.valueentity
 
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
-import kalix.javasdk.KalixRunner.Configuration
 import kalix.protocol.component.Failure
 import org.slf4j.LoggerFactory
 
 // FIXME these don't seem to be 'public API', more internals?
-import kalix.javasdk.Context
+import com.google.protobuf.Descriptors
 import kalix.javasdk.Metadata
-import kalix.javasdk.valueentity._
-
 import kalix.javasdk.impl.ValueEntityFactory
 import kalix.javasdk.impl._
 import kalix.javasdk.impl.effect.EffectSupport
@@ -39,6 +37,7 @@ import kalix.javasdk.impl.effect.MessageReplyImpl
 import kalix.javasdk.impl.valueentity.ValueEntityEffectImpl.DeleteState
 import kalix.javasdk.impl.valueentity.ValueEntityEffectImpl.UpdateState
 import kalix.javasdk.impl.valueentity.ValueEntityRouter.CommandResult
+import kalix.javasdk.valueentity._
 import kalix.protocol.value_entity.ValueEntityAction.Action.Delete
 import kalix.protocol.value_entity.ValueEntityAction.Action.Update
 import kalix.protocol.value_entity.ValueEntityStreamIn.Message.{ Command => InCommand }
@@ -47,14 +46,12 @@ import kalix.protocol.value_entity.ValueEntityStreamIn.Message.{ Init => InInit 
 import kalix.protocol.value_entity.ValueEntityStreamOut.Message.{ Failure => OutFailure }
 import kalix.protocol.value_entity.ValueEntityStreamOut.Message.{ Reply => OutReply }
 import kalix.protocol.value_entity._
-import com.google.protobuf.Descriptors
-import com.google.protobuf.any.{ Any => ScalaPbAny }
 
 final class ValueEntityService(
     val factory: ValueEntityFactory,
     override val descriptor: Descriptors.ServiceDescriptor,
     override val additionalDescriptors: Array[Descriptors.FileDescriptor],
-    val anySupport: AnySupport,
+    val messageCodec: MessageCodec,
     override val entityType: String,
     val entityOptions: Option[ValueEntityOptions])
     extends Service {
@@ -63,7 +60,7 @@ final class ValueEntityService(
       factory: ValueEntityFactory,
       descriptor: Descriptors.ServiceDescriptor,
       additionalDescriptors: Array[Descriptors.FileDescriptor],
-      anySupport: AnySupport,
+      anySupport: MessageCodec,
       entityType: String,
       entityOptions: ValueEntityOptions) =
     this(factory, descriptor, additionalDescriptors, anySupport, entityType, Some(entityOptions))
@@ -126,7 +123,7 @@ final class ValueEntitiesImpl(system: ActorSystem, val services: Map[String, Val
       case Some(ValueEntityInitState(stateOpt, _)) =>
         stateOpt match {
           case Some(state) =>
-            val decoded = service.anySupport.decodeMessage(state)
+            val decoded = service.messageCodec.decodeMessage(state)
             handler._internalSetInitState(decoded)
           case None => // no initial state
         }
@@ -149,7 +146,7 @@ final class ValueEntitiesImpl(system: ActorSystem, val services: Map[String, Val
 
           val metadata = new MetadataImpl(command.metadata.map(_.entries.toVector).getOrElse(Nil))
           val cmd =
-            service.anySupport.decodeMessage(
+            service.messageCodec.decodeMessage(
               command.payload.getOrElse(throw ProtocolException(command, "No command payload")))
           val context =
             new CommandContextImpl(thisEntityId, command.name, command.id, metadata, system)
@@ -167,12 +164,12 @@ final class ValueEntitiesImpl(system: ActorSystem, val services: Map[String, Val
 
           val serializedSecondaryEffect = effect.secondaryEffect match {
             case MessageReplyImpl(message, metadata, sideEffects) =>
-              MessageReplyImpl(service.anySupport.encodeJava(message), metadata, sideEffects)
+              MessageReplyImpl(service.messageCodec.encodeJava(message), metadata, sideEffects)
             case other => other
           }
 
           val clientAction =
-            serializedSecondaryEffect.replyToClientAction(service.anySupport, command.id)
+            serializedSecondaryEffect.replyToClientAction(service.messageCodec, command.id)
 
           serializedSecondaryEffect match {
             case error: ErrorReplyImpl[_] =>
@@ -183,7 +180,7 @@ final class ValueEntitiesImpl(system: ActorSystem, val services: Map[String, Val
                 case DeleteState =>
                   Some(ValueEntityAction(Delete(ValueEntityDelete())))
                 case UpdateState(newState) =>
-                  val newStateScalaPbAny = ScalaPbAny.fromJavaProto(service.anySupport.encodeJava(newState))
+                  val newStateScalaPbAny = service.messageCodec.encodeScala(newState)
                   Some(ValueEntityAction(Update(ValueEntityUpdate(Some(newStateScalaPbAny)))))
                 case _ =>
                   None
@@ -194,7 +191,7 @@ final class ValueEntitiesImpl(system: ActorSystem, val services: Map[String, Val
                   ValueEntityReply(
                     command.id,
                     clientAction,
-                    EffectSupport.sideEffectsFrom(service.anySupport, serializedSecondaryEffect),
+                    EffectSupport.sideEffectsFrom(service.messageCodec, serializedSecondaryEffect),
                     action)))
           }
 

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/action/Action.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/action/Action.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.action;
+
+import kalix.springsdk.impl.SpringKalixComponent;
+
+public abstract class Action extends kalix.javasdk.action.Action implements SpringKalixComponent {}

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/EntityKey.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/EntityKey.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EntityKey {
   String[] value() default {};

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/KalixComponent.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/KalixComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.annotations;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface KalixComponent {}

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/valueentity/ValueEntity.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/valueentity/ValueEntity.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.valueentity;
+
+import kalix.springsdk.impl.SpringKalixComponent;
+
+import java.util.Optional;
+
+public abstract class ValueEntity<S> extends kalix.javasdk.valueentity.ValueEntity<S>
+    implements SpringKalixComponent {
+
+  private Optional<S> currentState = Optional.empty();
+
+  /** INTERNAL API */
+  public void _internalSetCurrentState(S state) {
+    currentState = Optional.ofNullable(state);
+  }
+
+  /**
+   * Returns the state as currently stored by Kalix.
+   *
+   * <p>Note that modifying the state directly will not update it in storage. To save the state, one
+   * must call {{@code effects().updateState()}}.
+   *
+   * <p>This method can only be called when handling a command. Calling it outside a method (eg: in
+   * the constructor) will raise a IllegalStateException exception.
+   *
+   * @throws IllegalStateException if accessed outside a handler method
+   */
+  protected final S currentState() {
+    return currentState.orElseThrow(
+        () ->
+            new IllegalStateException("Current state can only available when handling a command."));
+  }
+}

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ComponentDescription.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ComponentDescription.scala
@@ -16,13 +16,9 @@
 
 package kalix.springsdk.impl
 
-import kalix.javasdk.Kalix
-import kalix.springsdk.action.EchoAction
-import kalix.springsdk.action.ReflectiveActionProvider
+import com.google.protobuf.Descriptors
 
-// Temporary class just for testing
-object SpringSDKTestRunner extends App {
-  val kalix = new Kalix()
-  kalix.register(ReflectiveActionProvider.of(classOf[EchoAction], _ => new EchoAction))
-  kalix.start().toCompletableFuture.get()
-}
+class ComponentDescription(
+    val fileDescriptor: Descriptors.FileDescriptor,
+    val serviceDescriptor: Descriptors.ServiceDescriptor,
+    val methods: Map[String, ComponentMethod])

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ComponentMethod.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ComponentMethod.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl
+
+import java.lang.reflect.Method
+
+import com.google.protobuf.Descriptors
+import kalix.springsdk.impl.reflection.ParameterExtractor
+
+// Might need to have one of each of these for unary, streamed out, streamed in and streamed.
+case class ComponentMethod(
+    method: Method,
+    grpcMethodName: String,
+    parameterExtractors: Array[ParameterExtractor[InvocationContext, AnyRef]],
+    messageDescriptor: Descriptors.Descriptor)

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/Introspector.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/Introspector.scala
@@ -33,6 +33,12 @@ object Introspector {
       nameGenerator: NameGenerator,
       objectMapper: ObjectMapper): ComponentDescription = {
 
+    // TODO: this is better done at compile time, by checking that
+    // the component annotation was added to a Spring Kalix component and not any other class
+    if (!classOf[SpringKalixComponent].isAssignableFrom(component))
+      throw new IllegalArgumentException(
+        s"Component [${component.getName}] is not one of the available components in the Spring SDK. ")
+
     val restService = RestServiceIntrospector.inspectService(component)
 
     val grpcService = ServiceDescriptorProto.newBuilder()

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/InvocationContext.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/InvocationContext.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl
+
+import com.google.protobuf.Descriptors
+import com.google.protobuf.any.{ Any => ScalaPbAny }
+import com.google.protobuf.DynamicMessage
+import kalix.javasdk.Metadata
+import kalix.springsdk.impl.reflection.DynamicMessageContext
+import kalix.springsdk.impl.reflection.MetadataContext
+
+object InvocationContext {
+  def apply(
+      anyMessage: ScalaPbAny,
+      methodDescriptor: Descriptors.Descriptor,
+      metadata: Metadata = Metadata.EMPTY): InvocationContext = {
+
+    val dynamicMessage = DynamicMessage.parseFrom(methodDescriptor, anyMessage.value)
+    new InvocationContext(dynamicMessage, metadata)
+  }
+}
+class InvocationContext(val message: DynamicMessage, val metadata: Metadata)
+    extends DynamicMessageContext
+    with MetadataContext

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/SpringKalixComponent.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/SpringKalixComponent.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl
+
+/**
+ * Marker for Spring Kalix components.
+ *
+ * INTERNAL API
+ */
+trait SpringKalixComponent

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/SpringSdkMessageCodec.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/SpringSdkMessageCodec.scala
@@ -16,6 +16,7 @@
 
 package kalix.springsdk.impl
 
+import com.google.protobuf
 import com.google.protobuf.any
 import kalix.javasdk.JsonSupport
 import kalix.javasdk.impl.MessageCodec
@@ -31,10 +32,14 @@ class SpringSdkMessageCodec extends MessageCodec {
    * In the Spring SDK, output data are encoded to Json.
    */
   override def encodeScala(value: Any): any.Any =
-    any.Any.fromJavaProto(JsonSupport.encodeJson(value))
+    any.Any.fromJavaProto(encodeJava(value))
+
+  override def encodeJava(value: Any): protobuf.Any =
+    JsonSupport.encodeJson(value)
 
   /**
    * In the Spring SDK, input data are kept as proto Any and delivered as such to the router
    */
   override def decodeMessage(value: any.Any): Any = value
+
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/DynamicMethodInfo.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/DynamicMethodInfo.scala
@@ -16,27 +16,26 @@
 
 package kalix.springsdk.impl.reflection
 
-import java.lang.reflect.{ Method, Type }
-
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.api.{ AnnotationsProto, CustomHttpPattern, HttpRule }
-import com.google.protobuf.DescriptorProtos.{
-  DescriptorProto,
-  FieldDescriptorProto,
-  MethodDescriptorProto,
-  MethodOptions,
-  UninterpretedOption
-}
-import com.google.protobuf.{ ByteString, Descriptors, DynamicMessage }
-import kalix.springsdk.impl.reflection.RestServiceIntrospector.{
-  BodyParameter,
-  PathParameter,
-  QueryParamParameter,
-  RestMethod
-}
-import org.springframework.web.bind.annotation.{ RequestMapping, RequestMethod }
+import java.lang.reflect.Type
 
 import scala.annotation.tailrec
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.AnnotationsProto
+import com.google.api.CustomHttpPattern
+import com.google.api.HttpRule
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.DescriptorProtos.DescriptorProto
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto
+import com.google.protobuf.DescriptorProtos.MethodOptions
+import com.google.protobuf.ByteString
+import com.google.protobuf.Descriptors
+import kalix.springsdk.impl.reflection.RestServiceIntrospector.BodyParameter
+import kalix.springsdk.impl.reflection.RestServiceIntrospector.PathParameter
+import kalix.springsdk.impl.reflection.RestServiceIntrospector.QueryParamParameter
+import kalix.springsdk.impl.reflection.RestServiceIntrospector.RestMethod
+import org.springframework.web.bind.annotation.RequestMethod
 
 case class DynamicMethodInfo(
     restMethod: RestMethod,
@@ -45,7 +44,13 @@ case class DynamicMethodInfo(
     extractors: Seq[(Int, ExtractorCreator)])
 
 object DynamicMethodInfo {
-  def build(restMethod: RestMethod, generator: NameGenerator, mapper: ObjectMapper): DynamicMethodInfo = {
+
+  def build(
+      restMethod: RestMethod,
+      generator: NameGenerator,
+      mapper: ObjectMapper,
+      entityKeys: Seq[String] = Seq.empty): DynamicMethodInfo = {
+
     val methodName = restMethod.method.getName.capitalize
     val inputTypeName = generator.getName(methodName + "Request")
 
@@ -77,6 +82,18 @@ object DynamicMethodInfo {
 
     val descriptor = DescriptorProto.newBuilder()
     descriptor.setName(inputTypeName)
+
+    def addEntityKeyIfNeeded(paramName: String, fieldDescriptor: FieldDescriptorProto.Builder) =
+      if (entityKeys.contains(paramName)) {
+        val fieldOptions = kalix.FieldOptions.newBuilder().setEntityKey(true).build()
+        val options =
+          DescriptorProtos.FieldOptions
+            .newBuilder()
+            .setExtension(kalix.Annotations.field, fieldOptions)
+            .build()
+
+        fieldDescriptor.setOptions(options)
+      }
 
     val indexedParams = restMethod.params.zipWithIndex
     val bodyField = indexedParams.collectFirst { case (BodyParameter(param, _), idx) =>
@@ -110,7 +127,7 @@ object DynamicMethodInfo {
       val fieldNumber = fieldIdx + 2
       fieldDescriptor.setNumber(fieldNumber)
       fieldDescriptor.setType(mapJavaTypeToProtobuf(paramType))
-      // todo entity key
+      addEntityKeyIfNeeded(paramName, fieldDescriptor)
       descriptor.addField(fieldDescriptor)
       maybeParamIdx.map(_ -> new ExtractorCreator {
         override def apply(descriptor: Descriptors.Descriptor): ParameterExtractor[DynamicMessageContext, AnyRef] = {

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/RestServiceIntrospector.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/RestServiceIntrospector.scala
@@ -37,7 +37,7 @@ object RestServiceIntrospector {
 
   private val discoverer = new DefaultParameterNameDiscoverer
 
-  def inspectService[T](pojo: Class[T]): RestService = {
+  def inspectService[T](component: Class[T]): RestService = {
     // Spring defines a number of annotations, eg, @GetMapping, @PostMapping, etc, that we want to support. These
     // annotations are annotated with @AliasFor annotations that essentially map all their properties to the more
     // generic @RequestMapping annotation. Spring's annotation support understands these annotations, and is therefore
@@ -45,12 +45,12 @@ object RestServiceIntrospector {
     // merge their properties according to the @AliasFor configuration, so that we only have to do the below call to
     // read the entire hierarchy.
 
-    val classMapping = Option(AnnotatedElementUtils.findMergedAnnotation(pojo, classOf[RequestMapping]))
+    val classMapping = Option(AnnotatedElementUtils.findMergedAnnotation(component, classOf[RequestMapping]))
     classMapping.foreach { mapping =>
-      validateRequestMapping(pojo, mapping)
+      validateRequestMapping(component, mapping)
     }
 
-    val methodMappings = pojo.getMethods
+    val methodMappings = component.getMethods
       .map { method =>
         method -> Option(AnnotatedElementUtils.findMergedAnnotation(method, classOf[RequestMapping]))
       }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/valueentity/ReflectiveValueEntityRouter.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/valueentity/ReflectiveValueEntityRouter.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl.valueentity
+
+import com.google.protobuf.any.{ Any => ScalaPbAny }
+import kalix.javasdk.impl.valueentity.ValueEntityRouter
+import kalix.javasdk.valueentity.CommandContext
+import kalix.javasdk.valueentity.ValueEntity
+import kalix.springsdk.impl.ComponentMethod
+import kalix.springsdk.impl.InvocationContext
+
+class ReflectiveValueEntityRouter[S, E <: ValueEntity[S]](
+    override protected val entity: E,
+    componentMethods: Map[String, ComponentMethod])
+    extends ValueEntityRouter[S, E](entity) {
+
+  private def methodLookup(commandName: String) =
+    componentMethods.getOrElse(commandName, throw new RuntimeException(s"no matching method for '$commandName'"))
+
+  override protected def handleCommand(
+      commandName: String,
+      state: S,
+      command: Any,
+      context: CommandContext): ValueEntity.Effect[_] = {
+
+    val componentMethod = methodLookup(commandName)
+    val context =
+      InvocationContext(command.asInstanceOf[ScalaPbAny], componentMethod.messageDescriptor)
+
+    // pass current state to entity
+    entity._internalSetCurrentState(state);
+
+    componentMethod.method
+      .invoke(entity, componentMethod.parameterExtractors.map(e => e.extract(context)): _*)
+      .asInstanceOf[ValueEntity.Effect[_]]
+  }
+}

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/valueentity/ReflectiveValueEntityRouter.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/valueentity/ReflectiveValueEntityRouter.scala
@@ -42,7 +42,7 @@ class ReflectiveValueEntityRouter[S, E <: ValueEntity[S]](
       InvocationContext(command.asInstanceOf[ScalaPbAny], componentMethod.messageDescriptor)
 
     // pass current state to entity
-    entity._internalSetCurrentState(state);
+    entity.asInstanceOf[kalix.springsdk.valueentity.ValueEntity[S]]._internalSetCurrentState(state);
 
     componentMethod.method
       .invoke(entity, componentMethod.parameterExtractors.map(e => e.extract(context)): _*)

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/action/RestAnnotatedActions.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/action/RestAnnotatedActions.java
@@ -16,7 +16,7 @@
 
 package kalix.springsdk.action;
 
-import kalix.javasdk.action.Action;
+import kalix.springsdk.action.Action;
 import org.springframework.web.bind.annotation.*;
 
 public class RestAnnotatedActions {
@@ -109,6 +109,13 @@ public class RestAnnotatedActions {
     @DeleteMapping("/message/{one}")
     public Action.Effect<Message> message(@PathVariable String one) {
       return effects().reply(new Message(one));
+    }
+  }
+
+  public static class ActionUsingJavaSdk extends kalix.javasdk.action.Action {
+    @GetMapping("/message")
+    public Action.Effect<Message> message() {
+      return effects().reply(new Message("hello"));
     }
   }
 }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/impl/SpringSDKTestRunner.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/impl/SpringSDKTestRunner.java
@@ -33,7 +33,7 @@ public class SpringSDKTestRunner {
         .register(
             ReflectiveValueEntityProvider.of(
                 "user-entity", // TODO: we should have this in some type level annotation, ie:
-                               // @KalixComponent(name)
+                // @KalixComponent(name)
                 UserEntity.class,
                 __ -> new UserEntity()));
     kalix.start().toCompletableFuture().get();

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/impl/SpringSDKTestRunner.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/impl/SpringSDKTestRunner.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl;
+
+import kalix.javasdk.Kalix;
+import kalix.springsdk.action.EchoAction;
+import kalix.springsdk.action.ReflectiveActionProvider;
+import kalix.springsdk.valueentity.ReflectiveValueEntityProvider;
+import kalix.springsdk.valueentity.UserEntity;
+
+import java.util.concurrent.ExecutionException;
+
+public class SpringSDKTestRunner {
+
+  public static void main(String[] args) throws ExecutionException, InterruptedException {
+    Kalix kalix = new Kalix();
+    kalix
+        .register(ReflectiveActionProvider.of(EchoAction.class, __ -> new EchoAction()))
+        .register(
+            ReflectiveValueEntityProvider.of(
+                "user-entity", // TODO: we should have this in some type level annotation, ie:
+                               // @KalixComponent(name)
+                UserEntity.class,
+                __ -> new UserEntity()));
+    kalix.start().toCompletableFuture().get();
+  }
+}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/CreateUser.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/CreateUser.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.valueentity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public class CreateUser {
+
+  public final String firstName;
+  public final String lastName;
+
+  @JsonCreator
+  public CreateUser(String firstName, String lastName) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/Done.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/Done.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.valueentity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Done {
+
+  public static Done instance = new Done("done");
+  public final String message;
+
+  @JsonCreator
+  public Done(@JsonProperty("message") String message) {
+    this.message = message;
+  }
+}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/RestAnnotatedValueEntities.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/RestAnnotatedValueEntities.java
@@ -16,7 +16,6 @@
 
 package kalix.springsdk.valueentity;
 
-import kalix.javasdk.valueentity.ValueEntity;
 import kalix.springsdk.annotations.EntityKey;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +26,20 @@ public class RestAnnotatedValueEntities {
   @EntityKey({"userId", "cartId"})
   @RequestMapping("/user/{userId}/{cartId}")
   public static class PostWithEntityKeys extends ValueEntity<User> {
+    @Override
+    public User emptyState() {
+      return User.empty();
+    }
+
+    @PostMapping("/create")
+    public ValueEntity.Effect<Done> createEntity(@RequestBody CreateUser createUser) {
+      return effects().reply(Done.instance);
+    }
+  }
+
+  @EntityKey({"userId", "cartId"})
+  @RequestMapping("/user/{userId}/{cartId}")
+  public static class ValueEntityUsingJavaSdk extends kalix.javasdk.valueentity.ValueEntity<User> {
     @Override
     public User emptyState() {
       return User.empty();

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/RestAnnotatedValueEntities.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/RestAnnotatedValueEntities.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.valueentity;
+
+import kalix.javasdk.valueentity.ValueEntity;
+import kalix.springsdk.annotations.EntityKey;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+public class RestAnnotatedValueEntities {
+
+  @EntityKey("id")
+  @RequestMapping("/user/{id}")
+  public static class PostWithoutParam extends ValueEntity<User> {
+
+    @Override
+    public User emptyState() {
+      return User.empty();
+    }
+
+    @PostMapping("/create")
+    public ValueEntity.Effect<Done> createUser(@RequestBody CreateUser createUser) {
+      return effects().reply(Done.instance);
+    }
+  }
+}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/RestAnnotatedValueEntities.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/RestAnnotatedValueEntities.java
@@ -24,17 +24,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 public class RestAnnotatedValueEntities {
 
-  @EntityKey("id")
-  @RequestMapping("/user/{id}")
-  public static class PostWithoutParam extends ValueEntity<User> {
-
+  @EntityKey({"userId", "cartId"})
+  @RequestMapping("/user/{userId}/{cartId}")
+  public static class PostWithEntityKeys extends ValueEntity<User> {
     @Override
     public User emptyState() {
       return User.empty();
     }
 
     @PostMapping("/create")
-    public ValueEntity.Effect<Done> createUser(@RequestBody CreateUser createUser) {
+    public ValueEntity.Effect<Done> createEntity(@RequestBody CreateUser createUser) {
       return effects().reply(Done.instance);
     }
   }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/User.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/User.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.valueentity;
+
+public class User {
+
+  public final String firstName;
+  public final String lastName;
+
+  public User(String firstName, String lastName) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  public static User empty() {
+    return new User("", "");
+  }
+}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/UserEntity.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/valueentity/UserEntity.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.valueentity;
+
+import kalix.javasdk.valueentity.ValueEntity;
+import kalix.springsdk.annotations.EntityKey;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@EntityKey("id")
+@RequestMapping("/user/{id}")
+public class UserEntity extends ValueEntity<User> {
+  @Override
+  public User emptyState() {
+    return User.empty();
+  }
+
+  @PostMapping("/create")
+  public ValueEntity.Effect<Done> createUser(@RequestBody CreateUser createUser) {
+    return effects().reply(Done.instance);
+  }
+}

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/IntrospectionSuite.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/IntrospectionSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl
+
+import scala.reflect.ClassTag
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.protobuf.Descriptors
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
+import kalix.springsdk.impl.reflection.NameGenerator
+import org.scalatest.matchers.should.Matchers
+
+trait IntrospectionSuite extends Matchers {
+
+  def assertDescriptor[E](assertFunc: ComponentDescription => Unit)(implicit ev: ClassTag[E]) = {
+    val nameGenerator = new NameGenerator
+    val objectMapper = new ObjectMapper
+
+    assertFunc(Introspector.inspect(ev.runtimeClass, nameGenerator, objectMapper))
+  }
+
+  def assertMessage(method: ComponentMethod, fieldName: String, expectedType: JavaType) = {
+    val field = findField(method, fieldName)
+    field.getJavaType shouldBe expectedType
+  }
+
+  def assertEntityKeyField(method: ComponentMethod, fieldName: String) = {
+    val field = findField(method, fieldName)
+    val fieldOption = field.toProto.getOptions.getExtension(kalix.Annotations.field)
+    fieldOption.getEntityKey shouldBe true
+  }
+
+  private def findField(method: ComponentMethod, fieldName: String): Descriptors.FieldDescriptor = {
+    val field = method.messageDescriptor.findFieldByName(fieldName)
+    if (field == null) throw new NoSuchElementException(s"no field found for $fieldName")
+    field
+  }
+}

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/action/ActionIntrospectorSpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/action/ActionIntrospectorSpec.scala
@@ -16,11 +16,7 @@
 
 package kalix.springsdk.impl.action
 
-import scala.reflect.ClassTag
-
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
-import kalix.javasdk.action.Action
 import kalix.springsdk.action.RestAnnotatedActions.DeleteWithOneParam
 import kalix.springsdk.action.RestAnnotatedActions.GetClassLevel
 import kalix.springsdk.action.RestAnnotatedActions.GetWithOneParam
@@ -33,11 +29,10 @@ import kalix.springsdk.action.RestAnnotatedActions.PostWithTwoParam
 import kalix.springsdk.action.RestAnnotatedActions.PostWithoutParam
 import kalix.springsdk.action.RestAnnotatedActions.PutWithOneParam
 import kalix.springsdk.action.RestAnnotatedActions.PutWithoutParam
-import kalix.springsdk.impl.reflection.NameGenerator
-import org.scalatest.matchers.should.Matchers
+import kalix.springsdk.impl.IntrospectionSuite
 import org.scalatest.wordspec.AnyWordSpec
 
-class ActionIntrospectorSpec extends AnyWordSpec with Matchers {
+class ActionIntrospectorSpec extends AnyWordSpec with IntrospectionSuite {
 
   "Action introspector" should {
 
@@ -135,19 +130,6 @@ class ActionIntrospectorSpec extends AnyWordSpec with Matchers {
         assertMessage(method, "one", JavaType.STRING)
       }
     }
-  }
-
-  private def assertDescriptor[A <: Action](assertFunc: ActionDescription[A] => Unit)(implicit ev: ClassTag[A]) = {
-    val nameGenerator = new NameGenerator
-    val objectMapper = new ObjectMapper
-
-    assertFunc(ActionIntrospector.inspect(ev.runtimeClass.asInstanceOf[Class[A]], nameGenerator, objectMapper))
-  }
-
-  private def assertMessage(method: ActionMethod, fieldName: String, expectedType: JavaType) = {
-    val field = method.messageDescriptor.findFieldByName(fieldName)
-    if (field == null) throw new NoSuchElementException(s"no field found for $fieldName")
-    field.getJavaType shouldBe expectedType
   }
 
 }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/action/ActionIntrospectorSpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/action/ActionIntrospectorSpec.scala
@@ -16,7 +16,9 @@
 
 package kalix.springsdk.impl.action
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
+import kalix.springsdk.action.RestAnnotatedActions.ActionUsingJavaSdk
 import kalix.springsdk.action.RestAnnotatedActions.DeleteWithOneParam
 import kalix.springsdk.action.RestAnnotatedActions.GetClassLevel
 import kalix.springsdk.action.RestAnnotatedActions.GetWithOneParam
@@ -30,6 +32,8 @@ import kalix.springsdk.action.RestAnnotatedActions.PostWithoutParam
 import kalix.springsdk.action.RestAnnotatedActions.PutWithOneParam
 import kalix.springsdk.action.RestAnnotatedActions.PutWithoutParam
 import kalix.springsdk.impl.IntrospectionSuite
+import kalix.springsdk.impl.Introspector
+import kalix.springsdk.impl.reflection.NameGenerator
 import org.scalatest.wordspec.AnyWordSpec
 
 class ActionIntrospectorSpec extends AnyWordSpec with IntrospectionSuite {
@@ -128,6 +132,12 @@ class ActionIntrospectorSpec extends AnyWordSpec with IntrospectionSuite {
       assertDescriptor[DeleteWithOneParam] { desc =>
         val method = desc.methods("Message")
         assertMessage(method, "one", JavaType.STRING)
+      }
+    }
+
+    "fail when inspecting an Action implementing Java SDK directly" in {
+      intercept[IllegalArgumentException] {
+        Introspector.inspect(classOf[ActionUsingJavaSdk], new NameGenerator, new ObjectMapper())
       }
     }
   }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/valueentity/ValueEntityIntrospectorSpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/valueentity/ValueEntityIntrospectorSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl.valueentity
+
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
+import kalix.springsdk.impl.IntrospectionSuite
+import kalix.springsdk.valueentity.RestAnnotatedValueEntities
+import org.scalatest.wordspec.AnyWordSpec
+
+class ValueEntityIntrospectorSpec extends AnyWordSpec with IntrospectionSuite {
+
+  "ValueEntity introspector" should {
+    "generate mappings for a Value Entity" in {
+      assertDescriptor[RestAnnotatedValueEntities.PostWithoutParam] { desc =>
+        val method = desc.methods("CreateUser")
+        assertMessage(method, "json_body", JavaType.MESSAGE)
+        assertMessage(method, "id", JavaType.STRING)
+        assertEntityKeyField(method, "id")
+      }
+    }
+  }
+
+}

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/valueentity/ValueEntityIntrospectorSpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/valueentity/ValueEntityIntrospectorSpec.scala
@@ -16,9 +16,13 @@
 
 package kalix.springsdk.impl.valueentity
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import kalix.springsdk.impl.IntrospectionSuite
+import kalix.springsdk.impl.Introspector
+import kalix.springsdk.impl.reflection.NameGenerator
 import kalix.springsdk.valueentity.RestAnnotatedValueEntities.PostWithEntityKeys
+import kalix.springsdk.valueentity.RestAnnotatedValueEntities.ValueEntityUsingJavaSdk
 import org.scalatest.wordspec.AnyWordSpec
 
 class ValueEntityIntrospectorSpec extends AnyWordSpec with IntrospectionSuite {
@@ -34,6 +38,12 @@ class ValueEntityIntrospectorSpec extends AnyWordSpec with IntrospectionSuite {
 
         assertMessage(method, "cartId", JavaType.STRING)
         assertEntityKeyField(method, "cartId")
+      }
+    }
+
+    "fail when inspecting a ValueEntity implementing Java SDK directly" in {
+      intercept[IllegalArgumentException] {
+        Introspector.inspect(classOf[ValueEntityUsingJavaSdk], new NameGenerator, new ObjectMapper())
       }
     }
 

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/valueentity/ValueEntityIntrospectorSpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/valueentity/ValueEntityIntrospectorSpec.scala
@@ -18,20 +18,25 @@ package kalix.springsdk.impl.valueentity
 
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import kalix.springsdk.impl.IntrospectionSuite
-import kalix.springsdk.valueentity.RestAnnotatedValueEntities
+import kalix.springsdk.valueentity.RestAnnotatedValueEntities.PostWithEntityKeys
 import org.scalatest.wordspec.AnyWordSpec
 
 class ValueEntityIntrospectorSpec extends AnyWordSpec with IntrospectionSuite {
 
   "ValueEntity introspector" should {
-    "generate mappings for a Value Entity" in {
-      assertDescriptor[RestAnnotatedValueEntities.PostWithoutParam] { desc =>
-        val method = desc.methods("CreateUser")
+    "generate mappings for a Value Entity with entity keys in path" in {
+      assertDescriptor[PostWithEntityKeys] { desc =>
+        val method = desc.methods("CreateEntity")
         assertMessage(method, "json_body", JavaType.MESSAGE)
-        assertMessage(method, "id", JavaType.STRING)
-        assertEntityKeyField(method, "id")
+
+        assertMessage(method, "userId", JavaType.STRING)
+        assertEntityKeyField(method, "userId")
+
+        assertMessage(method, "cartId", JavaType.STRING)
+        assertEntityKeyField(method, "cartId")
       }
     }
+
   }
 
 }


### PR DESCRIPTION
Follow up on: https://github.com/lightbend/kalix-jvm-sdk/pull/1015#discussion_r894468350

This is working more or less ok. We have thin layer of Spring SDK components and some basic runtime validation to ensure that users don't use Java SDK components classes. 

So far so good, but when coding against this we get IntelliJ offering both component versions and that's not great. But we can probably do something with Java Modules. I don't have experience with it, but worth trying to block direct usage of Java SDK components classes. 
