### PR TITLE
chore: avoiding calling through the mesh to the proxy

### DIFF
--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -175,7 +175,7 @@ public class KalixTestKit {
     proxyContainer.start();
     started = true;
     // pass on proxy and host to GrpcClients to allow for inter-component communication
-    GrpcClients.get(runner.system()).setSelfServicePort(proxyContainer.getProxyPort());
+    GrpcClients.get(runner.system()).setProxyPort(proxyContainer.getProxyPort());
     return this;
   }
 


### PR DESCRIPTION
This is the first attempt to avoid calling the proxy through DNS. 

Maybe the better way to do this is to change https://github.com/lightbend/kalix-proxy/blob/9215b87b92eb46f6fae443c3ef99468130af360c/proxy/core/src/main/resources/reference.conf#L5-L6

and add only one param which is the port kind of 
```
  proxy-port = 9000
  proxy-port = ${?KALIX_PROXY_PORT}
```
and then consume that from this SDK here https://github.com/lightbend/kalix-jvm-sdk/blob/1a00df65e569679804502124a67fdab2988b876d/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/GrpcClients.scala#L109

For that I would need to deal with the deployment yaml files which so far I don't know how to test. 
Do you think this could be the first part of a two-step solution?



References https://github.com/lightbend/kalix-proxy/issues/1469