### PR TITLE
chore: allow override of proxy version by config

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object Kalix {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 0
-    val ProxyVersion = "1.0.10"
+    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.0.10")
   }
 
   // changing the Scala version of the Java SDK affects end users


### PR DESCRIPTION
The goal is to allow external config of the proxy version dependency. One example would be when trying to run the integration tests of an app using the SDK but against a specific proxy version.
