### PR TITLE
chore: bump proxy version to 1.0.16

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object Kalix {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 0
-    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.0.15")
+    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.0.16")
   }
 
   // changing the Scala version of the Java SDK affects end users

--- a/samples/java-customer-registry-kafka-quickstart/docker-compose.yml
+++ b/samples/java-customer-registry-kafka-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-customer-registry-kafka-quickstart/kafka/docker-compose.yml
+++ b/samples/java-customer-registry-kafka-quickstart/kafka/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=kafka
     ports:
       - "9000:9000"

--- a/samples/java-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-customer-registry-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-customer-registry-views-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-eventsourced-counter/docker-compose.yml
+++ b/samples/java-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-eventsourced-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-fibonacci-action/docker-compose.yml
+++ b/samples/java-fibonacci-action/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-first-service/docker-compose.yml
+++ b/samples/java-first-service/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-reliable-timers/docker-compose.yml
+++ b/samples/java-reliable-timers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-replicatedentity-examples/docker-compose.yml
+++ b/samples/java-replicatedentity-examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/java-replicatedentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-shopping-cart-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-valueentity-counter/docker-compose.yml
+++ b/samples/java-valueentity-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-valueentity-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-valueentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-customer-registry-quickstart/docker-compose.yml
+++ b/samples/scala-customer-registry-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-eventsourced-counter/docker-compose.yml
+++ b/samples/scala-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/scala-eventsourced-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/scala-eventsourced-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-fibonacci-action/docker-compose.yml
+++ b/samples/scala-fibonacci-action/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-first-service/docker-compose.yml
+++ b/samples/scala-first-service/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-reliable-timers/docker-compose.yml
+++ b/samples/scala-reliable-timers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-replicatedentity-examples/docker-compose.yml
+++ b/samples/scala-replicatedentity-examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-replicatedentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-valueentity-counter/docker-compose.yml
+++ b/samples/scala-valueentity-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-valueentity-customer-registry/docker-compose.yml
+++ b/samples/scala-valueentity-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-valueentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"


### PR DESCRIPTION
References [Release Proxy 1.0.16](https://github.com/lightbend/kalix-proxy/issues/1611)