### PR TITLE
chore(ci): add missing sample and run samples after it tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1132,9 +1132,6 @@ workflows:
       - tests:
           requires:
             - checks
-      - spring-sdk-integration-tests:
-          requires:
-            - tests
       - scripted-tests:
           requires:
             - checks
@@ -1155,6 +1152,9 @@ workflows:
           requires:
             - checks
             - publish-local
+      - spring-sdk-integration-tests:
+          requires:
+            - tests
 
       # individual samples as jobs to allow parallelizing them
       - sample-java-customer-registry-quickstart:
@@ -1279,11 +1279,15 @@ workflows:
             - publish-local
       - sample-spring-fibonacci-action:
           requires:
-            - checks
+            - spring-sdk-integration-tests
             - publish-local
       - sample-spring-customer-registry-views-quickstart:
           requires:
-            - checks
+            - spring-sdk-integration-tests
+            - publish-local
+      - sample-spring-eventsourced-counter:
+          requires:
+            - spring-sdk-integration-tests
             - publish-local
       - publish:
           filters: # version tags only


### PR DESCRIPTION
Follow up of https://github.com/lightbend/kalix-jvm-sdk/pull/1113

Just noticed that the sample was not being run. Also, since we have the IT tests for spring-sdk I think it makes sense to only run the samples after the IT tests pass. Thoughts?