### PR TITLE
ci: add untested samples to workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1088,6 +1088,10 @@ workflows:
           requires:
             - checks
             - publish-local
+      - sample-java-customer-registry-kafka-quickstart:
+          requires:
+            - checks
+            - publish-local
       - sample-java-customer-registry-views-quickstart:
           requires:
             - checks
@@ -1169,6 +1173,10 @@ workflows:
             - checks
             - publish-local
       - sample-scala-valueentity-counter:
+          requires:
+            - checks
+            - publish-local
+      - sample-scala-eventsourced-counter:
           requires:
             - checks
             - publish-local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,8 +600,8 @@ jobs:
             echo "Running mvn with SDK version: '$SDK_VERSION'"
             mvn -Dkalix-sdk.version=$SDK_VERSION test-compile
             mvn -Dkalix-sdk.version=$SDK_VERSION test
-            # FIXME related to https://github.com/lightbend/kalix-jvm-sdk/issues/297
-            # mvn -Dkalix-sdk.version=$SDK_VERSION verify -Pit
+            # FIXME add eventing integration tests (related to https://github.com/lightbend/kalix-jvm-sdk/issues/297)
+            mvn -Dkalix-sdk.version=$SDK_VERSION verify -Pit
             echo "==== Verifying that generated unmanaged sources compile ===="
             rm -rf src/main/java src/test/java src/it/java
             mvn -Dkalix-sdk.version=$SDK_VERSION test-compile
@@ -853,8 +853,8 @@ jobs:
           command: |
             cd samples/scala-eventsourced-counter
             echo "Running sbt with SDK version: '$SDK_VERSION'"
+            # FIXME add eventing integration tests (related to https://github.com/lightbend/kalix-jvm-sdk/issues/297)
             sbt -Dkalix-sdk.version=$SDK_VERSION test
-            # FIXME integration tests
             echo "==== Verifying that generated unmanaged sources compile ===="
             rm -rf src/main/scala src/test/scala src/it/scala
             sbt -Dkalix-sdk.version=$SDK_VERSION Test/compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,9 +298,13 @@ jobs:
             ALL_OK=true
             for SAMPLE in samples/java* samples/scala*
             do
-              if [ $(grep -c $SAMPLE .circleci/config.yml) -lt 1 ]
-              then
+              if [ $(grep -c $SAMPLE .circleci/config.yml) -lt 1 ] ; then
                 echo "$SAMPLE is missing CI-tests"
+                ALL_OK=false
+              fi
+              SAMPLE_JOB_NAME="sample-${SAMPLE#samples/}"
+              if [ $(grep -c $SAMPLE_JOB_NAME .circleci/config.yml) -lt 2 ] ; then
+                echo "$SAMPLE_JOB_NAME is missing from CI workflow"
                 ALL_OK=false
               fi
             done

--- a/samples/java-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
+++ b/samples/java-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
@@ -48,9 +48,6 @@ service CounterJournalToTopic {
   } 
 
   rpc IncreaseConditional (com.example.domain.ValueIncreased) returns (Increased) { 
-    option (kalix.method).eventing.in = { 
-      event_sourced_entity: "counter" 
-    };
     option (kalix.method).eventing.out = {
       topic:  "counter-events"
     };

--- a/samples/scala-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
+++ b/samples/scala-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
@@ -46,9 +46,6 @@ service CounterJournalToTopic {
   } 
 
   rpc IncreaseConditional (com.example.domain.ValueIncreased) returns (Increased) { 
-    option (kalix.method).eventing.in = { 
-      event_sourced_entity: "counter" 
-    };
     option (kalix.method).eventing.out = {
       topic:  "counter-events"
     };


### PR DESCRIPTION
The `scala-eventsourced-counter` sample was reported as not working (in a slack discussion).

A couple of samples have jobs that are not included in the CI workflow. There's a verification that each sample has a CI job, but not whether these are in the workflow and actually run. May need a little more trickery for that verification.

Adding the missing samples, one of which should fail.
