### PR TITLE
chore: bump kalix proxy version to 1.0.20

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Kalix {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 0
-    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.0.16")
+    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.0.20")
   }
 
   // changing the Scala version of the Java SDK affects end users


### PR DESCRIPTION
Seems that I forgot to update it in https://github.com/lightbend/kalix-jvm-sdk/pull/1121