### PR TITLE
chore: formatAll commands alias

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -424,3 +424,5 @@ lazy val sbtPlugin = Project(id = "sbt-kalix", base = file("sbt-plugin"))
     },
     scriptedBufferLog := false)
   .dependsOn(codegenScala)
+
+addCommandAlias("formatAll", "scalafmtAll; javafmtAll")


### PR DESCRIPTION
Because I'm too lazy to type `scalafmtAll;javafmtAll` over and over again.