### PR TITLE
chore: improve labeling of samples

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,17 +8,20 @@ java-sdk:
   - sdk/java-sdk-testkit/**/*
   - maven-java/**/*
   - codegen/java-gen/**/*
+  - samples/java-*/**/*
 
 scala-sdk:
   - sdk/scala-sdk/**/*
   - sdk/scala-sdk-testkit/**/*
   - sbt-plugin/**/*
   - codegen/scala-gen/**/*
+  - samples/scala-*/**/*
+
 
 spring-sdk:
   - sdk/spring-sdk/**/*
   - sdk/spring-sdk-testkit/**/*
+  - samples/spring-*/**/*
 
 Documentation:
   - docs/**/*
-  - samples/**/*


### PR DESCRIPTION
In hindsight, I don't think #1132 was a good idea because almost everything ends up on that section which kind of defeats the purpose, see [last release](https://github.com/lightbend/kalix-jvm-sdk/releases/tag/v1.0.9) below. So I think a better option is to label each kind of sample under the respective sdk. Doc labels stays for changes in `docs`.


<img width="600" alt="Screenshot 2022-10-18 at 15 30 47" src="https://user-images.githubusercontent.com/1105359/196459675-da98fbc0-f5d1-40f0-a8c8-7c332bde2f13.png">

