### PR TITLE
fix: Allow 12M incoming, s2s client to allow 12M replies in cross service calls.

### DIFF
--- a/sdk/java-sdk/src/main/resources/reference.conf
+++ b/sdk/java-sdk/src/main/resources/reference.conf
@@ -8,6 +8,12 @@ kalix {
   # default passivation timeout for entities
   passivation-timeout = 30s
 
+  cross-service {
+    # Kalix proxy accepts up to this size of requests between services (Note: cannot be arbitrarily increased here,
+    # controlled by proxy, only needed to align the gRPC client with what the proxy may emit)
+    max-content-length: 12M
+  }
+
   event-sourced-entity {
     # It is strongly recommended to not disable snapshotting unless it is known that
     # event sourced entities will never have more than 100 events (in which case
@@ -69,6 +75,9 @@ kalix {
         http2.max-concurrent-streams = 30000
 
         http2.min-collect-strict-entity-size = 1
+
+        # Kalix proxy expects SDK to send reqs up to 12m to the SDK (and accepts 12m responses)
+        parsing.max-content-length = 12M
       }
     }
   }


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-proxy/issues/1604 and https://github.com/lightbend/kalix-proxy/issues/1466