### PR TITLE
feat(spring-sdk): support more HTTP methods in KalixClient

### DIFF
--- a/samples/spring-reliable-timers/docker-compose.yml
+++ b/samples/spring-reliable-timers/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.20
+    image: gcr.io/kalix-public/kalix-proxy:1.0.22
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-reliable-timers/src/main/java/com/example/actions/OrderAction.java
+++ b/samples/spring-reliable-timers/src/main/java/com/example/actions/OrderAction.java
@@ -60,7 +60,7 @@ public class OrderAction extends Action {
         orderId);
     // tag::place-order[]
 
-    var request = kalixClient.post("/order/"+orderId+"/place", orderRequest, Order.class); // <6>
+    var request = kalixClient.put("/order/"+orderId+"/place", orderRequest, Order.class); // <6>
     return effects().asyncReply( // <7>
         timerRegistration
             .thenCompose(done -> request.execute())

--- a/samples/spring-reliable-timers/src/main/java/com/example/domain/OrderEntity.java
+++ b/samples/spring-reliable-timers/src/main/java/com/example/domain/OrderEntity.java
@@ -22,7 +22,7 @@ public class OrderEntity extends ValueEntity<Order> {
     return new Order(entityId, false, false, "", 0);
   }
 
-  @PostMapping("/place")
+  @PutMapping("/place")
   public Effect<Order> placeOrder(@PathVariable String id, @RequestBody OrderRequest orderRequest) {
     var newOrder = new Order(id, false, true, orderRequest.item(), orderRequest.quantity());
     return effects()

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/XComponentCallsIntegrationTest.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/XComponentCallsIntegrationTest.java
@@ -18,6 +18,7 @@ package com.example.wiring;
 
 import com.example.Main;
 import com.example.wiring.actions.echo.Message;
+import com.example.wiring.valueentities.user.User;
 import kalix.springsdk.KalixConfigurationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -102,4 +103,19 @@ public class XComponentCallsIntegrationTest {
     Assertions.assertNotNull(usingPostResponse);
     Assertions.assertEquals("Parrot says: 'm3ss4g3 t b3 shrt3n3d'", usingPostResponse.text);
   }
+
+  @Test
+  public void verifyKalixClientUsingPutMethod() {
+
+    User u1 = new User("mary@pops.com", "MayPops");
+    String userCreation =
+        webClient
+            .put()
+            .uri("/validuser/MaryPops/" + u1.email + "/" + u1.name)
+            .retrieve()
+            .bodyToMono(String.class)
+            .block(timeout);
+    Assertions.assertEquals("\"Ok from put\"", userCreation);
+  }
+
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/XComponentCallsIntegrationTest.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/XComponentCallsIntegrationTest.java
@@ -118,4 +118,35 @@ public class XComponentCallsIntegrationTest {
     Assertions.assertEquals("\"Ok from put\"", userCreation);
   }
 
+  @Test
+  public void verifyKalixClientUsingPatchMethod() {
+
+    User u1 = new User("mary@patch.com", "MayPatch");
+    String userCreation =
+        webClient
+            .put()
+            .uri("/validuser/MayPatch/" + u1.email + "/" + u1.name)
+            .retrieve()
+            .bodyToMono(String.class)
+            .block(timeout);
+    Assertions.assertEquals("\"Ok from put\"", userCreation);
+
+    String userUpdate =
+        webClient
+            .patch()
+            .uri("/validuser/MayPatch/email/" + "new"+u1.email)
+            .retrieve()
+            .bodyToMono(String.class)
+            .block(timeout);
+    Assertions.assertEquals("\"Ok from patch\"", userUpdate);
+
+    User userGetResponse =
+        webClient
+            .get()
+            .uri("/user/MayPatch")
+            .retrieve()
+            .bodyToMono(User.class)
+            .block(timeout);
+    Assertions.assertEquals("new"+u1.email, userGetResponse.email);
+  }
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
@@ -16,6 +16,7 @@
 
 package com.example.wiring.valueentities.user;
 
+import io.grpc.Status;
 import kalix.javasdk.valueentity.ValueEntity;
 import kalix.javasdk.valueentity.ValueEntityContext;
 import kalix.springsdk.annotations.Entity;
@@ -33,6 +34,9 @@ public class UserEntity extends ValueEntity<User> {
 
   @GetMapping
   public Effect<User> getUser() {
+    if (currentState() == null)
+      return effects().error("User not found", Status.Code.NOT_FOUND);
+
     return effects().reply(currentState());
   }
 
@@ -49,5 +53,10 @@ public class UserEntity extends ValueEntity<User> {
   @PatchMapping("/email/{email}")
   public Effect<String> createUser(@PathVariable String email) {
     return effects().updateState(new User(email, currentState().name)).thenReply("Ok from patch");
+  }
+
+  @DeleteMapping
+  public Effect<String> deleteUser() {
+    return effects().deleteState().thenReply("Ok from delete");
   }
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
@@ -19,10 +19,7 @@ package com.example.wiring.valueentities.user;
 import kalix.javasdk.valueentity.ValueEntity;
 import kalix.javasdk.valueentity.ValueEntityContext;
 import kalix.springsdk.annotations.Entity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Entity(entityKey = "id", entityType = "user")
 @RequestMapping("/user/{id}")
@@ -34,6 +31,11 @@ public class UserEntity extends ValueEntity<User> {
     this.context = context;
   }
 
+  @GetMapping
+  public Effect<User> getUser() {
+    return effects().reply(currentState());
+  }
+
   @PostMapping("/{email}/{name}")
   public Effect<String> createOrUpdateUser(@PathVariable String email, @PathVariable String name) {
     return effects().updateState(new User(email, name)).thenReply("Ok");
@@ -42,5 +44,10 @@ public class UserEntity extends ValueEntity<User> {
   @PutMapping("/{email}/{name}")
   public Effect<String> createUser(@PathVariable String email, @PathVariable String name) {
     return effects().updateState(new User(email, name)).thenReply("Ok from put");
+  }
+
+  @PatchMapping("/email/{email}")
+  public Effect<String> createUser(@PathVariable String email) {
+    return effects().updateState(new User(email, currentState().name)).thenReply("Ok from patch");
   }
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/ValidateUserAction.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/ValidateUserAction.java
@@ -20,6 +20,7 @@ import io.grpc.Status;
 import kalix.javasdk.action.Action;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.springsdk.KalixClient;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,6 +42,15 @@ public class ValidateUserAction extends Action {
       return effects().error("No field can be empty", Status.Code.INVALID_ARGUMENT);
 
     var defCall = kalixClient.put("/user/" + user + "/" + email + "/" + name, "", String.class);
+    return effects().forward(defCall);
+  }
+
+  @PatchMapping("/email/{email}")
+  public Action.Effect<String> updateEmail(@PathVariable String user, @PathVariable String email) {
+    if (email.isEmpty())
+      return effects().error("No field can be empty", Status.Code.INVALID_ARGUMENT);
+
+    var defCall = kalixClient.patch("/user/" + user + "/email/" + email, "", String.class);
     return effects().forward(defCall);
   }
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/ValidateUserAction.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/user/ValidateUserAction.java
@@ -20,10 +20,7 @@ import io.grpc.Status;
 import kalix.javasdk.action.Action;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.springsdk.KalixClient;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/validuser/{user}")
 public class ValidateUserAction extends Action {
@@ -51,6 +48,12 @@ public class ValidateUserAction extends Action {
       return effects().error("No field can be empty", Status.Code.INVALID_ARGUMENT);
 
     var defCall = kalixClient.patch("/user/" + user + "/email/" + email, "", String.class);
+    return effects().forward(defCall);
+  }
+
+  @DeleteMapping
+  public Action.Effect<String> delete(@PathVariable String user) {
+    var defCall = kalixClient.delete("/user/" + user, "", String.class);
     return effects().forward(defCall);
   }
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
@@ -135,4 +135,33 @@ trait KalixClient {
    *   a [[kalix.javasdk.DeferredCall]] to be used in forwards and timers or to be executed in place
    */
   def patch[P, R](uri: String, body: P, returnType: Class[R]): DeferredCall[Any, R]
+
+  /**
+   * Provides utility to do a DELETE HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
+   * identified by a resource path (i.e. excluding authority and scheme).
+   *
+   * Example of use: TODO fix sample here
+   * {{{
+   *     @PutMapping("/next")
+   *     public Effect<Number> nextNumber(@RequestBody Number number) {
+   *       var serviceCall = kalixClient.put("/fibonacci/next", number, Number.class);
+   *       return effects().forward(serviceCall);
+   *     }
+   * }}}
+   *
+   * @param uri
+   *   The resource path where the target endpoint will be reached at. Query parameters can be passed in as part of the
+   *   URI but should be encoded if containing special characters.
+   * @param body
+   *   The HTTP body type expected by the target endpoint
+   * @param returnType
+   *   The type returned by the target endpoint
+   * @tparam P
+   *   Type used as a body for the request
+   * @tparam R
+   *   Type returned as response from the target endpoint
+   * @return
+   *   a [[kalix.javasdk.DeferredCall]] to be used in forwards and timers or to be executed in place
+   */
+  def delete[P, R](uri: String, body: P, returnType: Class[R]): DeferredCall[Any, R]
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
@@ -25,6 +25,31 @@ import com.google.protobuf.any.Any
 trait KalixClient {
 
   /**
+   * Provides utility to do a GET HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
+   * identified by a resource path (i.e. excluding authority and scheme).
+   *
+   * Example of use on a cross-component call:
+   * {{{
+   *     @GetMapping("/{number}/next")
+   *     public Effect<Number> nextNumber(@PathVariable Long number) {
+   *       var serviceCall = kalixClient.get("/fibonacci/"+number+"/next", Number.class);
+   *       return effects().forward(serviceCall);
+   *     }
+   * }}}
+   *
+   * @param uri
+   *   the resource path where the target endpoint will be reached at. . Query parameters can be passed in as part of
+   *   the URI but should be encoded if containing special characters.
+   * @param returnType
+   *   the type returned by the target endpoint
+   * @tparam R
+   *   type returned as response from the target endpoint
+   * @return
+   *   a [[kalix.javasdk.DeferredCall]] to be used in forwards and timers or to be executed in place
+   */
+  def get[R](uri: String, returnType: Class[R]): DeferredCall[Any, R]
+
+  /**
    * Provides utility to do a POST HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
    * identified by a resource path (i.e. excluding authority and scheme).
    *
@@ -54,27 +79,31 @@ trait KalixClient {
   def post[P, R](uri: String, body: P, returnType: Class[R]): DeferredCall[Any, R]
 
   /**
-   * Provides utility to do a GET HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
+   * Provides utility to do a PUT HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
    * identified by a resource path (i.e. excluding authority and scheme).
    *
-   * Example of use on a cross-component call:
+   * Example of use: TODO fix sample here
    * {{{
-   *     @GetMapping("/{number}/next")
-   *     public Effect<Number> nextNumber(@PathVariable Long number) {
-   *       var serviceCall = kalixClient.get("/fibonacci/"+number+"/next", Number.class);
+   *     @PutMapping("/next")
+   *     public Effect<Number> nextNumber(@RequestBody Number number) {
+   *       var serviceCall = kalixClient.put("/fibonacci/next", number, Number.class);
    *       return effects().forward(serviceCall);
    *     }
    * }}}
    *
    * @param uri
-   *   the resource path where the target endpoint will be reached at. . Query parameters can be passed in as part of
-   *   the URI but should be encoded if containing special characters.
+   *   The resource path where the target endpoint will be reached at. Query parameters can be passed in as part of the
+   *   URI but should be encoded if containing special characters.
+   * @param body
+   *   The HTTP body type expected by the target endpoint
    * @param returnType
-   *   the type returned by the target endpoint
+   *   The type returned by the target endpoint
+   * @tparam P
+   *   Type used as a body for the request
    * @tparam R
-   *   type returned as response from the target endpoint
+   *   Type returned as response from the target endpoint
    * @return
    *   a [[kalix.javasdk.DeferredCall]] to be used in forwards and timers or to be executed in place
    */
-  def get[R](uri: String, returnType: Class[R]): DeferredCall[Any, R]
+  def put[P, R](uri: String, body: P, returnType: Class[R]): DeferredCall[Any, R]
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
@@ -30,8 +30,7 @@ trait KalixClient {
    *
    * Example of use on a cross-component call:
    * {{{
-   *     @GetMapping("/{number}/next")
-   *     public Effect<Number> nextNumber(@PathVariable Long number) {
+   *     public Effect<Number> nextNumber(Long number) {
    *       var serviceCall = kalixClient.get("/fibonacci/"+number+"/next", Number.class);
    *       return effects().forward(serviceCall);
    *     }
@@ -55,8 +54,7 @@ trait KalixClient {
    *
    * Example of use:
    * {{{
-   *     @PostMapping("/next")
-   *     public Effect<Number> nextNumber(@RequestBody Number number) {
+   *     public Effect<Number> nextNumber(Number number) {
    *       var serviceCall = kalixClient.post("/fibonacci/next", number, Number.class);
    *       return effects().forward(serviceCall);
    *     }
@@ -82,10 +80,9 @@ trait KalixClient {
    * Provides utility to do a PUT HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
    * identified by a resource path (i.e. excluding authority and scheme).
    *
-   * Example of use: TODO fix sample here
+   * Example of use:
    * {{{
-   *     @PutMapping("/next")
-   *     public Effect<Number> nextNumber(@RequestBody Number number) {
+   *     public Effect<Number> nextNumber(Number number) {
    *       var serviceCall = kalixClient.put("/fibonacci/next", number, Number.class);
    *       return effects().forward(serviceCall);
    *     }
@@ -111,11 +108,10 @@ trait KalixClient {
    * Provides utility to do a PATCH HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
    * identified by a resource path (i.e. excluding authority and scheme).
    *
-   * Example of use: TODO fix sample here
+   * Example of use:
    * {{{
-   *     @PutMapping("/next")
-   *     public Effect<Number> nextNumber(@RequestBody Number number) {
-   *       var serviceCall = kalixClient.put("/fibonacci/next", number, Number.class);
+   *     public Effect<User> createUser(String email) {
+   *       var serviceCall = kalixClient.patch("/user/" + user.id + "/email", email, User.class);
    *       return effects().forward(serviceCall);
    *     }
    * }}}
@@ -140,11 +136,10 @@ trait KalixClient {
    * Provides utility to do a DELETE HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
    * identified by a resource path (i.e. excluding authority and scheme).
    *
-   * Example of use: TODO fix sample here
+   * Example of use:
    * {{{
-   *     @PutMapping("/next")
-   *     public Effect<Number> nextNumber(@RequestBody Number number) {
-   *       var serviceCall = kalixClient.put("/fibonacci/next", number, Number.class);
+   *     public Effect<String> deleteUser(@RequestBody String userId) {
+   *       var serviceCall = kalixClient.delete("/user/"+userId, "", String.class);
    *       return effects().forward(serviceCall);
    *     }
    * }}}

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/KalixClient.scala
@@ -106,4 +106,33 @@ trait KalixClient {
    *   a [[kalix.javasdk.DeferredCall]] to be used in forwards and timers or to be executed in place
    */
   def put[P, R](uri: String, body: P, returnType: Class[R]): DeferredCall[Any, R]
+
+  /**
+   * Provides utility to do a PATCH HTTP request to a target endpoint belonging to a Kalix component. Such endpoint is
+   * identified by a resource path (i.e. excluding authority and scheme).
+   *
+   * Example of use: TODO fix sample here
+   * {{{
+   *     @PutMapping("/next")
+   *     public Effect<Number> nextNumber(@RequestBody Number number) {
+   *       var serviceCall = kalixClient.put("/fibonacci/next", number, Number.class);
+   *       return effects().forward(serviceCall);
+   *     }
+   * }}}
+   *
+   * @param uri
+   *   The resource path where the target endpoint will be reached at. Query parameters can be passed in as part of the
+   *   URI but should be encoded if containing special characters.
+   * @param body
+   *   The HTTP body type expected by the target endpoint
+   * @param returnType
+   *   The type returned by the target endpoint
+   * @tparam P
+   *   Type used as a body for the request
+   * @tparam R
+   *   Type returned as response from the target endpoint
+   * @return
+   *   a [[kalix.javasdk.DeferredCall]] to be used in forwards and timers or to be executed in place
+   */
+  def patch[P, R](uri: String, body: P, returnType: Class[R]): DeferredCall[Any, R]
 }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/RestKalixClientImpl.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/RestKalixClientImpl.scala
@@ -16,7 +16,6 @@
 
 package kalix.springsdk.impl
 
-import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.{ HttpMethod, HttpMethods, Uri }
 import com.google.protobuf.{ Descriptors, DynamicMessage }
 import com.google.protobuf.any.Any


### PR DESCRIPTION
References https://github.com/lightbend/kalix/issues/7628

This:
- adds support for `PUT`, `PATCH` and `DELETE`

Still confirming if/how to support custom HTTP methods.