### PR TITLE
feat: emptyState defaults to 'null' in java sdk

### DIFF
--- a/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -39,8 +39,8 @@ public abstract class EventSourcedEntity<S> {
    *
    * <p>Also known as "zero state" or "neutral state".
    *
-   * <p>The default implementation of this method returns <code>null</code>. It can be overridden to return a more
-   * sensible initial state.
+   * <p>The default implementation of this method returns <code>null</code>. It can be overridden to
+   * return a more sensible initial state.
    */
   public S emptyState() {
     return null;

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -39,9 +39,12 @@ public abstract class EventSourcedEntity<S> {
    *
    * <p>Also known as "zero state" or "neutral state".
    *
-   * <p><code>null</code> is an allowed value.
+   * <p>The default implementation of this method returns <code>null</code>. It can be overridden to return a more
+   * sensible initial state.
    */
-  public abstract S emptyState();
+  public S emptyState() {
+    return null;
+  }
 
   /**
    * Additional context and metadata for a command handler.

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -36,8 +36,8 @@ public abstract class ValueEntity<S> {
    *
    * <p>Also known as "zero state" or "neutral state".
    *
-   * <p>The default implementation of this method returns <code>null</code>. It can be overridden to return a more
-   * sensible initial state.
+   * <p>The default implementation of this method returns <code>null</code>. It can be overridden to
+   * return a more sensible initial state.
    */
   public S emptyState() {
     return null;

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -36,9 +36,12 @@ public abstract class ValueEntity<S> {
    *
    * <p>Also known as "zero state" or "neutral state".
    *
-   * <p><code>null</code> is an allowed value.
+   * <p>The default implementation of this method returns <code>null</code>. It can be overridden to return a more
+   * sensible initial state.
    */
-  public abstract S emptyState();
+  public S emptyState() {
+    return null;
+  }
 
   /**
    * Additional context and metadata for a command handler.

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/view/View.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/view/View.java
@@ -46,8 +46,8 @@ public abstract class View<S> {
   }
 
   /**
-   * The default implementation of this method returns <code>null</code>. It can be overridden to return a more
-   * sensible initial state.
+   * The default implementation of this method returns <code>null</code>. It can be overridden to
+   * return a more sensible initial state.
    *
    * @return an empty state object or `null` to hand to the process method when an event for a
    *     previously unknown subject id is seen.

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/view/View.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/view/View.java
@@ -46,10 +46,15 @@ public abstract class View<S> {
   }
 
   /**
+   * The default implementation of this method returns <code>null</code>. It can be overridden to return a more
+   * sensible initial state.
+   *
    * @return an empty state object or `null` to hand to the process method when an event for a
    *     previously unknown subject id is seen.
    */
-  public abstract S emptyState();
+  public S emptyState() {
+    return null;
+  }
 
   /**
    * Construct the effect that is returned by the command handler. The effect describes next


### PR DESCRIPTION
Defaults the `emptyState` to `null` for the Java API. This is most probably what a Java developer will expect. 

This change only affects `ValueEntity`, `EventSourcedEntity` and `View`. `ReplicatedEntity` is left as is because the `emptyData` cannot be `null`. 

This idea came out while implementing Views in the Spring SDK. Actually, it doesn't make much sense to have an empty state for views. Either we have a row in the index or we have nothing. 

