### PR TITLE
feat: support for service and method level ACL

### DIFF
--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Acl.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Acl.java
@@ -18,26 +18,75 @@ package kalix.springsdk.annotations;
 
 import java.lang.annotation.*;
 
+
+/**
+ * Defines ACL configuration for a resource.
+ */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Acl {
 
+  /**
+   * Principals that are allowed to access this resource.
+   * An incoming request must have at least one principal associated with it in this list to be allowed.
+   */
   Matcher[] allow() default {};
 
+
+  /**
+   * After matching an allow rule, an incoming request that has at least one principal
+   * that matches a deny rule will be denied.
+   */
   Matcher[] deny() default {};
 
+
+  /**
+   * The gRPC status code to respond with when access is denied.
+   *
+   * By default, this will be 7 (permission denied), but alternatives might include 16 (unauthenticated) or 5 (not
+   * found). If 0, indicates that the code should be inherited from the parent (regardless of the inherit field).
+   *
+   * When HTTP transcoding is in use, this code will be translated to an equivalent HTTP status code.
+   */
   int denyCode() default 0;
 
+
+  /**
+   * A principal matcher that can be used in an ACL.
+   *
+   * A principal is a very broad concept. It can correlate to a person, a system, or a more abstract concept, such as
+   * the internet.
+   *
+   * A single request may have multiple principals associated with it, for example, it may have come from a particular
+   * source system, and it may have certain credentials associated with it. When a matcher is applied to the request,
+   * the request is considered to match if at least one of the principals attached to the request matches.
+   *
+   * Each Matcher can be configured either with a 'service' or a 'principal', but not both.
+   */
   @Target({ElementType.TYPE, ElementType.METHOD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
   @interface Matcher {
+
+    /**
+     * Match a Kalix service principal.
+     *
+     * This matches a service in the same Kalix project.
+     *
+     * Supports glob matching, that is, * means all services in this project.
+     */
     String service() default "";
 
+    /** A principal matcher that can be specified with no additional configuration. */
     Principal principal() default Principal.UNSPECIFIED;
   }
 
+
+  /**
+   * This enum contains principal matchers that don't have any configuration, such as a name, associated with them,
+   * for ease of reference in annotations.k
+   */
   enum Principal {
     UNSPECIFIED,
     /**

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Acl.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Acl.java
@@ -85,7 +85,7 @@ public @interface Acl {
 
   /**
    * This enum contains principal matchers that don't have any configuration, such as a name, associated with them,
-   * for ease of reference in annotations.k
+   * for ease of reference in annotations.
    */
   enum Principal {
     UNSPECIFIED,

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ActionDescriptorFactory.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ActionDescriptorFactory.scala
@@ -152,11 +152,12 @@ private[impl] object ActionDescriptorFactory extends ComponentDescriptorFactory 
       nameGenerator,
       messageCodec,
       serviceName,
+      serviceOptions = AclDescriptorFactory.serviceLevelAclAnnotation(component),
       component.getPackageName,
-      filterAndAddKalixOptions(springAnnotatedMethods, publicationTopicMethods)
-      ++ subscriptionValueEntityMethods
-      ++ combineByES(component.getName, subscriptionEventSourcedEntityMethods, messageCodec)
-      ++ combineByTopic(subscriptionTopicMethods)
-      ++ removeDuplicates(springAnnotatedMethods, publicationTopicMethods))
+      filterAndAddKalixOptions(springAnnotatedMethods, publicationTopicMethods) ++
+      subscriptionValueEntityMethods ++
+      combineByES(component.getName, subscriptionEventSourcedEntityMethods, messageCodec) ++
+      combineByTopic(subscriptionTopicMethods) ++
+      removeDuplicates(springAnnotatedMethods, publicationTopicMethods))
   }
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ActionDescriptorFactory.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ActionDescriptorFactory.scala
@@ -154,10 +154,10 @@ private[impl] object ActionDescriptorFactory extends ComponentDescriptorFactory 
       serviceName,
       serviceOptions = AclDescriptorFactory.serviceLevelAclAnnotation(component),
       component.getPackageName,
-      filterAndAddKalixOptions(springAnnotatedMethods, publicationTopicMethods) ++
-      subscriptionValueEntityMethods ++
-      combineByES(component.getName, subscriptionEventSourcedEntityMethods, messageCodec) ++
-      combineByTopic(subscriptionTopicMethods) ++
-      removeDuplicates(springAnnotatedMethods, publicationTopicMethods))
+      filterAndAddKalixOptions(springAnnotatedMethods, publicationTopicMethods)
+      ++ subscriptionValueEntityMethods
+      ++ combineByES(component.getName, subscriptionEventSourcedEntityMethods, messageCodec)
+      ++ combineByTopic(subscriptionTopicMethods)
+      ++ removeDuplicates(springAnnotatedMethods, publicationTopicMethods))
   }
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ComponentDescriptorFactory.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ComponentDescriptorFactory.scala
@@ -16,18 +16,20 @@
 
 package kalix.springsdk.impl
 
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
 import kalix.MethodOptions
 import kalix.springsdk.annotations.JWT
 import kalix.springsdk.annotations.Table
-import kalix.springsdk.annotations.{ Entity, Publish, Subscribe }
-import kalix.springsdk.impl.ComponentDescriptorFactory.hasJwtMethodOptions
-import kalix.springsdk.impl.ComponentDescriptorFactory.jwtMethodOptions
+import kalix.springsdk.annotations.Entity
+import kalix.springsdk.annotations.Publish
+import kalix.springsdk.annotations.Subscribe
 import kalix.springsdk.impl.reflection._
-import kalix.{ EventDestination, EventSource, Eventing, JwtMethodOptions }
-import java.lang.reflect.{ Method, Modifier }
-
-import kalix.javasdk.JsonSupport
-import kalix.javasdk.JsonSupport._
+import kalix.EventDestination
+import kalix.EventSource
+import kalix.Eventing
+import kalix.JwtMethodOptions
 
 private[impl] object ComponentDescriptorFactory {
 
@@ -51,7 +53,7 @@ private[impl] object ComponentDescriptorFactory {
     Modifier.isPublic(javaMehod.getModifiers) &&
     javaMehod.getAnnotation(classOf[JWT]) != null
 
-  def findEventSourcedEntityType(javaMethod: Method): String = {
+  private def findEventSourcedEntityType(javaMethod: Method): String = {
     val ann = javaMethod.getAnnotation(classOf[Subscribe.EventSourcedEntity])
     val entityClass = ann.value()
     entityClass.getAnnotation(classOf[Entity]).entityType()
@@ -69,17 +71,17 @@ private[impl] object ComponentDescriptorFactory {
     entityClass.getAnnotation(classOf[Entity]).entityType()
   }
 
-  def findSubTopicName(javaMethod: Method): String = {
+  private def findSubTopicName(javaMethod: Method): String = {
     val ann = javaMethod.getAnnotation(classOf[Subscribe.Topic])
     ann.value()
   }
 
-  def findSubConsumerGroup(javaMethod: Method): String = {
+  private def findSubConsumerGroup(javaMethod: Method): String = {
     val ann = javaMethod.getAnnotation(classOf[Subscribe.Topic])
     ann.consumerGroup()
   }
 
-  def findPubTopicName(javaMethod: Method): String = {
+  private def findPubTopicName(javaMethod: Method): String = {
     val ann = javaMethod.getAnnotation(classOf[Publish.Topic])
     ann.value()
   }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/EntityDescriptorFactory.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/EntityDescriptorFactory.scala
@@ -36,6 +36,12 @@ private[impl] object EntityDescriptorFactory extends ComponentDescriptorFactory 
       }
 
     val serviceName = nameGenerator.getName(component.getSimpleName)
-    ComponentDescriptor(nameGenerator, messageCodec, serviceName, component.getPackageName, kalixMethods)
+    ComponentDescriptor(
+      nameGenerator,
+      messageCodec,
+      serviceName,
+      serviceOptions = AclDescriptorFactory.serviceLevelAclAnnotation(component),
+      component.getPackageName,
+      kalixMethods)
   }
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ViewDescriptorFactory.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ViewDescriptorFactory.scala
@@ -25,18 +25,18 @@ import kalix.springsdk.annotations.Subscribe
 import kalix.springsdk.annotations.Table
 import kalix.springsdk.impl.ComponentDescriptorFactory.buildJWTOptions
 import kalix.springsdk.impl.ComponentDescriptorFactory.combineByES
+import kalix.springsdk.impl.ComponentDescriptorFactory.eventingInForEventSourcedEntity
 import kalix.springsdk.impl.ComponentDescriptorFactory.eventingInForValueEntity
 import kalix.springsdk.impl.ComponentDescriptorFactory.findValueEntityType
+import kalix.springsdk.impl.ComponentDescriptorFactory.hasEventSourcedEntitySubscription
 import kalix.springsdk.impl.ComponentDescriptorFactory.hasValueEntitySubscription
 import kalix.springsdk.impl.reflection.KalixMethod
 import kalix.springsdk.impl.reflection.NameGenerator
-import kalix.springsdk.impl.reflection.RestServiceIntrospector
-import kalix.springsdk.impl.reflection.SyntheticRequestServiceMethod
 import kalix.springsdk.impl.reflection.ReflectionUtils
+import kalix.springsdk.impl.reflection.RestServiceIntrospector
 import kalix.springsdk.impl.reflection.RestServiceIntrospector.BodyParameter
-import kalix.springsdk.impl.ComponentDescriptorFactory.eventingInForEventSourcedEntity
-import kalix.springsdk.impl.ComponentDescriptorFactory.hasEventSourcedEntitySubscription
 import kalix.springsdk.impl.reflection.SubscriptionServiceMethod
+import kalix.springsdk.impl.reflection.SyntheticRequestServiceMethod
 import kalix.springsdk.impl.reflection.VirtualServiceMethod
 import reactor.core.publisher.Flux
 
@@ -167,6 +167,7 @@ private[impl] object ViewDescriptorFactory extends ComponentDescriptorFactory {
       nameGenerator,
       messageCodec,
       serviceName,
+      serviceOptions = AclDescriptorFactory.serviceLevelAclAnnotation(component),
       component.getPackageName,
       kalixMethods,
       additionalMessages.toSeq)

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/RestServiceIntrospector.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/RestServiceIntrospector.scala
@@ -16,13 +16,16 @@
 
 package kalix.springsdk.impl.reflection
 
-import org.springframework.core.{ DefaultParameterNameDiscoverer, MethodParameter }
-import org.springframework.core.annotation.{ AnnotatedElementUtils, SynthesizingMethodParameter }
-import org.springframework.web.bind.annotation._
-
 import java.lang.annotation.Annotation
 import java.lang.reflect.AnnotatedElement
+
 import scala.reflect.ClassTag
+
+import org.springframework.core.DefaultParameterNameDiscoverer
+import org.springframework.core.MethodParameter
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.core.annotation.SynthesizingMethodParameter
+import org.springframework.web.bind.annotation._
 
 object RestServiceIntrospector {
 
@@ -115,33 +118,33 @@ object RestServiceIntrospector {
 
   private[kalix] def validateRequestMapping(element: AnnotatedElement, mapping: RequestMapping): Unit = {
     if (!isEmpty(mapping.consumes())) {
-      throw new ServiceIntrospectionException(
+      throw ServiceIntrospectionException(
         element,
         "Unsupported RequestMapping attribute: consumes. Kalix Spring SDK does not support mapping requests by consumes, all methods are assumed to handle JSON and only JSON.")
     }
     if (!isEmpty(mapping.produces())) {
-      throw new ServiceIntrospectionException(
+      throw ServiceIntrospectionException(
         element,
         "Unsupported RequestMapping attribute: produces. Kalix Spring SDK does not support mapping requests by what it produces, all methods are assumed to produce JSON and only JSON.")
     }
     if (!isEmpty(mapping.headers())) {
-      throw new ServiceIntrospectionException(
+      throw ServiceIntrospectionException(
         element,
         "Unsupported RequestMapping attribute: headers. Kalix Spring SDK does not support mapping requests by headers.")
     }
     if (!isEmpty(mapping.params())) {
-      throw new ServiceIntrospectionException(
+      throw ServiceIntrospectionException(
         element,
         "Unsupported RequestMapping attribute: params. Kalix Spring SDK does not support mapping requests by request parameters.")
     }
     // This could be relaxed, since gRPC transcoding does have an additionalBindings field.
     if (!isEmpty(mapping.path()) && mapping.path().length > 1) {
-      throw new ServiceIntrospectionException(
+      throw ServiceIntrospectionException(
         element,
         "Invalid multiple path mapping. Kalix Spring SDK only supports mapping methods to one HTTP request path.")
     }
     if (!isEmpty(mapping.method()) && mapping.method().length > 1) {
-      throw new ServiceIntrospectionException(
+      throw ServiceIntrospectionException(
         element,
         "Invalid multiple request method mapping. Kalix Spring SDK only supports mapping methods to one HTTP request method.")
     }
@@ -150,5 +153,3 @@ object RestServiceIntrospector {
   private[kalix] def isEmpty[T](array: Array[T]): Boolean = array == null || array.isEmpty
 
 }
-
-class ServiceIntrospectionException(element: AnnotatedElement, msg: String) extends RuntimeException(msg)

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/ServiceIntrospectionException.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/reflection/ServiceIntrospectionException.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.impl.reflection
+
+import java.lang.reflect.AnnotatedElement
+import java.lang.reflect.Method
+
+object ServiceIntrospectionException {
+  def apply(element: AnnotatedElement, msg: String): ServiceIntrospectionException = {
+    val elementStr =
+      element match {
+        case clz: Class[_] => clz.getName
+        case meth: Method  => s"${meth.getDeclaringClass.getName}#${meth.getName}"
+        case any           => any.toString
+      }
+
+    new ServiceIntrospectionException(s"On $elementStr: $msg")
+  }
+
+}
+
+class ServiceIntrospectionException private (msg: String) extends RuntimeException(msg)

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
@@ -16,13 +16,11 @@
 
 package kalix.springsdk.testmodels.eventsourcedentity;
 
-import kalix.JwtMethodOptions;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
+import kalix.springsdk.annotations.Acl;
 import kalix.springsdk.annotations.Entity;
 import kalix.springsdk.annotations.EventHandler;
 import kalix.springsdk.annotations.JWT;
-import kalix.springsdk.annotations.Subscribe;
-import kalix.springsdk.testmodels.valueentity.UserEntity;
 import org.springframework.web.bind.annotation.*;
 
 public class EventSourcedEntitiesTestModels {
@@ -131,6 +129,25 @@ public class EventSourcedEntitiesTestModels {
     @EventHandler
     public Integer receivedIntegerEventAndString(Integer event, String s1) {
       return 0;
+    }
+  }
+
+  @Entity(entityKey = "id", entityType = "counter")
+  @Acl(allow = @Acl.Matcher(service = "test"))
+  public static class EventSourcedEntityWithServiceLevelAcl extends EventSourcedEntity<Integer> {
+
+  }
+
+
+  @Entity(entityKey = "id", entityType = "counter")
+  @RequestMapping("/employee/{id}")
+  public static class EventSourcedEntityWithMethodLevelAcl extends EventSourcedEntity<Integer> {
+    @PostMapping
+    @Acl(allow = @Acl.Matcher(service = "test"))
+    public Effect<String> createUser(@RequestBody CreateEmployee create) {
+      return effects()
+          .emitEvent(new EmployeeCreated(create.firstName, create.lastName, create.email))
+          .thenReply(__ -> "ok");
     }
   }
 }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/subscriptions/PubSubTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/subscriptions/PubSubTestModels.java
@@ -17,15 +17,16 @@
 package kalix.springsdk.testmodels.subscriptions;
 
 import kalix.javasdk.action.Action;
-import kalix.springsdk.annotations.Subscribe;
+import kalix.springsdk.annotations.Acl;
 import kalix.springsdk.annotations.Publish;
+import kalix.springsdk.annotations.Subscribe;
 import kalix.springsdk.testmodels.Message;
 import kalix.springsdk.testmodels.Message2;
-import kalix.springsdk.testmodels.valueentity.Counter;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.WellAnnotatedESEntity;
+import kalix.springsdk.testmodels.valueentity.Counter;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 public class PubSubTestModels {
 
@@ -105,6 +106,28 @@ public class PubSubTestModels {
     // this should fail as not allowed
     @Subscribe.ValueEntity(Counter.class)
     @PostMapping("/message/one")
+    public Action.Effect<Message> messageOne(@RequestBody Message message) {
+      return effects().reply(message);
+    }
+  }
+
+
+  @Acl(allow = @Acl.Matcher(service = "test"))
+  public static class ActionWithServiceLevelAcl extends Action {
+  }
+
+
+  public static class ActionWithMethodLevelAcl extends Action {
+    @Acl(allow = @Acl.Matcher(service = "test"))
+    @PostMapping("/message/one")
+    public Action.Effect<Message> messageOne(@RequestBody Message message) {
+      return effects().reply(message);
+    }
+  }
+
+  public static class ActionWithMethodLevelAclAndSubscription extends Action {
+    @Acl(allow = @Acl.Matcher(service = "test"))
+    @Subscribe.ValueEntity(Counter.class)
     public Action.Effect<Message> messageOne(@RequestBody Message message) {
       return effects().reply(message);
     }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/valueentity/ValueEntitiesTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/valueentity/ValueEntitiesTestModels.java
@@ -17,6 +17,7 @@
 package kalix.springsdk.testmodels.valueentity;
 
 import kalix.javasdk.valueentity.ValueEntity;
+import kalix.springsdk.annotations.Acl;
 import kalix.springsdk.annotations.Entity;
 import kalix.springsdk.testmodels.Done;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,6 +37,24 @@ public class ValueEntitiesTestModels {
     }
 
     @PostMapping("/create")
+    public ValueEntity.Effect<Done> createEntity(@RequestBody CreateUser createUser) {
+      return effects().reply(Done.instance);
+    }
+  }
+
+  @Entity(
+      entityKey = {"userId", "cartId"},
+      entityType = "user")
+  @Acl(allow = @Acl.Matcher(service = "test"))
+  public static class ValueEntityWithServiceLevelAcl extends ValueEntity<User> {
+  }
+
+  @Entity(
+      entityKey = {"userId", "cartId"},
+      entityType = "user")
+  public static class ValueEntityWithMethodLevelAcl extends ValueEntity<User> {
+    @PostMapping("/create")
+    @Acl(allow = @Acl.Matcher(service = "test"))
     public ValueEntity.Effect<Done> createEntity(@RequestBody CreateUser createUser) {
       return effects().reply(Done.instance);
     }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/view/ViewTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/view/ViewTestModels.java
@@ -17,21 +17,17 @@
 package kalix.springsdk.testmodels.view;
 
 import kalix.javasdk.view.View;
-import kalix.springsdk.annotations.JWT;
-import kalix.springsdk.annotations.Query;
-import kalix.springsdk.annotations.Subscribe;
-import kalix.springsdk.annotations.Table;
+import kalix.springsdk.annotations.*;
 import kalix.springsdk.testmodels.eventsourcedentity.Employee;
-import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels;
 import kalix.springsdk.testmodels.eventsourcedentity.EmployeeCreated;
 import kalix.springsdk.testmodels.eventsourcedentity.EmployeeEvent;
+import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels;
 import kalix.springsdk.testmodels.valueentity.User;
 import kalix.springsdk.testmodels.valueentity.UserEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-
 import reactor.core.publisher.Flux;
 
 public class ViewTestModels {
@@ -227,6 +223,27 @@ public class ViewTestModels {
 
     @Query("SELECT * FROM employees_view WHERE email = :email")
     @PostMapping("/employees/by-email/{email}")
+    public Employee getEmployeeByEmail(@PathVariable String email) {
+      return null;
+    }
+  }
+
+
+  @Table(value = "employees_view")
+  @Acl(allow = @Acl.Matcher(service = "test"))
+  public static class ViewWithServiceLevelAcl extends View<Employee> {
+    @Query("SELECT * FROM employees_view WHERE email = :email")
+    @PostMapping("/employees/by-email/{email}")
+    public Employee getEmployeeByEmail(@PathVariable String email) {
+      return null;
+    }
+  }
+
+  @Table(value = "employees_view")
+  public static class ViewWithMethodLevelAcl extends View<Employee> {
+    @Query("SELECT * FROM employees_view WHERE email = :email")
+    @PostMapping("/employees/by-email/{email}")
+    @Acl(allow = @Acl.Matcher(service = "test"))
     public Employee getEmployeeByEmail(@PathVariable String email) {
       return null;
     }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/AclDescriptorFactorySpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/AclDescriptorFactorySpec.scala
@@ -18,6 +18,7 @@ package kalix.springsdk.impl
 
 import scala.reflect.ClassTag
 
+import kalix.FileOptions
 import kalix.PrincipalMatcher
 import kalix.springsdk.testmodels.AclTestModels.MainAllowAllServices
 import kalix.springsdk.testmodels.AclTestModels.MainAllowListOfServices
@@ -36,35 +37,34 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class AclDescriptorFactorySpec extends AnyWordSpec with Matchers {
 
-  def lookupExtention[T: ClassTag] =
+  def lookupExtension[T: ClassTag]: Option[FileOptions] =
     AclDescriptorFactory
       .defaultAclFileDescriptor(implicitly[ClassTag[T]].runtimeClass)
       .map { aclFileDesc =>
-
         aclFileDesc.getOptions.getExtension(kalix.Annotations.file)
       }
 
-  "The DefaultAclDescriptorFactory" should {
+  "AclDescriptorFactory.defaultAclFileDescriptor" should {
 
     "generate an empty descriptor if no ACL annotation is found" in {
-      val extension = lookupExtention[MainWithoutAnnotation]
+      val extension = lookupExtension[MainWithoutAnnotation]
       extension shouldBe empty
     }
 
     "generate a default ACL file descriptor with deny code" in {
-      val extension = lookupExtention[MainDenyWithCode].get
+      val extension = lookupExtension[MainDenyWithCode].get
       val denyCode = extension.getAcl.getDenyCode
       denyCode shouldBe 7
     }
 
     "generate a default ACL file descriptor with allow all services" in {
-      val extension = lookupExtention[MainAllowAllServices].get
+      val extension = lookupExtension[MainAllowAllServices].get
       val service = extension.getAcl.getAllow(0).getService
       service shouldBe "*"
     }
 
     "generate a default ACL file descriptor with allow two services" in {
-      val extension = lookupExtention[MainAllowListOfServices].get
+      val extension = lookupExtension[MainAllowListOfServices].get
       val service1 = extension.getAcl.getAllow(0).getService
       service1 shouldBe "foo"
 
@@ -73,31 +73,31 @@ class AclDescriptorFactorySpec extends AnyWordSpec with Matchers {
     }
 
     "generate a default ACL file descriptor with allow Principal INTERNET" in {
-      val extension = lookupExtention[MainAllowPrincipalInternet].get
+      val extension = lookupExtension[MainAllowPrincipalInternet].get
       val principal = extension.getAcl.getAllow(0).getPrincipal
       principal shouldBe PrincipalMatcher.Principal.INTERNET
     }
 
     "generate a default ACL file descriptor with allow Principal ALL" in {
-      val extension = lookupExtention[MainAllowPrincipalAll].get
+      val extension = lookupExtension[MainAllowPrincipalAll].get
       val principal = extension.getAcl.getAllow(0).getPrincipal
       principal shouldBe PrincipalMatcher.Principal.ALL
     }
 
     "fail if both Principal and Service are defined" in {
       intercept[IllegalArgumentException] {
-        lookupExtention[MainWithInvalidAllowAnnotation]
+        lookupExtension[MainWithInvalidAllowAnnotation]
       }.getMessage shouldBe AclDescriptorFactory.invalidAnnotationUsage
     }
 
     "generate a default ACL file descriptor with deny all services" in {
-      val extension = lookupExtention[MainDenyAllServices].get
+      val extension = lookupExtension[MainDenyAllServices].get
       val service = extension.getAcl.getDeny(0).getService
       service shouldBe "*"
     }
 
     "generate a default ACL file descriptor with deny two services" in {
-      val extension = lookupExtention[MainDenyListOfServices].get
+      val extension = lookupExtension[MainDenyListOfServices].get
       val service1 = extension.getAcl.getDeny(0).getService
       service1 shouldBe "foo"
 
@@ -106,20 +106,20 @@ class AclDescriptorFactorySpec extends AnyWordSpec with Matchers {
     }
 
     "generate a default ACL file descriptor with deny Principal INTERNET" in {
-      val extension = lookupExtention[MainDenyPrincipalInternet].get
+      val extension = lookupExtension[MainDenyPrincipalInternet].get
       val principal = extension.getAcl.getDeny(0).getPrincipal
       principal shouldBe PrincipalMatcher.Principal.INTERNET
     }
 
     "generate a default ACL file descriptor with deny Principal ALL" in {
-      val extension = lookupExtention[MainDenyPrincipalAll].get
+      val extension = lookupExtension[MainDenyPrincipalAll].get
       val principal = extension.getAcl.getDeny(0).getPrincipal
       principal shouldBe PrincipalMatcher.Principal.ALL
     }
 
     "fail if both Principal and Service are defined in 'deny' field" in {
       intercept[IllegalArgumentException] {
-        lookupExtention[MainWithInvalidDenyAnnotation]
+        lookupExtension[MainWithInvalidDenyAnnotation]
       }.getMessage shouldBe AclDescriptorFactory.invalidAnnotationUsage
     }
   }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ComponentDescriptorSuite.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ComponentDescriptorSuite.scala
@@ -16,12 +16,14 @@
 
 package kalix.springsdk.impl
 
-import com.google.api.{ AnnotationsProto, HttpRule }
-
 import scala.reflect.ClassTag
+
+import com.google.api.AnnotationsProto
+import com.google.api.HttpRule
 import com.google.protobuf.Descriptors
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import kalix.MethodOptions
+import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 
 trait ComponentDescriptorSuite extends Matchers {
@@ -29,24 +31,27 @@ trait ComponentDescriptorSuite extends Matchers {
   def descriptorFor[T](implicit ev: ClassTag[T]): ComponentDescriptor =
     ComponentDescriptor.descriptorFor(ev.runtimeClass, new SpringSdkMessageCodec)
 
-  def assertDescriptor[E](assertFunc: ComponentDescriptor => Unit)(implicit ev: ClassTag[E]) = {
+  def assertDescriptor[E](assertFunc: ComponentDescriptor => Unit)(implicit ev: ClassTag[E]): Unit = {
     val descriptor = descriptorFor[E]
     withClue(ProtoDescriptorRenderer.toString(descriptor.fileDescriptor)) {
       assertFunc(descriptor)
     }
   }
 
-  def assertRequestFieldJavaType(method: CommandHandler, fieldName: String, expectedType: JavaType) = {
+  def assertRequestFieldJavaType(method: CommandHandler, fieldName: String, expectedType: JavaType): Assertion = {
     val field = findField(method, fieldName)
     field.getJavaType shouldBe expectedType
   }
 
-  def assertRequestFieldMessageType(method: CommandHandler, fieldName: String, expectedMessageType: String) = {
+  def assertRequestFieldMessageType(
+      method: CommandHandler,
+      fieldName: String,
+      expectedMessageType: String): Assertion = {
     val field = findField(method, fieldName)
     field.getMessageType.getFullName shouldBe expectedMessageType
   }
 
-  def assertEntityKeyField(method: CommandHandler, fieldName: String) = {
+  def assertEntityKeyField(method: CommandHandler, fieldName: String): Assertion = {
     val field = findField(method, fieldName)
     val fieldOption = field.toProto.getOptions.getExtension(kalix.Annotations.field)
     fieldOption.getEntityKey shouldBe true
@@ -69,4 +74,6 @@ trait ComponentDescriptorSuite extends Matchers {
     if (field == null) throw new NoSuchElementException(s"no field found for $fieldName")
     field
   }
+
+//  def findAclExtension
 }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/EventSourcedEntityDescriptorFactorySpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/EventSourcedEntityDescriptorFactorySpec.scala
@@ -18,6 +18,8 @@ package kalix.springsdk.impl
 
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import kalix.JwtMethodOptions.JwtMethodMode
+import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EventSourcedEntityWithMethodLevelAcl
+import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EventSourcedEntityWithServiceLevelAcl
 import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.WellAnnotatedESEntity
 import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.WellAnnotatedESEntityWithJWT
 import org.scalatest.wordspec.AnyWordSpec
@@ -62,6 +64,22 @@ class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with Component
         jwtOption2.getBearerTokenIssuer(1) shouldBe "b"
         jwtOption2.getValidate(0) shouldBe JwtMethodMode.BEARER_TOKEN
         jwtOption2.getSign(0) shouldBe JwtMethodMode.MESSAGE
+      }
+    }
+
+    "generate ACL annotations at service level" in {
+      assertDescriptor[EventSourcedEntityWithServiceLevelAcl] { desc =>
+        val extension = desc.serviceDescriptor.getOptions.getExtension(kalix.Annotations.service)
+        val service = extension.getAcl.getAllow(0).getService
+        service shouldBe "test"
+      }
+    }
+
+    "generate ACL annotations at method level" in {
+      assertDescriptor[EventSourcedEntityWithMethodLevelAcl] { desc =>
+        val extension = findKalixMethodOptions(desc, "CreateUser")
+        val service = extension.getAcl.getAllow(0).getService
+        service shouldBe "test"
       }
     }
   }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ValueEntityDescriptorFactorySpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ValueEntityDescriptorFactorySpec.scala
@@ -19,6 +19,8 @@ package kalix.springsdk.impl
 import com.google.protobuf.Any
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import kalix.springsdk.testmodels.valueentity.ValueEntitiesTestModels.PostWithEntityKeys
+import kalix.springsdk.testmodels.valueentity.ValueEntitiesTestModels.ValueEntityWithMethodLevelAcl
+import kalix.springsdk.testmodels.valueentity.ValueEntitiesTestModels.ValueEntityWithServiceLevelAcl
 import org.scalatest.wordspec.AnyWordSpec
 
 class ValueEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuite {
@@ -35,6 +37,22 @@ class ValueEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDescrip
 
         assertRequestFieldJavaType(method, "cartId", JavaType.STRING)
         assertEntityKeyField(method, "cartId")
+      }
+    }
+
+    "generate ACL annotations at service level" in {
+      assertDescriptor[ValueEntityWithServiceLevelAcl] { desc =>
+        val extension = desc.serviceDescriptor.getOptions.getExtension(kalix.Annotations.service)
+        val service = extension.getAcl.getAllow(0).getService
+        service shouldBe "test"
+      }
+    }
+
+    "generate ACL annotations at method level" in {
+      assertDescriptor[ValueEntityWithMethodLevelAcl] { desc =>
+        val extension = findKalixMethodOptions(desc, "CreateEntity")
+        val service = extension.getAcl.getAllow(0).getService
+        service shouldBe "test"
       }
     }
   }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ViewDescriptorFactorySpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ViewDescriptorFactorySpec.scala
@@ -28,12 +28,31 @@ import kalix.springsdk.testmodels.view.ViewTestModels.UserByEmailWithPost
 import kalix.springsdk.testmodels.view.ViewTestModels.UserByEmailWithPostRequestBodyOnly
 import kalix.springsdk.testmodels.view.ViewTestModels.UserByNameEmailWithPost
 import kalix.springsdk.testmodels.view.ViewTestModels.UserByNameStreamed
+import kalix.springsdk.testmodels.view.ViewTestModels.ViewWithMethodLevelAcl
 import kalix.springsdk.testmodels.view.ViewTestModels.ViewWithNoQuery
+import kalix.springsdk.testmodels.view.ViewTestModels.ViewWithServiceLevelAcl
 import kalix.springsdk.testmodels.view.ViewTestModels.ViewWithSubscriptionsInMixedLevels
 import kalix.springsdk.testmodels.view.ViewTestModels.ViewWithTwoQueries
 import org.scalatest.wordspec.AnyWordSpec
 
 class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuite {
+
+  "View descriptor factory" should {
+    "generate ACL annotations at service level" in {
+      assertDescriptor[ViewWithServiceLevelAcl] { desc =>
+        val extension = desc.serviceDescriptor.getOptions.getExtension(kalix.Annotations.service)
+        val service = extension.getAcl.getAllow(0).getService
+        service shouldBe "test"
+      }
+    }
+    "generate ACL annotations at method level" in {
+      assertDescriptor[ViewWithMethodLevelAcl] { desc =>
+        val extension = findKalixMethodOptions(desc, "GetEmployeeByEmail")
+        val service = extension.getAcl.getAllow(0).getService
+        service shouldBe "test"
+      }
+    }
+  }
 
   "View descriptor factory (for Value Entity)" should {
 
@@ -329,4 +348,5 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
       }
     }
   }
+
 }


### PR DESCRIPTION
Adds support for ACL annotations on type level (service) and method level.

Also block the mix of `@Acl` annotations with `@Subscription`

Resolves https://github.com/lightbend/kalix/issues/7368