### PR TITLE
docs(spring-sdk): remove page for replicated entities

### DIFF
--- a/docs/src/modules/spring/nav.adoc
+++ b/docs/src/modules/spring/nav.adoc
@@ -4,7 +4,7 @@
 *** xref:spring:development-process-spring.adoc[Development Process]
 *** xref:spring:value-entity.adoc[Implementing Value Entities]
 *** xref:spring:event-sourced-entities.adoc[Implementing Event Sourced Entities]
-*** xref:spring:replicated-entity.adoc[Implementing Replicated Entities]
+// *** xref:spring:replicated-entity.adoc[Implementing Replicated Entities] to be implemented
 *** xref:spring:views.adoc[Implementing Views]
 *** xref:spring:actions.adoc[Implementing Actions]
 *** xref:spring:actions-as-controller.adoc[Actions as Controllers]


### PR DESCRIPTION
Fix https://github.com/lightbend/kalix-jvm-sdk/issues/1276

I don't think it's worth removing the link to "Calling others services" since that one is also about to be merged (failing on CI ATM).

I ended up not removing the file itself, only the link to it..