### PR TITLE
chore: adding spring event-sourced shopping cart sample

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1148,6 +1148,23 @@ jobs:
             echo "Running mvn with SDK version: '$SDK_VERSION'"
             mvn -Dkalix-sdk.version=$SDK_VERSION verify -Pit
 
+  sample-spring-eventsourced-shopping-cart:
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout-and-merge-to-main
+      - setup_sbt
+      - restore_deps_cache
+      # note: `copy-from-workspace` requires `publish-local` to be run first as declared in workflow section below
+      - copy-from-workspace
+      - set-sdk-version
+      - run:
+          name: Spring SDK Reliable Timers
+          command: |
+            cd samples/spring-eventsourced-shopping-cart
+            echo "Running mvn with SDK version: '$SDK_VERSION'"
+            mvn -Dkalix-sdk.version=$SDK_VERSION verify -Pit
+
   publish:
     docker:
       - image: circleci/openjdk:11
@@ -1431,6 +1448,10 @@ workflows:
             - spring-sdk-integration-tests
             - publish-local
       - sample-spring-reliable-timers:
+          requires:
+            - spring-sdk-integration-tests
+            - publish-local
+      - sample-spring-eventsourced-shopping-cart:
           requires:
             - spring-sdk-integration-tests
             - publish-local

--- a/samples/spring-eventsourced-shopping-cart/README.md
+++ b/samples/spring-eventsourced-shopping-cart/README.md
@@ -1,0 +1,63 @@
+# spring-eventsourced-shoppingcart
+
+To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/services/development-process.html) in the documentation.
+
+This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/). Spring-SDK is an experimental feature and so far there is no [official](https://docs.kalix.io/) documentation. Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
+
+Use Maven to build your project:
+
+```shell
+mvn compile
+```
+
+To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
+It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
+To start the proxy, run the following command from this directory:
+
+```shell
+docker-compose up
+```
+
+To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+
+```shell
+mvn spring-boot:run
+```
+
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`. 
+
+## Exercise the service
+
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
+
+- Add items to shopping cart
+```shell
+curl -i -XPOST -H "Content-Type: application/json" localhost:9000/cart/123/add -d '{"productId":"akka-tshirt", "name":"Akka Tshirt", "quantity": 10}'
+curl -i -XPOST -H "Content-Type: application/json" localhost:9000/cart/123/add -d '{"productId":"scala-tshirt", "name":"Scala Tshirt", "quantity": 20}'
+```
+
+- See current status of the shopping cart 
+```shell
+curl -i -XGET -H "Content-Type: application/json" localhost:9000/cart/123
+```
+
+- Remove an item from the cart
+```shell
+curl -XPOST -H "Content-Type: application/json" localhost:9000/cart/123/items/akka-tshirt/remove
+```
+
+## Deploying
+
+To deploy your service, install the `kalix` CLI as documented in
+[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+and configure a Docker Registry to upload your docker image to.
+
+You will need to update the `dockerImage` property in the `pom.xml` and refer to
+[Configuring registries](https://docs.kalix.io/projects/container-registries.html)
+for more information on how to make your docker image available to Kalix.
+
+Finally, you can use the [Kalix Console](https://console.kalix.io)
+to create a project and then deploy your service into the project either by using `mvn deploy` which
+will also conveniently package and publish your docker image prior to deployment, or by first packaging and
+publishing the docker image through `mvn clean package docker:push -DskipTests` and then deploying the image
+through the `kalix` CLI.

--- a/samples/spring-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/spring-eventsourced-shopping-cart/docker-compose.yml
@@ -1,0 +1,19 @@
+
+version: "3"
+services:
+  kalix-proxy:
+    image: gcr.io/kalix-public/kalix-proxy:1.0.22
+    command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
+    ports:
+      - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
+      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
+  gcloud-pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
+    command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085
+    ports:
+      - 8085:8085

--- a/samples/spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/spring-eventsourced-shopping-cart/pom.xml
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>spring-eventsourced-shopping-cart</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>spring-eventsourced-shopping-cart</name>
+  <properties>
+
+    <!-- TODO Update to your own Docker repository or Docker Hub scope -->
+    <dockerImage>gcr.io/kalix-public/${project.artifactId}</dockerImage>
+    <dockerTag>${project.version}-${build.timestamp}</dockerTag>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+    <mainClass>com.example.shoppingcart.Main</mainClass>
+
+    <jdk.target>17</jdk.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <kalix-sdk.version>1.0.10</kalix-sdk.version>
+    <akka-grpc.version>2.1.4</akka-grpc.version>
+  </properties>
+
+  <build>
+    <resources>
+      <!-- Add the generated protobuf descriptor to the classpath, so that source mapping works -->
+      <resource>
+        <directory>${project.build.directory}/generated-resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.7.0</version>
+      </extension>
+    </extensions>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>${jdk.target}</source>
+          <target>${jdk.target}</target>
+          <compilerArgs>
+            <arg>-Xlint:deprecation</arg>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>reference.conf</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>${mainClass}</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.39.1</version>
+        <configuration>
+          <images>
+            <image>
+              <name>${dockerImage}:%l</name>
+              <build>
+                <!-- Base Docker image which contains jre-->
+                <from>docker.io/library/eclipse-temurin:${D}{jdk.target}-alpine</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
+                <tags>
+                  <!-- tag for generated image -->
+                  <tag>${dockerTag}</tag>
+                </tags>
+                <ports>
+                  <!-- expose port in Docker container -->
+                  <port>8080</port>
+                </ports>
+                <assembly>
+                  <!-- NOTE: (optional) switch to "artifact-with-dependencies" to show dependencies library-->
+                  <descriptorRef>artifact</descriptorRef>
+                </assembly>
+                <entryPoint>
+                  <arg>java</arg>
+                  <arg>-jar</arg>
+                  <arg>/maven/${project.build.finalName}.jar</arg>
+                </entryPoint>
+              </build>
+            </image>
+          </images>
+        </configuration>
+        <executions>
+          <execution>
+            <id>build-docker-image</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>push-docker-image</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>push</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <!-- configure src/it/java and src/it/resources -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>add-integration-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/it/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-integration-test-resource</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>src/it/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+        <configuration>
+          <excludes>
+            <!-- ignore integration test classes -->
+            <exclude>**/*IntegrationTest</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>io.kalix</groupId>
+        <artifactId>kalix-maven-plugin</artifactId>
+        <version>${kalix-sdk.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+              <goal>deploy</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
+          <mainClass>${mainClass}</mainClass>
+          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+       <groupId>org.springframework.boot</groupId>
+       <artifactId>spring-boot-maven-plugin</artifactId>
+       <version>2.7.4</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <!-- run Integration Tests in src/it/java with `mvn verify -Pit`-->
+      <id>it</id>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- run *IntegrationTest with failsafe -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>2.22.2</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/*IntegrationTest</include>
+                  </includes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.kalix</groupId>
+      <artifactId>kalix-spring-sdk</artifactId>
+      <version>${kalix-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kalix</groupId>
+      <artifactId>kalix-spring-sdk-testkit</artifactId>
+      <version>${kalix-sdk.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>2.7.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.5.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.5.2</version>
+      <scope>test</scope>
+    </dependency>
+    
+  </dependencies>
+</project>

--- a/samples/spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/spring-eventsourced-shopping-cart/pom.xml
@@ -209,7 +209,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>generate</goal>
               <goal>deploy</goal>
             </goals>
           </execution>

--- a/samples/spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/spring-eventsourced-shopping-cart/pom.xml
@@ -11,7 +11,7 @@
   <properties>
 
     <!-- TODO Update to your own Docker repository or Docker Hub scope -->
-    <dockerImage>gcr.io/kalix-public/${project.artifactId}</dockerImage>
+    <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
     <dockerTag>${project.version}-${build.timestamp}</dockerTag>
     <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <mainClass>com.example.shoppingcart.Main</mainClass>
@@ -91,7 +91,7 @@
               <name>${dockerImage}:%l</name>
               <build>
                 <!-- Base Docker image which contains jre-->
-                <from>docker.io/library/eclipse-temurin:${D}{jdk.target}-alpine</from>
+                <from>docker.io/library/eclipse-temurin:${jdk.target}-alpine</from>
                 <createImageOptions>
                   <platform>linux/amd64</platform>
                 </createImageOptions>

--- a/samples/spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/spring-eventsourced-shopping-cart/pom.xml
@@ -25,10 +25,6 @@
 
   <build>
     <resources>
-      <!-- Add the generated protobuf descriptor to the classpath, so that source mapping works -->
-      <resource>
-        <directory>${project.build.directory}/generated-resources</directory>
-      </resource>
       <resource>
         <directory>src/main/resources</directory>
       </resource>

--- a/samples/spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
+++ b/samples/spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
@@ -1,8 +1,8 @@
 package com.example;
 
 import com.example.shoppingcart.Main;
-import com.example.shoppingcart.domain.LineItem;
 import com.example.shoppingcart.domain.ShoppingCart;
+import com.example.shoppingcart.domain.ShoppingCart.LineItem;
 import kalix.springsdk.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;

--- a/samples/spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
+++ b/samples/spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
@@ -1,0 +1,101 @@
+package com.example;
+
+import com.example.shoppingcart.Main;
+import com.example.shoppingcart.domain.LineItem;
+import com.example.shoppingcart.domain.ShoppingCart;
+import kalix.springsdk.testkit.KalixIntegrationTestKitSupport;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+
+/**
+ * This is a skeleton for implmenting integration tests for a Kalix application built with the Spring SDK.
+ *
+ * This test will initiate a Kalix Proxy using testcontainers and therefore it's required to have Docker installed
+ * on your machine. This test will also start your Spring Boot application.
+ *
+ * Since this is an integration tests, it interacts with the application using a WebClient
+ * (already configured and provided automatically through injection).
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Main.class)
+public class IntegrationTest extends KalixIntegrationTestKitSupport {
+
+  @Autowired
+  private WebClient webClient;
+
+  @Test
+  public void test() throws Exception {
+    // implement your integration tests here by calling your
+    // REST endpoints using the provided WebClient
+  }
+
+  private Duration timeout = Duration.of(5, SECONDS);
+
+  @Test
+  public void createAndManageCart() {
+    String cartId = "my-cart";
+    var item1 = new LineItem("tv", "Super TV 55'", 1);
+
+    ResponseEntity<String> itemOne =
+        webClient.post()
+            .uri("/cart/" + cartId + "/add")
+            .bodyValue(item1)
+            .retrieve()
+            .toEntity(String.class)
+            .block(timeout);
+
+    Assertions.assertEquals(HttpStatus.OK, itemOne.getStatusCode());
+
+    var item2 = new LineItem("tv-table", "Table for TV", 1);
+    ResponseEntity<String> itemTwo =
+        webClient.post()
+            .uri("/cart/" + cartId + "/add")
+            .bodyValue(item2)
+            .retrieve()
+            .toEntity(String.class)
+            .block(timeout);
+
+    Assertions.assertEquals(HttpStatus.OK, itemTwo.getStatusCode());
+
+    ShoppingCart cartInfo =
+        webClient.get()
+            .uri("/cart/" + cartId)
+            .retrieve()
+            .bodyToMono(ShoppingCart.class)
+            .block(timeout);
+    Assertions.assertEquals(2, cartInfo.items().size());
+
+
+    // removing one of the items
+    ResponseEntity<String> removingItemOne =
+        webClient.post()
+            .uri("/cart/" + cartId + "/items/" + item1.productId() + "/remove")
+            .retrieve()
+            .toEntity(String.class)
+            .block(timeout);
+
+    // confirming only one product remains
+    ShoppingCart cartUpdated =
+        webClient.get()
+            .uri("/cart/" + cartId)
+            .retrieve()
+            .bodyToMono(ShoppingCart.class)
+            .block(timeout);
+    Assertions.assertEquals(1, cartUpdated.items().size());
+    Assertions.assertEquals(item2, cartUpdated.items().get(0));
+  }
+}

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/Main.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/Main.java
@@ -1,0 +1,26 @@
+package com.example.shoppingcart;
+
+import kalix.springsdk.annotations.Acl;
+import kalix.springsdk.KalixConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+@SpringBootApplication
+@Import(KalixConfiguration.class)
+// Allow all other Kalix services deployed in the same project to access the components of this
+// Kalix service, but disallow access from the internet. This can be overridden explicitly
+// per component or method using annotations.
+// Documentation at https://docs.kalix.io/services/using-acls.html
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
+public class Main {
+
+  private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+  public static void main(String[] args) {
+    logger.info("Starting Kalix - Spring SDK");
+    SpringApplication.run(Main.class, args);
+  }
+}

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartService.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartService.java
@@ -1,7 +1,7 @@
 package com.example.shoppingcart;
 
-import com.example.shoppingcart.domain.LineItem;
 import com.example.shoppingcart.domain.ShoppingCart;
+import com.example.shoppingcart.domain.ShoppingCart.LineItem;
 import com.example.shoppingcart.domain.ShoppingCartEvent;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartService.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartService.java
@@ -1,0 +1,116 @@
+package com.example.shoppingcart;
+
+import com.example.shoppingcart.domain.LineItem;
+import com.example.shoppingcart.domain.ShoppingCart;
+import com.example.shoppingcart.domain.ShoppingCartEvent;
+import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
+import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import kalix.springsdk.annotations.Entity;
+import kalix.springsdk.annotations.EventHandler;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+// tag::class[]
+@Entity(entityKey = "cartId", entityType = "shopping-cart")
+@RequestMapping("/cart/{cartId}")
+public class ShoppingCartService extends EventSourcedEntity<ShoppingCart> {
+
+  private final String entityId;
+
+  public ShoppingCartService(EventSourcedEntityContext context) { this.entityId = context.entityId(); }
+
+  @Override
+  public ShoppingCart emptyState() { // <2>
+    return new ShoppingCart(entityId, Collections.emptyList());
+  }
+  // end::class[]
+
+  // tag::addItem[]
+  @PostMapping("/add")
+  public Effect<String> addItem(@RequestBody LineItem item) {
+    if (item.quantity() <= 0) { // <1>
+      return effects().error("Quantity for item " + item.productId() + " must be greater than zero.");
+    }
+
+    var event = new ShoppingCartEvent.ItemAdded(item); // <2>
+
+    return effects()
+        .emitEvent(event) // <3>
+        .thenReply(newState -> "OK"); // <4>
+  }
+  // end::addItem[]
+
+  @PostMapping("/items/{productId}/remove")
+  public Effect<String> removeItem(@PathVariable String productId) {
+    if (findItemByProductId(currentState(), productId).isEmpty()) {
+      return effects()
+          .error(
+              "Cannot remove item " + productId + " because it is not in the cart.");
+    }
+
+    var event = new ShoppingCartEvent.ItemRemoved(productId);
+
+    return effects()
+        .emitEvent(event)
+        .thenReply(newState -> "OK");
+  }
+
+  // tag::getCart[]
+  @GetMapping
+  public Effect<ShoppingCart> getCart() {
+    return effects().reply(currentState());
+  }
+  // end::getCart[]
+
+  // tag::itemAdded[]
+  @EventHandler
+  public ShoppingCart itemAdded(ShoppingCartEvent.ItemAdded itemAdded) {
+    var item = itemAdded.item();
+    var lineItem = updateItem(item, currentState());
+    List<LineItem> lineItems =
+        removeItemByProductId(currentState(), item.productId());
+    lineItems.add(lineItem);
+    lineItems.sort(Comparator.comparing(LineItem::productId));
+    return currentState().withItems(lineItems);
+  }
+
+  // end::itemAdded[]
+
+  @EventHandler
+  public ShoppingCart itemRemoved(ShoppingCartEvent.ItemRemoved itemRemoved) {
+    List<LineItem> items =
+        removeItemByProductId(currentState(), itemRemoved.productId());
+    items.sort(Comparator.comparing(LineItem::productId));
+    return currentState().withItems(items);
+  }
+
+  // tag::itemAdded[]
+  private LineItem updateItem(
+      LineItem item, ShoppingCart cart) {
+    return findItemByProductId(cart, item.productId())
+        .map(li -> li.withQuantity(li.quantity() + item.quantity()))
+        .orElse(item);
+  }
+
+  private Optional<LineItem> findItemByProductId(
+      ShoppingCart cart, String productId) {
+    Predicate<LineItem> lineItemExists =
+        lineItem -> lineItem.productId().equals(productId);
+    return cart.items().stream().filter(lineItemExists).findFirst();
+  }
+
+  private List<LineItem> removeItemByProductId(
+      ShoppingCart cart, String productId) {
+    return cart.items().stream()
+        .filter(lineItem -> !lineItem.productId().equals(productId))
+        .collect(Collectors.toList());
+  }
+  // end::itemAdded[]
+
+}

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/LineItem.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/LineItem.java
@@ -1,0 +1,7 @@
+package com.example.shoppingcart.domain;
+
+public record LineItem(String productId, String name, int quantity) {
+  public LineItem withQuantity(int quantity) {
+    return new LineItem(productId, name, quantity);
+  }
+}

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/LineItem.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/LineItem.java
@@ -1,7 +1,0 @@
-package com.example.shoppingcart.domain;
-
-public record LineItem(String productId, String name, int quantity) {
-  public LineItem withQuantity(int quantity) {
-    return new LineItem(productId, name, quantity);
-  }
-}

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCart.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCart.java
@@ -1,6 +1,10 @@
 package com.example.shoppingcart.domain;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public record ShoppingCart(String cartId, List<LineItem> items) {
 
@@ -10,7 +14,44 @@ public record ShoppingCart(String cartId, List<LineItem> items) {
     }
   }
 
-  public ShoppingCart withItems(List<LineItem> items) {
-    return new ShoppingCart(cartId, items);
+  // tag::itemAdded[]
+  public ShoppingCart onItemAdded(ShoppingCartEvent.ItemAdded itemAdded) {
+    var item = itemAdded.item();
+    var lineItem = updateItem(item, this);
+    List<LineItem> lineItems =
+        removeItemByProductId(this, item.productId());
+    lineItems.add(lineItem);
+    lineItems.sort(Comparator.comparing(LineItem::productId));
+    return new ShoppingCart(cartId, lineItems);
   }
+  // end::itemAdded[]
+
+  public ShoppingCart onItemRemoved(ShoppingCartEvent.ItemRemoved itemRemoved) {
+    List<LineItem> updatedItems =
+        removeItemByProductId(this, itemRemoved.productId());
+    updatedItems.sort(Comparator.comparing(LineItem::productId));
+    return new ShoppingCart(cartId, updatedItems);
+  }
+
+  // tag::itemAdded[]
+
+  private static LineItem updateItem(LineItem item, ShoppingCart cart) {
+    return cart.findItemByProductId(item.productId())
+        .map(li -> li.withQuantity(li.quantity() + item.quantity()))
+        .orElse(item);
+  }
+
+  public Optional<LineItem> findItemByProductId(String productId) {
+    Predicate<LineItem> lineItemExists =
+        lineItem -> lineItem.productId().equals(productId);
+    return items.stream().filter(lineItemExists).findFirst();
+  }
+
+  private static List<LineItem> removeItemByProductId(
+      ShoppingCart cart, String productId) {
+    return cart.items().stream()
+        .filter(lineItem -> !lineItem.productId().equals(productId))
+        .collect(Collectors.toList());
+  }
+  // end::itemAdded[]
 }

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCart.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCart.java
@@ -1,0 +1,10 @@
+package com.example.shoppingcart.domain;
+
+import java.util.List;
+
+public record ShoppingCart(String cartId, List<LineItem> items) {
+
+  public ShoppingCart withItems(List<LineItem> items) {
+    return new ShoppingCart(cartId, items);
+  }
+}

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCart.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCart.java
@@ -4,6 +4,12 @@ import java.util.List;
 
 public record ShoppingCart(String cartId, List<LineItem> items) {
 
+  public record LineItem(String productId, String name, int quantity) {
+    public LineItem withQuantity(int quantity) {
+      return new LineItem(productId, name, quantity);
+    }
+  }
+
   public ShoppingCart withItems(List<LineItem> items) {
     return new ShoppingCart(cartId, items);
   }

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCartEvent.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCartEvent.java
@@ -1,0 +1,24 @@
+package com.example.shoppingcart.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    {
+        @JsonSubTypes.Type(value = ShoppingCartEvent.ItemAdded.class, name = "item-added"),
+        @JsonSubTypes.Type(value = ShoppingCartEvent.ItemRemoved.class, name = "item-removed"),
+        @JsonSubTypes.Type(value = ShoppingCartEvent.CheckedOut.class, name = "checked-out")
+    })
+public sealed interface ShoppingCartEvent {
+
+  record ItemAdded(LineItem item) implements ShoppingCartEvent {
+  }
+
+  record ItemRemoved(String productId) implements ShoppingCartEvent {
+  }
+
+  record CheckedOut(int timestamp) implements ShoppingCartEvent {
+  }
+}

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCartEvent.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/domain/ShoppingCartEvent.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     })
 public sealed interface ShoppingCartEvent {
 
-  record ItemAdded(LineItem item) implements ShoppingCartEvent {
+  record ItemAdded(ShoppingCart.LineItem item) implements ShoppingCartEvent {
   }
 
   record ItemRemoved(String productId) implements ShoppingCartEvent {

--- a/samples/spring-eventsourced-shopping-cart/src/main/resources/application.properties
+++ b/samples/spring-eventsourced-shopping-cart/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# Don't remove this. 
+# this configuration is required in order to  block Spring Boot to start it's own http server
+# Kalix brings in its own http server and that's the one that will be starter.
+spring.main.web-application-type=none

--- a/samples/spring-eventsourced-shopping-cart/src/main/resources/logback.xml
+++ b/samples/spring-eventsourced-shopping-cart/src/main/resources/logback.xml
@@ -1,0 +1,36 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="JSON-STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="kalix.javasdk.logging.LogbackJsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <!-- Don't use prettyPrint true in production, but can be useful for local development -->
+                    <prettyPrint>false</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC-JSON-STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="JSON-STDOUT"/>
+    </appender>
+
+    <logger name="akka" level="INFO"/>
+    <logger name="kalix" level="INFO"/>
+    <logger name="akka.http" level="INFO"/>
+    <logger name="io.grpc" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/samples/spring-eventsourced-shopping-cart/src/test/java/com/example/shoppingcart/domain/ShoppingCartTest.java
+++ b/samples/spring-eventsourced-shopping-cart/src/test/java/com/example/shoppingcart/domain/ShoppingCartTest.java
@@ -15,8 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShoppingCartTest {
 
-  private Address address = new Address("Acme Street", "Acme City");
-  private LineItem akkaTshirt = new LineItem("akka-tshirt", "Akka Tshirt", 10);
+  private final ShoppingCart.LineItem akkaTshirt = new ShoppingCart.LineItem("akka-tshirt", "Akka Tshirt", 10);
 
 
   @Test

--- a/samples/spring-eventsourced-shopping-cart/src/test/java/com/example/shoppingcart/domain/ShoppingCartTest.java
+++ b/samples/spring-eventsourced-shopping-cart/src/test/java/com/example/shoppingcart/domain/ShoppingCartTest.java
@@ -1,0 +1,46 @@
+package com.example.shoppingcart.domain;
+
+import akka.actor.Address;
+import com.example.shoppingcart.ShoppingCartService;
+import kalix.javasdk.testkit.EventSourcedResult;
+import kalix.springsdk.testkit.EventSourcedTestKit;
+import org.junit.jupiter.api.Test;
+
+import javax.sound.sampled.Line;
+
+import java.util.List;
+
+import static com.example.shoppingcart.domain.ShoppingCartEvent.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ShoppingCartTest {
+
+  private Address address = new Address("Acme Street", "Acme City");
+  private LineItem akkaTshirt = new LineItem("akka-tshirt", "Akka Tshirt", 10);
+
+
+  @Test
+  public void testAddLineItem() {
+
+    EventSourcedTestKit<ShoppingCart, ShoppingCartService> testKit = EventSourcedTestKit.of(ShoppingCartService::new);
+    {
+      EventSourcedResult<String> result = testKit.call(e -> e.addItem(akkaTshirt));
+      assertEquals("OK", result.getReply());
+      assertEquals(10, result.getNextEventOfType(ItemAdded.class).item().quantity());
+    }
+
+    // actually we want more akka tshirts
+    {
+      EventSourcedResult<String> result = testKit.call(e -> e.addItem(akkaTshirt.withQuantity(5)));
+      assertEquals("OK", result.getReply());
+      assertEquals(5, result.getNextEventOfType(ItemAdded.class).item().quantity());
+    }
+
+    {
+      EventSourcedResult<ShoppingCart> result = testKit.call(ShoppingCartService::getCart);
+      assertEquals(new ShoppingCart("testkit-entity-id", List.of(akkaTshirt.withQuantity(15))), result.getReply());
+    }
+
+  }
+
+}


### PR DESCRIPTION
References https://github.com/lightbend/kalix/issues/7715

We agreed on using similar samples from the ones being used on the java/scala counterpart, so we were missing a shoppingcart ES sample to use in docs. Adding it here.

Have a look at the approach of Service vs Entity, trying to model things closer to what a Spring dev would expect.
~I might add the ES docs here as well or we can merge this independently. Will see.~ I will do that on a separate PR.