### PR TITLE
chore: Bump jackson databind

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
   val AkkaVersion = "2.6.20"
   val AkkaHttpVersion = "10.2.10" // Note: should at least the Akka HTTP version required by Akka gRPC
   val ScalaTestVersion = "3.2.14"
-  val JacksonVersion = "2.13.4.1"
-  val JacksonDatabindVersion = JacksonVersion
+  val JacksonVersion = "2.13.4"
+  val JacksonDatabindVersion = "2.13.4.1"
   val DockerBaseImageVersion = "adoptopenjdk/openjdk11:debianslim-jre"
   val LogbackVersion = "1.2.11"
   val LogbackContribVersion = "0.1.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
   val AkkaVersion = "2.6.20"
   val AkkaHttpVersion = "10.2.10" // Note: should at least the Akka HTTP version required by Akka gRPC
   val ScalaTestVersion = "3.2.14"
-  val JacksonVersion = "2.13.4"
-  val JacksonDatabindVersion = "2.13.4"
+  val JacksonVersion = "2.13.4.1"
+  val JacksonDatabindVersion = JacksonVersion
   val DockerBaseImageVersion = "adoptopenjdk/openjdk11:debianslim-jre"
   val LogbackVersion = "1.2.11"
   val LogbackContribVersion = "0.1.5"


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2022-42003 (even if we were not really affected out of the box).