### PR TITLE
chore: emptyState can be null - Optional(null)

### DIFF
--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -32,6 +32,8 @@ public abstract class ValueEntity<S> {
 
   private Optional<S> currentState = Optional.empty();
 
+  private boolean handlingCommands = false;
+
   /**
    * Implement by returning the initial empty state object. This object will be passed into the
    * command handlers, until a new state replaces it.
@@ -65,6 +67,7 @@ public abstract class ValueEntity<S> {
 
   /** INTERNAL API */
   public void _internalSetCurrentState(S state) {
+    handlingCommands = true;
     currentState = Optional.ofNullable(state);
   }
 
@@ -80,9 +83,10 @@ public abstract class ValueEntity<S> {
    * @throws IllegalStateException if accessed outside a handler method
    */
   protected final S currentState() {
-    return currentState.orElseThrow(
-        () ->
-            new IllegalStateException("Current state is only available when handling a command."));
+    // user may call this method inside a command handler and get a null because it's legal
+    // to have emptyState set to null.
+    if (handlingCommands) return currentState.orElse(null);
+    else new IllegalStateException("Current state is only available when handling a command.");
   }
 
   protected final Effect.Builder<S> effects() {

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -86,7 +86,8 @@ public abstract class ValueEntity<S> {
     // user may call this method inside a command handler and get a null because it's legal
     // to have emptyState set to null.
     if (handlingCommands) return currentState.orElse(null);
-    else new IllegalStateException("Current state is only available when handling a command.");
+    else
+      throw new IllegalStateException("Current state is only available when handling a command.");
   }
 
   protected final Effect.Builder<S> effects() {


### PR DESCRIPTION
In #1052, we make it possible to have an emptyState set to `null`. That's convenient and even expected for java developers. 

However, on first command, one may want to check if the state was already created with `if (currentState() == null)`. 

Because we were using `Optional.ofNullable(state)`, we still have an empty Optional that will later fail with "Current state is only available when handling a command."

I'm opting to have a `Optional(null)` here because we then preserve the behavior that `currentState()` can only be called inside the command handler. 