### PR TITLE
fix: configure spring apps to not start embedded webserver

### DIFF
--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# Don't remove this. 
+# this configuration is required in order to  block Spring Boot to start it's own http server
+# Kalix brings in its own http server and that's the one that will be starter.
+spring.main.web-application-type=none

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -114,8 +114,7 @@ object Dependencies {
   val springDeps = Seq(
     jacksonDataFormatProto,
     "org.springframework.boot" % "spring-boot" % SpringVersion,
-    ("org.springframework.boot" % "spring-boot-starter-webflux" % SpringVersion)
-      .exclude("org.springframework.boot", "spring-boot-starter-tomcat"))
+    "org.springframework.boot" % "spring-boot-starter-webflux" % SpringVersion)
 
   val sdkSpring = deps ++= coreDeps ++ springDeps ++ Seq(
     "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % IntegrationTest,

--- a/samples/spring-customer-registry-views-quickstart/src/main/resources/application.properties
+++ b/samples/spring-customer-registry-views-quickstart/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# Don't remove this. 
+# this configuration is required in order to  block Spring Boot to start it's own http server
+# Kalix brings in its own http server and that's the one that will be starter.
+spring.main.web-application-type=none

--- a/samples/spring-eventsourced-counter/src/main/resources/application.properties
+++ b/samples/spring-eventsourced-counter/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# Don't remove this. 
+# this configuration is required in order to  block Spring Boot to start it's own http server
+# Kalix brings in its own http server and that's the one that will be starter.
+spring.main.web-application-type=none

--- a/samples/spring-fibonacci-action/src/main/resources/application.properties
+++ b/samples/spring-fibonacci-action/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# Don't remove this. 
+# this configuration is required in order to  block Spring Boot to start it's own http server
+# Kalix brings in its own http server and that's the one that will be starter.
+spring.main.web-application-type=none


### PR DESCRIPTION
References https://github.com/lightbend/kalix/issues/7515

This is a temporary solution. We need an extra piece of configuration to tell Spring to not start the embedded server. 

A Kalix Spring application using the webflux starter. We need to keep it for now because of the reactive webclient it brings in. 

However, we may want to provide our own starter, see: https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.developing-auto-configuration

