### PR TITLE
Example on how to call exposed service

### DIFF
--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
@@ -266,6 +266,16 @@ You can https://docs.kalix.io/services/invoke-service.html#_exposing_services_to
 kalix service expose <service name>
 ----
 
+Try to call the exposed service with `grpcurl`:
+
+[source,command line]
+----
+grpcurl \
+  -d '{"customer_id": "abc123"}' \
+  <generated hostname>:443 \
+  customer.api.CustomerService/GetCustomer
+----
+
 == Next steps
 
 * You can learn more about xref:java:value-entity.adoc[Value Entities].

--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-scala.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-scala.adoc
@@ -283,6 +283,16 @@ You can https://docs.kalix.io/services/invoke-service.html#_exposing_services_to
 kalix service expose <service name>
 ----
 
+Try to call the exposed service with `grpcurl`:
+
+[source,command line]
+----
+grpcurl \
+  -d '{"customer_id": "abc123"}' \
+  <generated hostname>:443 \
+  customer.api.CustomerService/GetCustomer
+----
+
 == Next steps
 
 * You can learn more about xref:java:value-entity.adoc[Value Entities].


### PR DESCRIPTION
I am following the scala/java quickguide to learn more about Kalix.

There is already an example on how to expose a service on a public address but no example on how to call it. 


When I copied the grpcurl example from how to call the service via the local proxy I made a simple mistake by not removing the  `--plaintext` argument and also add  `:443`. This combined with that go client produce an error like `Failed to dial target host "xxx-xxx.kalix.app": context deadline exceeded`  and `Error invoking method "customer-registry/GetCustomer": target server does not expose service "customer-registry"` got me lost.


I manage to add an example and build the docs locally. Please let me know if I need to do something more or/and if you don't think that this is a good idea.

<img width="684" alt="Screenshot 2022-08-22 at 17 06 35" src="https://user-images.githubusercontent.com/506762/185959363-af4ac6ee-e436-40a2-80ef-c94eb8fbebec.png">


