### PR TITLE
chore: fix display for group-scala in quickstart template page

### DIFF
--- a/docs/src/modules/java/pages/quickstart-template.adoc
+++ b/docs/src/modules/java/pages/quickstart-template.adoc
@@ -241,7 +241,7 @@ sbt test
 
 The project is configured to package your service into a Docker image which can be deployed to Kalix. The Docker image name can be changed in the [.group-java]#`pom.xml` file's `properties` section.# [.group-scala]#`build.sbt`.# Update this file to publish your image to your Docker repository.
 
-This uses JDK {java-version} and the image is based on the link:https://adoptium.net/[Eclipse Adoptium] JDK image (formerly Adopt OpenJDK). Choose a different image in the [.group-java]#`docker-maven-plugin` configuration  `pom.xml` file.# [.group-scala]#`build.sbt`.
+This uses JDK {java-version} and the image is based on the link:https://adoptium.net/[Eclipse Adoptium] JDK image (formerly Adopt OpenJDK). Choose a different image in the [.group-java]#`docker-maven-plugin` configuration  `pom.xml` file.# [.group-scala]#`build.sbt`.#
 
 [.tabset]
 Java::


### PR DESCRIPTION
Rendering mistake in java/scala page.

![CleanShot 2022-10-25 at 15 55 57](https://user-images.githubusercontent.com/502982/197794141-adef14c7-10aa-4c27-9645-e9ff66281923.png)
