### PR TITLE
chore: ApiMayChange for currentState() methods

### DIFF
--- a/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -16,6 +16,7 @@
 
 package kalix.javasdk.eventsourcedentity;
 
+import akka.annotation.ApiMayChange;
 import kalix.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl;
 import kalix.javasdk.Metadata;
 import kalix.javasdk.DeferredCall;
@@ -96,6 +97,7 @@ public abstract class EventSourcedEntity<S> {
    *
    * @throws IllegalStateException if accessed outside a handler method
    */
+  @ApiMayChange
   protected final S currentState() {
     // user may call this method inside a command handler and get a null because it's legal
     // to have emptyState set to null.

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -16,6 +16,7 @@
 
 package kalix.javasdk.valueentity;
 
+import akka.annotation.ApiMayChange;
 import kalix.javasdk.DeferredCall;
 import kalix.javasdk.Metadata;
 import kalix.javasdk.SideEffect;
@@ -82,6 +83,7 @@ public abstract class ValueEntity<S> {
    *
    * @throws IllegalStateException if accessed outside a handler method
    */
+  @ApiMayChange
   protected final S currentState() {
     // user may call this method inside a command handler and get a null because it's legal
     // to have emptyState set to null.


### PR DESCRIPTION
Those methods were added to support the Spring SDK. At some point in the future, we may need or prefer to have them moved to Spring SDK specific component classes. 

I had previously a PR on this: https://github.com/lightbend/kalix-jvm-sdk/pull/1018, but closed because I was not so happy with the directly. 

I would like to add this annotation just for good measure and give us the option to move then later.