### PR TITLE
fix: fail to publish docs on release

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -112,5 +112,6 @@ validate-links:
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
 		-c "cd /antora/${base_path} && find src -name '*.adoc' -print0 | xargs -0 -n1 asciidoc-link-check --progress --config config/validate-links.json"
 
+# TODO: we will need to include publication for spring module once we want it out
 deploy: clean managed
-	bin/deploy.sh --module ${module} --upstream ${upstream} --branch ${branch} ${sources}
+	bin/deploy.sh --module java --upstream ${upstream} --branch ${branch} ${sources}

--- a/docs/bin/deploy.sh
+++ b/docs/bin/deploy.sh
@@ -15,7 +15,7 @@
 # deploy author
 
 readonly deploy_name="Kalix Bot"
-readonly deploy_email="bot@kalix.io"
+readonly deploy_email="kalix.github@lightbend.com"
 
 # locations
 


### PR DESCRIPTION
Fix #1250


Follow-up of https://github.com/lightbend/kalix-jvm-sdk/pull/1199