### PR TITLE
fix: Ensure streaming calls from proxy are parallel 

### DIFF
--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
@@ -266,6 +266,7 @@ private[javasdk] final class ActionsImpl(
               // user stream failed with an "unexpected" error
               handleUnexpectedException(service, in, ex)
             }
+            .async
         } catch {
           case NonFatal(ex) =>
             // command handler threw an "unexpected" error

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -247,6 +247,7 @@ final class EventSourcedEntitiesImpl(
           EventSourcedStreamOut(OutFailure(Failure(description = s"Unexpected failure [$correlationId]")))
         }
       }
+      .async
   }
 
   private class CommandContextImpl(

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImpl.scala
@@ -100,6 +100,7 @@ final class ReplicatedEntitiesImpl(system: ActorSystem, services: Map[String, Re
           ReplicatedEntityStreamOut(Out.Failure(Failure(description = s"Unexpected error [$correlationId]")))
         }
       }
+      .async
 
   private def runEntity(
       init: ReplicatedEntityInit): Flow[ReplicatedEntityStreamIn, ReplicatedEntityStreamOut, NotUsed] = {

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -114,6 +114,7 @@ final class ValueEntitiesImpl(system: ActorSystem, val services: Map[String, Val
           ValueEntityStreamOut(OutFailure(Failure(description = s"Unexpected error [$correlationId]")))
         }
       }
+      .async
 
   private def runEntity(init: ValueEntityInit): Flow[ValueEntityStreamIn, ValueEntityStreamOut, NotUsed] = {
     val service =

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
@@ -150,6 +150,7 @@ final class ViewsImpl(system: ActorSystem, _services: Map[String, ViewService], 
             s"Kalix protocol failure: expected ReceiveEvent message, but got ${other.getClass.getName}"
           Source.failed(new RuntimeException(errMsg))
       }
+      .async
 
   private final class UpdateContextImpl(
       override val viewId: String,


### PR DESCRIPTION
Refs #1078

Calls to stream out methods from the same client are sequential with Akka HTTP/gRPC
by default, this adds an async boundary to allow them to run in parallel.