### PR TITLE
chore: merge main into spring sdk 

### DIFF
--- a/docs/src/modules/java/pages/spring-client.adoc
+++ b/docs/src/modules/java/pages/spring-client.adoc
@@ -153,7 +153,7 @@ Download the resulting ZIP file, which is an archive of a web application that i
 
 ----
   <properties>
-        <kalix-sdk.version>1.0.3</kalix-sdk.version>
+        <kalix-sdk.version>1.0.6</kalix-sdk.version>
         <akka-grpc.version>2.1.4</akka-grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-maven-archetype-event-sourced-entity</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
 
     <name>Kalix Maven Archetype (Event Sourced entity)</name>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -9,7 +9,7 @@ While designing your service it is useful to read [designing services](https://d
 ## Developing
 ]]#
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
-extend it it may be useful to read up on [developing services](https://docs.kalix.io/services/)
+extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [Java section](https://docs.kalix.io/java/index.html)
 
 #[[

--- a/maven-java/kalix-maven-archetype-value-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-maven-archetype</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
 
     <name>Kalix Maven Archetype (Value entity)</name>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
@@ -9,7 +9,7 @@ While designing your service it is useful to read [designing services](https://d
 ## Developing
 ]]#
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
-extend it it may be useful to read up on [developing services](https://docs.kalix.io/services/)
+extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [Java section](https://docs.kalix.io/java/index.html)
 
 #[[

--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
 
   <groupId>io.kalix</groupId>
   <artifactId>kalix-maven-plugin</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <packaging>maven-plugin</packaging>
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-maven-java</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
   </parent>
 
   <name>Kalix Maven Plugin</name>

--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.kalix</groupId>
   <artifactId>kalix-maven-java</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <packaging>pom</packaging>
 
   <name>Kalix Java Maven parent pom</name>

--- a/samples/java-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-customer-registry-kafka-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-customer-registry-quickstart/pom.xml
+++ b/samples/java-customer-registry-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-customer-registry-views-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-doc-snippets/pom.xml
+++ b/samples/java-doc-snippets/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-eventsourced-counter/README.md
+++ b/samples/java-eventsourced-counter/README.md
@@ -9,7 +9,7 @@ While designing your service it is useful to read [designing services](https://d
 ## Developing
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
-extend it it may be useful to read up on [developing services](https://docs.kalix.io/services/)
+extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [Java section](https://docs.kalix.io/java/)
 
 

--- a/samples/java-eventsourced-counter/pom.xml
+++ b/samples/java-eventsourced-counter/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-eventsourced-customer-registry/pom.xml
+++ b/samples/java-eventsourced-customer-registry/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
         <jdk.target>11</jdk.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kalix-sdk.version>1.0.5</kalix-sdk.version>
+        <kalix-sdk.version>1.0.6</kalix-sdk.version>
         <akka-grpc.version>2.1.4</akka-grpc.version>
     </properties>
 

--- a/samples/java-fibonacci-action/pom.xml
+++ b/samples/java-fibonacci-action/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-first-service/README.md
+++ b/samples/java-first-service/README.md
@@ -9,7 +9,7 @@ While designing your service it is useful to read [designing services](https://d
 ## Developing
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
-extend it it may be useful to read up on [developing services](https://docs.kalix.io/services/)
+extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [Java section](https://docs.kalix.io/java/)
 
 

--- a/samples/java-first-service/pom.xml
+++ b/samples/java-first-service/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-reliable-timers/pom.xml
+++ b/samples/java-reliable-timers/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 

--- a/samples/java-replicatedentity-examples/pom.xml
+++ b/samples/java-replicatedentity-examples/pom.xml
@@ -20,7 +20,7 @@
       <jdk.target>11</jdk.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-      <kalix-sdk.version>1.0.5</kalix-sdk.version>
+      <kalix-sdk.version>1.0.6</kalix-sdk.version>
       <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-replicatedentity-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
       <jdk.target>11</jdk.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-      <kalix-sdk.version>1.0.5</kalix-sdk.version>
+      <kalix-sdk.version>1.0.6</kalix-sdk.version>
       <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-shopping-cart-quickstart/pom.xml
+++ b/samples/java-shopping-cart-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-valueentity-counter-spring-client/pom.xml
+++ b/samples/java-valueentity-counter-spring-client/pom.xml
@@ -21,7 +21,7 @@
         <java.version>11</java.version>
         <jdk.target>11</jdk.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kalix-sdk.version>1.0.5</kalix-sdk.version>
+        <kalix-sdk.version>1.0.6</kalix-sdk.version>
         <akka-grpc.version>2.1.4</akka-grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>

--- a/samples/java-valueentity-counter/pom.xml
+++ b/samples/java-valueentity-counter/pom.xml
@@ -20,7 +20,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-valueentity-customer-registry/pom.xml
+++ b/samples/java-valueentity-customer-registry/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
       <jdk.target>11</jdk.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-      <kalix-sdk.version>1.0.5</kalix-sdk.version>
+      <kalix-sdk.version>1.0.6</kalix-sdk.version>
       <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/scala-customer-registry-quickstart/project/plugins.sbt
+++ b/samples/scala-customer-registry-quickstart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-doc-snippets/project/plugins.sbt
+++ b/samples/scala-doc-snippets/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-eventsourced-counter/project/plugins.sbt
+++ b/samples/scala-eventsourced-counter/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-eventsourced-customer-registry/project/plugins.sbt
+++ b/samples/scala-eventsourced-customer-registry/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-eventsourced-shopping-cart/project/plugins.sbt
+++ b/samples/scala-eventsourced-shopping-cart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-fibonacci-action/project/plugins.sbt
+++ b/samples/scala-fibonacci-action/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-first-service/README.md
+++ b/samples/scala-first-service/README.md
@@ -7,7 +7,7 @@ While designing your service it is useful to read [designing services](https://d
 ## Developing
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
-extend it it may be useful to read up on [developing services](https://docs.kalix.io/services/)
+extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [JVM section](https://docs.kalix.io/java/)
 
 ## Building

--- a/samples/scala-first-service/project/plugins.sbt
+++ b/samples/scala-first-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-reliable-timers/project/plugins.sbt
+++ b/samples/scala-reliable-timers/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-replicatedentity-examples/project/plugins.sbt
+++ b/samples/scala-replicatedentity-examples/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-replicatedentity-shopping-cart/README.md
+++ b/samples/scala-replicatedentity-shopping-cart/README.md
@@ -8,7 +8,7 @@ While designing your service it is useful to read [designing services](https://d
 ## Developing
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
-extend it it may be useful to read up on [developing services](https://docs.kalix.io/services/)
+extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [JVM section](https://docs.kalix.io/java/)
 
 ## Building

--- a/samples/scala-replicatedentity-shopping-cart/project/plugins.sbt
+++ b/samples/scala-replicatedentity-shopping-cart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-valueentity-counter/project/plugins.sbt
+++ b/samples/scala-valueentity-counter/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-valueentity-customer-registry/project/plugins.sbt
+++ b/samples/scala-valueentity-customer-registry/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-valueentity-shopping-cart/README.md
+++ b/samples/scala-valueentity-shopping-cart/README.md
@@ -8,7 +8,7 @@ While designing your service it is useful to read [designing services](https://d
 ## Developing
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
-extend it it may be useful to read up on [developing services](https://docs.kalix.io/services/)
+extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [JVM section](https://docs.kalix.io/java/)
 
 ## Building

--- a/samples/scala-valueentity-shopping-cart/project/plugins.sbt
+++ b/samples/scala-valueentity-shopping-cart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.5"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.6"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/spring-customer-registry-views-quickstart/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/spring-fibonacci-action/pom.xml
+++ b/samples/spring-fibonacci-action/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/spring-wiring-tests/pom.xml
+++ b/samples/spring-wiring-tests/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.5</kalix-sdk.version>
+    <kalix-sdk.version>1.0.6</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
@@ -265,6 +265,7 @@ private[javasdk] final class ActionsImpl(
               // user stream failed with an "unexpected" error
               handleUnexpectedException(service, in, ex)
             }
+            .async
         } catch {
           case NonFatal(ex) =>
             // command handler threw an "unexpected" error

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -250,6 +250,7 @@ final class EventSourcedEntitiesImpl(
           EventSourcedStreamOut(OutFailure(Failure(description = s"Unexpected failure [$correlationId]")))
         }
       }
+      .async
   }
 
   private class CommandContextImpl(

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImpl.scala
@@ -100,6 +100,7 @@ final class ReplicatedEntitiesImpl(system: ActorSystem, services: Map[String, Re
           ReplicatedEntityStreamOut(Out.Failure(Failure(description = s"Unexpected error [$correlationId]")))
         }
       }
+      .async
 
   private def runEntity(
       init: ReplicatedEntityInit): Flow[ReplicatedEntityStreamIn, ReplicatedEntityStreamOut, NotUsed] = {

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -111,6 +111,7 @@ final class ValueEntitiesImpl(system: ActorSystem, val services: Map[String, Val
           ValueEntityStreamOut(OutFailure(Failure(description = s"Unexpected error [$correlationId]")))
         }
       }
+      .async
 
   private def runEntity(init: ValueEntityInit): Flow[ValueEntityStreamIn, ValueEntityStreamOut, NotUsed] = {
     val service =

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
@@ -150,6 +150,7 @@ final class ViewsImpl(system: ActorSystem, _services: Map[String, ViewService], 
             s"Kalix protocol failure: expected ReceiveEvent message, but got ${other.getClass.getName}"
           Source.failed(new RuntimeException(errMsg))
       }
+      .async
 
   private final class UpdateContextImpl(
       override val viewId: String,


### PR DESCRIPTION
Getting it in closed to `main` before we merge the `spring-sdk` into `main`

Also because I think it will make it easier if all samples move to 1.0.6 first. A PR from spring-sdk to main will probably fail. 