### PR TITLE
fix: codegen support for Any as a state type

### DIFF
--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/AbstractKalixGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/AbstractKalixGenerator.scala
@@ -39,7 +39,7 @@ abstract class AbstractKalixGenerator extends CodeGenApp {
 
   override def process(request: CodeGenRequest): CodeGenResponse = {
     val debugEnabled = request.parameter.contains(enableDebug)
-    val model = ModelBuilder.introspectProtobufClasses(request.filesToGenerate)(
+    val model = ModelBuilder.introspectProtobufClasses(request.filesToGenerate, request.allProtos)(
       DebugPrintlnLog(debugEnabled),
       ProtoMessageTypeExtractor(request))
     try {


### PR DESCRIPTION
fixing
```
--jvm_3_out: java.lang.IllegalArgumentException: No descriptor found declaring package [google.protobuf] and message [Any]
	at kalix.codegen.ModelBuilder$.$anonfun$lookupDomainDescriptor$3(ModelBuilder.scala:452)
	at scala.Option.getOrElse(Option.scala:189)
	at kalix.codegen.ModelBuilder$.lookupDomainDescriptor(ModelBuilder.scala:451)
	at kalix.codegen.ModelBuilder$.resolveMessageType(ModelBuilder.scala:475)
	at kalix.codegen.ModelBuilder$.extractValueEntity(ModelBuilder.scala:670)
	at kalix.codegen.ModelBuilder$.modelFromCodegenOptions(ModelBuilder.scala:582)
	at kalix.codegen.ModelBuilder$.$anonfun$introspectProtobufClasses$2(ModelBuilder.scala:372)
	at scala.collection.TraversableOnce$folder$1.apply(TraversableOnce.scala:196)
```
for value entity with Any as a state type:
```
  option (kalix.codegen) = {
    value_entity: {
      name: "com.example.user.UserEntity"
      entity_type: "user"
      state: "google.protobuf.Any"
    }
  };
```