### PR TITLE
chore: set current state in ValueEntity testkit

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
@@ -144,6 +144,7 @@ object ValueEntityTestKitGenerator {
         s"""|public ValueEntityResult<$output> ${lowerFirst(command.name)}(${command.inputType.fullName} ${lowerFirst(
           command.inputType.name)}, Metadata metadata) {
        |  entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+       |  entity._internalSetCurrentState(state);
        |  ValueEntity.Effect<$output> effect = entity.${lowerFirst(command.name)}(state, ${lowerFirst(
           command.inputType.name)});
        |  return interpretEffects(effect);

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ValueEntityTestKitGenerator.scala
@@ -143,7 +143,7 @@ object ValueEntityTestKitGenerator {
         val output = selectOutput(command)
         s"""|public ValueEntityResult<$output> ${lowerFirst(command.name)}(${command.inputType.fullName} ${lowerFirst(
           command.inputType.name)}, Metadata metadata) {
-       |  entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+       |  entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
        |  entity._internalSetCurrentState(state);
        |  ValueEntity.Effect<$output> effect = entity.${lowerFirst(command.name)}(state, ${lowerFirst(
           command.inputType.name)});

--- a/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
@@ -77,12 +77,14 @@ public final class CounterTestKit {
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);
   }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
@@ -76,14 +76,14 @@ public final class CounterTestKit {
   }
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);

--- a/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-managed/org/example/valueentity/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-managed/org/example/valueentity/CounterTestKit.java
@@ -75,12 +75,14 @@ public final class CounterTestKit {
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);
   }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-managed/org/example/valueentity/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/domain-in-service-package/generated-test-managed/org/example/valueentity/CounterTestKit.java
@@ -74,14 +74,14 @@ public final class CounterTestKit {
   }
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);

--- a/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
@@ -76,12 +76,14 @@ public final class CounterTestKit {
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);
   }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/named-new-style/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
@@ -75,14 +75,14 @@ public final class CounterTestKit {
   }
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);

--- a/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
@@ -77,12 +77,14 @@ public final class CounterTestKit {
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);
   }

--- a/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/state-events-in-different-pacakge/generated-test-managed/org/example/valueentity/domain/CounterTestKit.java
@@ -76,14 +76,14 @@ public final class CounterTestKit {
   }
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);

--- a/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-managed/org/example/valueentity/CounterServiceEntityTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-managed/org/example/valueentity/CounterServiceEntityTestKit.java
@@ -75,14 +75,14 @@ public final class CounterServiceEntityTestKit {
   }
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
-    entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
     entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);

--- a/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-managed/org/example/valueentity/CounterServiceEntityTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/value-entity/unnamed-new-style/generated-test-managed/org/example/valueentity/CounterServiceEntityTestKit.java
@@ -76,12 +76,14 @@ public final class CounterServiceEntityTestKit {
 
   public ValueEntityResult<Empty> increase(CounterApi.IncreaseValue increaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.increase(state, increaseValue);
     return interpretEffects(effect);
   }
 
   public ValueEntityResult<Empty> decrease(CounterApi.DecreaseValue decreaseValue, Metadata metadata) {
     entity ._internalSetCommandContext(Optional.of(new TestKitValueEntityCommandContext(entityId, metadata)));
+    entity._internalSetCurrentState(state);
     ValueEntity.Effect<Empty> effect = entity.decrease(state, decreaseValue);
     return interpretEffects(effect);
   }


### PR DESCRIPTION
Discovered that while working on #1135

We have introduced the `currentState` for the value entities, but if a user uses it and then write a test using the testkit, they will get an error because the testkit was not setting the state.

For EventSourced entities, it's already covered in #1135. This is done in the `EventSourcedEntityEffectsRunner`