### PR TITLE
fix: propagate GRPC status code to response for entities

### DIFF
--- a/samples/java-valueentity-counter/src/main/java/com/example/domain/Counter.java
+++ b/samples/java-valueentity-counter/src/main/java/com/example/domain/Counter.java
@@ -5,6 +5,7 @@
 
 package com.example.domain;
 
+import io.grpc.Status;
 import kalix.javasdk.Metadata;
 import kalix.javasdk.valueentity.ValueEntityContext;
 import com.example.CounterApi;
@@ -55,7 +56,7 @@ public class Counter extends AbstractCounter { // <1>
         CounterDomain.CounterState currentState, CounterApi.IncreaseValue command) {
       if (command.getValue() < 0) { 
         return effects().error("Increase requires a positive value. It was [" +
-            command.getValue() + "].");
+            command.getValue() + "].", Status.Code.INVALID_ARGUMENT);
       }
       CounterDomain.CounterState newState;
       if (commandContext().metadata().get("myKey").equals(Optional.of("myValue"))) {

--- a/samples/scala-valueentity-counter/src/main/scala/com/example/domain/Counter.scala
+++ b/samples/scala-valueentity-counter/src/main/scala/com/example/domain/Counter.scala
@@ -10,6 +10,7 @@ import kalix.scalasdk.valueentity.ValueEntityContext
 import com.example
 import com.example.CurrentCounter
 import com.google.protobuf.empty.Empty
+import io.grpc.Status.Code
 
 // tag::class[]
 class Counter(context: ValueEntityContext) extends AbstractCounter { // <1>
@@ -31,7 +32,7 @@ class Counter(context: ValueEntityContext) extends AbstractCounter { // <1>
 
   override def increaseWithConditional(currentState: CounterState, command: example.IncreaseValue): ValueEntity.Effect[Empty] =
     if (command.value < 0) // <1>
-      effects.error(s"Increase requires a positive value. It was [${command.value}].")
+      effects.error(s"Increase requires a positive value. It was [${command.value}].", Code.INVALID_ARGUMENT)
     else {
       if (commandContext.metadata.get("myKey") == Some("myValue")) {
       val newState = currentState.copy(value = currentState.value + command.value*2)

--- a/samples/scala-valueentity-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
+++ b/samples/scala-valueentity-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
@@ -1,5 +1,7 @@
 package com.example
 
+import io.grpc.Status.Code
+import io.grpc.StatusRuntimeException
 import kalix.scalasdk.testkit.KalixTestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -8,6 +10,8 @@ import org.scalatest.time.Millis
 import org.scalatest.time.Seconds
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.language.postfixOps
 
 // This class was initially generated based on the .proto definition by Kalix tooling.
 //
@@ -43,6 +47,14 @@ class CounterServiceIntegrationSpec
 
       val getResult = client.getCurrentCounter(GetCounter(counterId))
       getResult.futureValue.value shouldBe(42-32)
+    }
+
+    "Return correct status code if command fails" in {
+      val counterId = "42"
+      val updateResult = client.increaseWithConditional(IncreaseValue(counterId, -5)).failed.futureValue
+
+      updateResult shouldBe a[StatusRuntimeException]
+      updateResult.asInstanceOf[StatusRuntimeException].getStatus.getCode shouldBe Code.INVALID_ARGUMENT
     }
 
   }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/effect/SecondaryEffectImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/effect/SecondaryEffectImpl.scala
@@ -38,7 +38,8 @@ sealed trait SecondaryEffectImpl {
         Some(
           ClientAction(
             ClientAction.Action
-              .Failure(kalix.protocol.component.Failure(commandId, failure.description))))
+              .Failure(kalix.protocol.component
+                .Failure(commandId, failure.description, grpcStatusCode = failure.status.map(_.value()).getOrElse(0)))))
       case NoSecondaryEffectImpl(_) =>
         throw new RuntimeException("No reply or forward returned by command handler!")
     }

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntity.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntity.java
@@ -43,7 +43,9 @@ public class CartEntity extends AbstractCartEntity {
       ShoppingCartDomain.Cart currentState, ShoppingCartApi.AddLineItem command) {
     if (command.getQuantity() <= 0) {
       return effects()
-          .error("Quantity for item " + command.getProductId() + " must be greater than zero.", INVALID_ARGUMENT);
+          .error(
+              "Quantity for item " + command.getProductId() + " must be greater than zero.",
+              INVALID_ARGUMENT);
     } else {
       return effects()
           .emitEvent(createItemAddedEvent(command))

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntity.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntity.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static io.grpc.Status.Code.INVALID_ARGUMENT;
+
 /** User implementation of entity */
 public class CartEntity extends AbstractCartEntity {
 
@@ -41,7 +43,7 @@ public class CartEntity extends AbstractCartEntity {
       ShoppingCartDomain.Cart currentState, ShoppingCartApi.AddLineItem command) {
     if (command.getQuantity() <= 0) {
       return effects()
-          .error("Quantity for item " + command.getProductId() + " must be greater than zero.");
+          .error("Quantity for item " + command.getProductId() + " must be greater than zero.", INVALID_ARGUMENT);
     } else {
       return effects()
           .emitEvent(createItemAddedEvent(command))

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/replicatedentity/CartEntity.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/replicatedentity/CartEntity.java
@@ -18,13 +18,14 @@ package kalix.javasdk.replicatedentity;
 
 import com.example.replicatedentity.shoppingcart.ShoppingCartApi;
 import com.example.replicatedentity.shoppingcart.domain.ShoppingCartDomain;
-import com.example.replicatedentity.shoppingcart.domain.ShoppingCartDomain.LineItem;
 import com.google.protobuf.Empty;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static io.grpc.Status.Code.INVALID_ARGUMENT;
 
 public class CartEntity extends AbstractCartEntity {
   @SuppressWarnings("unused")
@@ -40,7 +41,7 @@ public class CartEntity extends AbstractCartEntity {
       ShoppingCartApi.AddLineItem addLineItem) {
     if (addLineItem.getQuantity() <= 0) {
       return effects()
-          .error("Quantity for item " + addLineItem.getProductId() + " must be greater than zero.");
+          .error("Quantity for item " + addLineItem.getProductId() + " must be greater than zero.", INVALID_ARGUMENT);
     }
 
     return effects()

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/replicatedentity/CartEntity.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/replicatedentity/CartEntity.java
@@ -41,7 +41,9 @@ public class CartEntity extends AbstractCartEntity {
       ShoppingCartApi.AddLineItem addLineItem) {
     if (addLineItem.getQuantity() <= 0) {
       return effects()
-          .error("Quantity for item " + addLineItem.getProductId() + " must be greater than zero.", INVALID_ARGUMENT);
+          .error(
+              "Quantity for item " + addLineItem.getProductId() + " must be greater than zero.",
+              INVALID_ARGUMENT);
     }
 
     return effects()

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/valueentity/CartEntity.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/valueentity/CartEntity.java
@@ -47,7 +47,9 @@ public class CartEntity extends AbstractCartEntity {
       ShoppingCartDomain.Cart currentState, ShoppingCartApi.AddLineItem addLineItem) {
     if (addLineItem.getQuantity() <= 0) {
       return effects()
-          .error("Quantity for item " + addLineItem.getProductId() + " must be greater than zero.", INVALID_ARGUMENT);
+          .error(
+              "Quantity for item " + addLineItem.getProductId() + " must be greater than zero.",
+              INVALID_ARGUMENT);
     }
 
     ShoppingCartDomain.LineItem lineItem = updateItem(addLineItem, currentState);

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/valueentity/CartEntity.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/valueentity/CartEntity.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static io.grpc.Status.Code.INVALID_ARGUMENT;
+
 /** A value entity. */
 public class CartEntity extends AbstractCartEntity {
   @SuppressWarnings("unused")
@@ -45,7 +47,7 @@ public class CartEntity extends AbstractCartEntity {
       ShoppingCartDomain.Cart currentState, ShoppingCartApi.AddLineItem addLineItem) {
     if (addLineItem.getQuantity() <= 0) {
       return effects()
-          .error("Quantity for item " + addLineItem.getProductId() + " must be greater than zero.");
+          .error("Quantity for item " + addLineItem.getProductId() + " must be greater than zero.", INVALID_ARGUMENT);
     }
 
     ShoppingCartDomain.LineItem lineItem = updateItem(addLineItem, currentState);

--- a/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImplSpec.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImplSpec.scala
@@ -16,6 +16,7 @@
 
 package kalix.javasdk.impl.eventsourcedentity
 
+import io.grpc.Status.Code.INVALID_ARGUMENT
 import kalix.javasdk.eventsourcedentity._
 import kalix.testkit.TestProtocol
 import kalix.testkit.eventsourcedentity.EventSourcedMessages
@@ -181,7 +182,7 @@ class EventSourcedEntitiesImplSpec extends AnyWordSpec with Matchers with Before
       val entity = protocol.eventSourced.connect()
       entity.send(init(ShoppingCart.Name, "cart"))
       entity.send(command(1, "cart", "AddItem", addItem("foo", "bar", -1)))
-      entity.expect(actionFailure(1, "Quantity for item foo must be greater than zero."))
+      entity.expect(actionFailure(1, "Quantity for item foo must be greater than zero.", INVALID_ARGUMENT))
       entity.send(command(2, "cart", "GetCart", getShoppingCart("cart")))
       entity.expect(reply(2, EmptyCart)) // check entity state hasn't changed
       entity.passivate()

--- a/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImplSpec.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImplSpec.scala
@@ -16,6 +16,7 @@
 
 package kalix.javasdk.impl.replicatedentity
 
+import io.grpc.Status.Code.INVALID_ARGUMENT
 import kalix.javasdk.replicatedentity.CartEntity
 import kalix.javasdk.replicatedentity.CartEntityProvider
 import kalix.protocol.replicated_entity.ReplicatedEntityDelta
@@ -187,7 +188,7 @@ class ReplicatedEntitiesImplSpec extends AnyWordSpec with Matchers with BeforeAn
         .connect()
         .send(init(ShoppingCart.Name, "cart"))
         .send(command(1, "cart", "AddItem", addItem("foo", "bar", -1)))
-        .expect(failure(1, "Quantity for item foo must be greater than zero."))
+        .expect(failure(1, "Quantity for item foo must be greater than zero.", INVALID_ARGUMENT))
         .send(command(2, "cart", "GetCart", getShoppingCart("cart")))
         .expect(reply(2, EmptyCart)) // check update-then-fail doesn't change entity state
         .passivate()

--- a/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImplSpec.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImplSpec.scala
@@ -16,6 +16,7 @@
 
 package kalix.javasdk.impl.valueentity
 
+import io.grpc.Status.Code.INVALID_ARGUMENT
 import kalix.javasdk.valueentity.CartEntity
 import kalix.javasdk.valueentity.CartEntityProvider
 import kalix.testkit.TestProtocol
@@ -113,7 +114,7 @@ class ValueEntitiesImplSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       val entity = protocol.valueEntity.connect()
       entity.send(init(ShoppingCart.Name, "cart"))
       entity.send(command(1, "cart", "AddItem", addItem("foo", "bar", -1)))
-      entity.expect(actionFailure(1, "Quantity for item foo must be greater than zero."))
+      entity.expect(actionFailure(1, "Quantity for item foo must be greater than zero.", INVALID_ARGUMENT))
       entity.send(command(2, "cart", "GetCart", getShoppingCart("cart")))
       entity.expect(reply(2, EmptyCart)) // check update-then-fail doesn't change entity state
 

--- a/sdk/java-sdk/src/test/scala/kalix/testkit/entity/EntityMessages.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/testkit/entity/EntityMessages.scala
@@ -35,10 +35,13 @@ trait EntityMessages {
     Some(ClientAction(ClientAction.Action.Forward(Forward(service, command, payload))))
 
   def clientActionFailure(description: String): Option[ClientAction] =
-    clientActionFailure(id = 0, description)
+    clientActionFailure(id = 0, description, statusCode = 0)
 
   def clientActionFailure(id: Long, description: String): Option[ClientAction] =
-    Some(ClientAction(ClientAction.Action.Failure(Failure(id, description))))
+    clientActionFailure(id, description, statusCode = 0)
+
+  def clientActionFailure(id: Long, description: String, statusCode: Int): Option[ClientAction] =
+    Some(ClientAction(ClientAction.Action.Failure(Failure(id, description, statusCode))))
 
   def sideEffect(service: String, command: String, payload: JavaPbMessage): SideEffect =
     sideEffect(service, command, messagePayload(payload), synchronous = false)

--- a/sdk/java-sdk/src/test/scala/kalix/testkit/eventsourcedentity/EventSourcedMessages.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/testkit/eventsourcedentity/EventSourcedMessages.scala
@@ -22,6 +22,7 @@ import kalix.protocol.event_sourced_entity._
 import kalix.testkit.entity.EntityMessages
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Message => JavaPbMessage }
+import io.grpc.Status
 import scalapb.{ GeneratedMessage => ScalaPbMessage }
 
 object EventSourcedMessages extends EntityMessages {
@@ -143,6 +144,9 @@ object EventSourcedMessages extends EntityMessages {
 
   def actionFailure(id: Long, description: String): OutMessage =
     OutMessage.Reply(EventSourcedReply(id, clientActionFailure(id, description)))
+
+  def actionFailure(id: Long, description: String, statusCode: Status.Code): OutMessage =
+    OutMessage.Reply(EventSourcedReply(id, clientActionFailure(id, description, statusCode.value())))
 
   def failure(description: String): OutMessage =
     failure(id = 0, description)

--- a/sdk/java-sdk/src/test/scala/kalix/testkit/replicatedentity/ReplicatedEntityMessages.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/testkit/replicatedentity/ReplicatedEntityMessages.scala
@@ -22,6 +22,7 @@ import kalix.protocol.entity.Command
 import kalix.testkit.entity.EntityMessages
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Message => JavaPbMessage }
+import io.grpc.Status
 import scalapb.{ GeneratedMessage => ScalaPbMessage }
 
 object ReplicatedEntityMessages extends EntityMessages {
@@ -117,10 +118,13 @@ object ReplicatedEntityMessages extends EntityMessages {
     failure(id = 0, description)
 
   def failure(id: Long, description: String): OutMessage =
-    failure(id, description, Effects.empty)
+    failure(id, description, Status.Code.UNKNOWN, Effects.empty)
 
-  def failure(id: Long, description: String, effects: Effects): OutMessage =
-    replicatedEntityReply(id, clientActionFailure(id, description), effects)
+  def failure(id: Long, description: String, statusCode: Status.Code): OutMessage =
+    failure(id, description, statusCode, Effects.empty)
+
+  def failure(id: Long, description: String, statusCode: Status.Code, effects: Effects): OutMessage =
+    replicatedEntityReply(id, clientActionFailure(id, description, statusCode.value()), effects)
 
   def replicatedEntityReply(id: Long, clientAction: Option[ClientAction], effects: Effects): OutMessage =
     OutMessage.Reply(ReplicatedEntityReply(id, clientAction, effects.sideEffects, effects.stateAction))

--- a/sdk/java-sdk/src/test/scala/kalix/testkit/valueentity/ValueEntityMessages.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/testkit/valueentity/ValueEntityMessages.scala
@@ -22,6 +22,7 @@ import kalix.protocol.value_entity._
 import kalix.testkit.entity.EntityMessages
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Message => JavaPbMessage }
+import io.grpc.Status
 import scalapb.{ GeneratedMessage => ScalaPbMessage }
 
 object ValueEntityMessages extends EntityMessages {
@@ -127,6 +128,9 @@ object ValueEntityMessages extends EntityMessages {
 
   def actionFailure(id: Long, description: String): OutMessage =
     OutMessage.Reply(ValueEntityReply(id, clientActionFailure(id, description)))
+
+  def actionFailure(id: Long, description: String, statusCode: Status.Code): OutMessage =
+    OutMessage.Reply(ValueEntityReply(id, clientActionFailure(id, description, statusCode.value())))
 
   def failure(description: String): OutMessage =
     failure(id = 0, description)


### PR DESCRIPTION
References #955 

This was working correctly but only for actions, not for entities.