### PR TITLE
chore: label changes on samples as Documentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,3 +21,4 @@ spring-sdk:
 
 Documentation:
   - docs/**/*
+  - samples/**/*


### PR DESCRIPTION
When releasing, some changes we did in `samples` ended up on the Java SDK section of the Release Notes. I think it would make more sense to label those as documentation automatically.