### PR TITLE
chore: fix spring-boot-maven-plugin version

### DIFF
--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -227,6 +227,7 @@
       <plugin>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
+       <version>2.7.4</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/spring-customer-registry-views-quickstart/pom.xml
@@ -241,6 +241,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>2.7.4</version>
       </plugin>
 
       <plugin>

--- a/samples/spring-eventsourced-counter/pom.xml
+++ b/samples/spring-eventsourced-counter/pom.xml
@@ -227,6 +227,7 @@
       <plugin>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
+       <version>2.7.4</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-eventsourced-customer-registry/pom.xml
+++ b/samples/spring-eventsourced-customer-registry/pom.xml
@@ -242,6 +242,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>2.7.4</version>
       </plugin>
 
       <plugin>

--- a/samples/spring-fibonacci-action/pom.xml
+++ b/samples/spring-fibonacci-action/pom.xml
@@ -241,6 +241,7 @@
      <plugin>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
+       <version>2.7.4</version>
      </plugin>
 
       <plugin>


### PR DESCRIPTION
This was reported by @aklikic. 

IntelliJ may fail to import project do to missing plugin version.

The plugin documentation page itself doesn't indicate a version. And projects created using start.spring.io have a spring starter as parent pom. The parent pom probably includes a bom file that specifies the version. 

We probably copy it over and it worked most of the time, but it seems that it may fail in some environments.

We do plan to have our own starter project later, so we can also take the same path. For now, better to just fix the version for the plugin to avoid surprises.