### PR TITLE
chore: restoring parent branch in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
             git config user.email "circleci@example.com"
             git config user.name "CircleCI"
       - build-tools/merge-with-parent:
-          parent: spring-sdk # we need to revert this when merging back into main
+          parent: main
 
   install-java-11:
     description: install openjdk-11


### PR DESCRIPTION
This is to fix the pipeline failing after the merge of `spring-sdk`into `main`