### PR TITLE
chore: reverting docker plugin base img bump

### DIFF
--- a/project/DockerImage.scala
+++ b/project/DockerImage.scala
@@ -9,7 +9,7 @@ object DockerImage extends AutoPlugin {
   override def requires = JavaAppPackaging && DockerPlugin && SdkVersion
 
   override def projectSettings = Seq(
-    dockerBaseImage := "adoptopenjdk/openjdk11:jre-11.0.9_10-ubi",
+    dockerBaseImage := "adoptopenjdk/openjdk11:jre-11.0.8_10-ubi",
     dockerUsername := Some("kalix"),
     dockerUpdateLatest := true,
     // disable javadoc/scaladoc for projects published as docker images


### PR DESCRIPTION
This version bump got in with https://github.com/lightbend/kalix-jvm-sdk/pull/1178 [here](https://github.com/lightbend/kalix-jvm-sdk/pull/1178/files#diff-853c9692471808e8bbfa5f1075c005cb2ff22e8b7e6e39d22b4a0bf3df8a74c1) but is causing the 1.0.10 release to [fail](https://app.circleci.com/pipelines/github/lightbend/kalix-jvm-sdk/4429/workflows/8cb3fdba-2b21-4148-a3e9-4454c381f4f7/jobs/68489) with `[error] manifest for adoptopenjdk/openjdk11:jre-11.0.9_10-ubi not found: manifest unknown: manifest unknown`.

So I suppose downgrade is an option, let me know if there's a better one.

Refs https://github.com/lightbend/kalix-jvm-sdk/issues/1186