### PR TITLE
build: fix sbt run for scala samples by forking

### DIFF
--- a/samples/scala-customer-registry-quickstart/build.sbt
+++ b/samples/scala-customer-registry-quickstart/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-doc-snippets/build.sbt
+++ b/samples/scala-doc-snippets/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-eventsourced-counter/build.sbt
+++ b/samples/scala-eventsourced-counter/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-eventsourced-customer-registry/build.sbt
+++ b/samples/scala-eventsourced-customer-registry/build.sbt
@@ -41,7 +41,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-eventsourced-shopping-cart/build.sbt
+++ b/samples/scala-eventsourced-shopping-cart/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-fibonacci-action/build.sbt
+++ b/samples/scala-fibonacci-action/build.sbt
@@ -34,7 +34,7 @@ Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oDF")
 Test / logBuffered := false
 
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-reliable-timers/build.sbt
+++ b/samples/scala-reliable-timers/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-replicatedentity-examples/build.sbt
+++ b/samples/scala-replicatedentity-examples/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-replicatedentity-shopping-cart/build.sbt
+++ b/samples/scala-replicatedentity-shopping-cart/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-valueentity-counter/build.sbt
+++ b/samples/scala-valueentity-counter/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq(

--- a/samples/scala-valueentity-customer-registry/build.sbt
+++ b/samples/scala-valueentity-customer-registry/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.12" % Test)

--- a/samples/scala-valueentity-shopping-cart/build.sbt
+++ b/samples/scala-valueentity-shopping-cart/build.sbt
@@ -39,7 +39,7 @@ Compile / run := {
   sys.props += "kalix.user-function-interface" -> "0.0.0.0"
   (Compile / run).evaluated
 }
-run / fork := false
+run / fork := true
 Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
`sbt run` returns immediately, since sbt 1.6 — https://github.com/sbt/sbt/issues/6767

Fork the runs to fix this for now.