### PR TITLE
chore: fix release issue link

### DIFF
--- a/docs/release-issue-template.md
+++ b/docs/release-issue-template.md
@@ -6,7 +6,7 @@
 - [ ] Check that the [latest build](https://app.circleci.com/pipelines/github/lightbend/kalix-jvm-sdk) successfully finished
 - [ ] Make sure a version of the proxy that supports the protocol version the SDK expects has been deployed to production
 
-You can see the proxy version on prod [on grafana](https://lightbendcloud.grafana.net/d/ebzw4ARnz/prod-kalix-operations-dashboard?orgId=1) or using [various other methods](https://github.com/lightbend/kalix/wiki/Versioning-and-how-to-determine-what-version-is-running).
+You can see the proxy version on prod [on grafana](https://lightbendcloud.grafana.net/d/2n4jVuw7z/prod-kalix-metrics?orgId=1) or using [various other methods](https://github.com/lightbend/kalix/wiki/Versioning-and-how-to-determine-what-version-is-running).
 
 ### Cutting the release 
 


### PR DESCRIPTION
No issue.. just noted a broken link in the release issue.

(we still have a operations dashboard but I think this one is more high-level so seems more suited to check the versions)