### PR TITLE
fix: add -parameters to compiler config

### DIFF
--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -52,6 +52,7 @@
           <target>${jdk.target}</target>
           <compilerArgs>
             <arg>-Xlint:deprecation</arg>
+            <arg>-parameters</arg>
           </compilerArgs>
         </configuration>
       </plugin>


### PR DESCRIPTION
We need the arg `-parameters` to make it more convenient to use the `@JsonProperty`. With this arg, we don't need to name the properties.