### PR TITLE
chore: bump sdk version to 1.0.10

### DIFF
--- a/docs/src/modules/java/pages/spring-client.adoc
+++ b/docs/src/modules/java/pages/spring-client.adoc
@@ -153,7 +153,7 @@ Download the resulting ZIP file, which is an archive of a web application that i
 
 ----
   <properties>
-        <kalix-sdk.version>1.0.9</kalix-sdk.version>
+        <kalix-sdk.version>1.0.10</kalix-sdk.version>
         <akka-grpc.version>2.1.4</akka-grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-maven-archetype-event-sourced-entity</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.0.9</version>
+        <version>1.0.10</version>
     </parent>
 
     <name>Kalix Maven Archetype (Event Sourced entity)</name>

--- a/maven-java/kalix-maven-archetype-value-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-maven-archetype</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.0.9</version>
+        <version>1.0.10</version>
     </parent>
 
     <name>Kalix Maven Archetype (Value entity)</name>

--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
 
   <groupId>io.kalix</groupId>
   <artifactId>kalix-maven-plugin</artifactId>
-  <version>1.0.9</version>
+  <version>1.0.10</version>
   <packaging>maven-plugin</packaging>
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-maven-java</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
   </parent>
 
   <name>Kalix Maven Plugin</name>

--- a/maven-java/kalix-spring-boot-archetype/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-spring-boot-archetype</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.0.9</version>
+        <version>1.0.10</version>
     </parent>
 
     <name>Kalix Maven Archetype (Spring SDK)</name>

--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.kalix</groupId>
   <artifactId>kalix-maven-java</artifactId>
-  <version>1.0.9</version>
+  <version>1.0.10</version>
   <packaging>pom</packaging>
 
   <name>Kalix Java Maven parent pom</name>

--- a/samples/java-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-customer-registry-kafka-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-customer-registry-quickstart/pom.xml
+++ b/samples/java-customer-registry-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-customer-registry-views-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-doc-snippets/pom.xml
+++ b/samples/java-doc-snippets/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-eventsourced-counter/pom.xml
+++ b/samples/java-eventsourced-counter/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-eventsourced-customer-registry-subscriber/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-eventsourced-customer-registry/pom.xml
+++ b/samples/java-eventsourced-customer-registry/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
         <jdk.target>11</jdk.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kalix-sdk.version>1.0.9</kalix-sdk.version>
+        <kalix-sdk.version>1.0.10</kalix-sdk.version>
         <akka-grpc.version>2.1.4</akka-grpc.version>
     </properties>
 

--- a/samples/java-fibonacci-action/pom.xml
+++ b/samples/java-fibonacci-action/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-first-service/pom.xml
+++ b/samples/java-first-service/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-reliable-timers/pom.xml
+++ b/samples/java-reliable-timers/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 

--- a/samples/java-replicatedentity-examples/pom.xml
+++ b/samples/java-replicatedentity-examples/pom.xml
@@ -20,7 +20,7 @@
       <jdk.target>11</jdk.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-      <kalix-sdk.version>1.0.9</kalix-sdk.version>
+      <kalix-sdk.version>1.0.10</kalix-sdk.version>
       <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-replicatedentity-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
       <jdk.target>11</jdk.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-      <kalix-sdk.version>1.0.9</kalix-sdk.version>
+      <kalix-sdk.version>1.0.10</kalix-sdk.version>
       <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-shopping-cart-quickstart/pom.xml
+++ b/samples/java-shopping-cart-quickstart/pom.xml
@@ -18,7 +18,7 @@
 
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-valueentity-counter-spring-client/pom.xml
+++ b/samples/java-valueentity-counter-spring-client/pom.xml
@@ -21,7 +21,7 @@
         <java.version>11</java.version>
         <jdk.target>11</jdk.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kalix-sdk.version>1.0.9</kalix-sdk.version>
+        <kalix-sdk.version>1.0.10</kalix-sdk.version>
         <akka-grpc.version>2.1.4</akka-grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>

--- a/samples/java-valueentity-counter/pom.xml
+++ b/samples/java-valueentity-counter/pom.xml
@@ -20,7 +20,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-valueentity-customer-registry/pom.xml
+++ b/samples/java-valueentity-customer-registry/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
       <jdk.target>11</jdk.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-      <kalix-sdk.version>1.0.9</kalix-sdk.version>
+      <kalix-sdk.version>1.0.10</kalix-sdk.version>
       <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/scala-customer-registry-quickstart/project/plugins.sbt
+++ b/samples/scala-customer-registry-quickstart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-doc-snippets/project/plugins.sbt
+++ b/samples/scala-doc-snippets/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-eventsourced-counter/project/plugins.sbt
+++ b/samples/scala-eventsourced-counter/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-eventsourced-customer-registry-subscriber/project/plugins.sbt
+++ b/samples/scala-eventsourced-customer-registry-subscriber/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-eventsourced-customer-registry/project/plugins.sbt
+++ b/samples/scala-eventsourced-customer-registry/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-eventsourced-shopping-cart/project/plugins.sbt
+++ b/samples/scala-eventsourced-shopping-cart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-fibonacci-action/project/plugins.sbt
+++ b/samples/scala-fibonacci-action/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-first-service/project/plugins.sbt
+++ b/samples/scala-first-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-reliable-timers/project/plugins.sbt
+++ b/samples/scala-reliable-timers/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-replicatedentity-examples/project/plugins.sbt
+++ b/samples/scala-replicatedentity-examples/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-replicatedentity-shopping-cart/project/plugins.sbt
+++ b/samples/scala-replicatedentity-shopping-cart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-valueentity-counter/project/plugins.sbt
+++ b/samples/scala-valueentity-counter/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-valueentity-customer-registry/project/plugins.sbt
+++ b/samples/scala-valueentity-customer-registry/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-valueentity-shopping-cart/project/plugins.sbt
+++ b/samples/scala-valueentity-shopping-cart/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.9"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.0.10"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/spring-customer-registry-views-quickstart/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>17</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/spring-eventsourced-counter/pom.xml
+++ b/samples/spring-eventsourced-counter/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>17</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/spring-eventsourced-customer-registry/pom.xml
+++ b/samples/spring-eventsourced-customer-registry/pom.xml
@@ -20,7 +20,7 @@
     <jdk.target>17</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/spring-fibonacci-action/pom.xml
+++ b/samples/spring-fibonacci-action/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>17</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 

--- a/samples/spring-reliable-timers/pom.xml
+++ b/samples/spring-reliable-timers/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>17</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <kalix-sdk.version>1.0.9</kalix-sdk.version>
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
     <akka-grpc.version>2.1.4</akka-grpc.version>
   </properties>
 


### PR DESCRIPTION
References https://github.com/lightbend/kalix-jvm-sdk/issues/1186

I think although the release was half-baked it probably still makes sense to bump the samples, otherwise any spring sample with ACLs or deferred calls does not work properly (if run as is).
