### PR TITLE
feat!: support views with multiple tables

### DIFF
--- a/codegen/core/src/main/scala/kalix/codegen/ModelBuilder.scala
+++ b/codegen/core/src/main/scala/kalix/codegen/ModelBuilder.scala
@@ -298,7 +298,7 @@ object ModelBuilder {
           s"must have `option (kalix.method).view.update.transform_updates` equals `true`")
       }
 
-    val state = State(updates.head.outputType)
+    val stateTypes: Seq[ProtoMessageType] = updates.map(_.outputType).toSeq.distinct
   }
 
   /**

--- a/codegen/core/src/main/scala/kalix/codegen/ModelBuilder.scala
+++ b/codegen/core/src/main/scala/kalix/codegen/ModelBuilder.scala
@@ -322,7 +322,8 @@ object ModelBuilder {
       inFromTopic: Boolean,
       outToTopic: Boolean,
       ignore: Boolean,
-      handleDeletes: Boolean) {
+      handleDeletes: Boolean,
+      viewTable: String) {
 
     def isUnary: Boolean = !streamedInput && !streamedOutput
     def isStreamIn: Boolean = streamedInput && !streamedOutput
@@ -335,6 +336,7 @@ object ModelBuilder {
   object Command {
     def from(method: Descriptors.MethodDescriptor)(implicit messageExtractor: ProtoMessageTypeExtractor): Command = {
       val eventing = method.getOptions.getExtension(kalix.Annotations.method).getEventing
+      val viewUpdate = method.getOptions.getExtension(kalix.Annotations.method).getView.getUpdate
       Command(
         method.getName,
         messageExtractor(method.getInputType),
@@ -344,7 +346,8 @@ object ModelBuilder {
         inFromTopic = eventing.hasIn && eventing.getIn.hasTopic,
         outToTopic = eventing.hasOut && eventing.getOut.hasTopic,
         ignore = eventing.hasIn && eventing.getIn.getIgnore,
-        handleDeletes = eventing.hasIn && eventing.getIn.getHandleDeletes)
+        handleDeletes = eventing.hasIn && eventing.getIn.getHandleDeletes,
+        viewUpdate.getTable)
     }
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.java
@@ -6,10 +6,10 @@ import kalix.javasdk.view.View;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractMyUserByNameView extends View<UserViewModel.UserState> {
+public abstract class AbstractMyUserByNameView extends View {
 
   @Override
-  public UserViewModel.UserState emptyState() {
+  public Object emptyState() {
     return null; // emptyState is only used with transform_updates=true
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class MyUserByNameViewProvider implements ViewProvider<UserViewModel.UserState, MyUserByNameView> {
+public class MyUserByNameViewProvider implements ViewProvider<MyUserByNameView> {
 
   private final Function<ViewCreationContext, MyUserByNameView> viewFactory;
   private final String viewId;

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
@@ -8,16 +8,16 @@ import kalix.javasdk.view.View;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class MyUserByNameViewRouter extends ViewRouter<UserViewModel.UserState, MyUserByNameView> {
+public class MyUserByNameViewRouter extends ViewRouter<MyUserByNameView> {
 
   public MyUserByNameViewRouter(MyUserByNameView view) {
     super(view);
   }
 
   @Override
-  public View.UpdateEffect<UserViewModel.UserState> handleUpdate(
+  public <S> View.UpdateEffect<S> handleUpdate(
       String eventName,
-      UserViewModel.UserState state,
+      S state,
       Object event) {
 
     switch (eventName) {

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
@@ -31,7 +31,8 @@ public class MyUserByNameViewRouter extends ViewRouter<MyUserByNameView> {
   public String viewTable(String eventName, Object event) {
     switch (eventName) {
 
-      default: return "";
+      default:
+        return "";
     }
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
@@ -27,5 +27,13 @@ public class MyUserByNameViewRouter extends ViewRouter<MyUserByNameView> {
     }
   }
 
+  @Override
+  public String viewTable(String eventName, Object event) {
+    switch (eventName) {
+
+      default: return "";
+    }
+  }
+
 }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.java
@@ -6,10 +6,10 @@ import kalix.javasdk.view.View;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractUserByNameView extends View<UserViewModel.UserState> {
+public abstract class AbstractUserByNameView extends View {
 
   @Override
-  public UserViewModel.UserState emptyState() {
+  public Object emptyState() {
     return null; // emptyState is only used with transform_updates=true
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class UserByNameViewProvider implements ViewProvider<UserViewModel.UserState, UserByNameView> {
+public class UserByNameViewProvider implements ViewProvider<UserByNameView> {
 
   private final Function<ViewCreationContext, UserByNameView> viewFactory;
   private final String viewId;

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
@@ -31,7 +31,8 @@ public class UserByNameViewRouter extends ViewRouter<UserByNameView> {
   public String viewTable(String eventName, Object event) {
     switch (eventName) {
 
-      default: return "";
+      default:
+        return "";
     }
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
@@ -27,5 +27,13 @@ public class UserByNameViewRouter extends ViewRouter<UserByNameView> {
     }
   }
 
+  @Override
+  public String viewTable(String eventName, Object event) {
+    switch (eventName) {
+
+      default: return "";
+    }
+  }
+
 }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
@@ -8,16 +8,16 @@ import kalix.javasdk.view.View;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class UserByNameViewRouter extends ViewRouter<UserViewModel.UserState, UserByNameView> {
+public class UserByNameViewRouter extends ViewRouter<UserByNameView> {
 
   public UserByNameViewRouter(UserByNameView view) {
     super(view);
   }
 
   @Override
-  public View.UpdateEffect<UserViewModel.UserState> handleUpdate(
+  public <S> View.UpdateEffect<S> handleUpdate(
       String eventName,
-      UserViewModel.UserState state,
+      S state,
       Object event) {
 
     switch (eventName) {

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.java
@@ -6,10 +6,10 @@ import kalix.javasdk.view.View;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractUserByNameView extends View<UserViewModel.UserState> {
+public abstract class AbstractUserByNameView extends View {
 
   @Override
-  public UserViewModel.UserState emptyState() {
+  public Object emptyState() {
     return null; // emptyState is only used with transform_updates=true
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class UserByNameViewProvider implements ViewProvider<UserViewModel.UserState, UserByNameViewImpl> {
+public class UserByNameViewProvider implements ViewProvider<UserByNameViewImpl> {
 
   private final Function<ViewCreationContext, UserByNameViewImpl> viewFactory;
   private final String viewId;

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
@@ -31,7 +31,8 @@ public class UserByNameViewRouter extends ViewRouter<UserByNameViewImpl> {
   public String viewTable(String eventName, Object event) {
     switch (eventName) {
 
-      default: return "";
+      default:
+        return "";
     }
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
@@ -27,5 +27,13 @@ public class UserByNameViewRouter extends ViewRouter<UserByNameViewImpl> {
     }
   }
 
+  @Override
+  public String viewTable(String eventName, Object event) {
+    switch (eventName) {
+
+      default: return "";
+    }
+  }
+
 }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
@@ -8,16 +8,16 @@ import kalix.javasdk.view.View;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class UserByNameViewRouter extends ViewRouter<UserViewModel.UserState, UserByNameViewImpl> {
+public class UserByNameViewRouter extends ViewRouter<UserByNameViewImpl> {
 
   public UserByNameViewRouter(UserByNameViewImpl view) {
     super(view);
   }
 
   @Override
-  public View.UpdateEffect<UserViewModel.UserState> handleUpdate(
+  public <S> View.UpdateEffect<S> handleUpdate(
       String eventName,
-      UserViewModel.UserState state,
+      S state,
       Object event) {
 
     switch (eventName) {

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.java
@@ -1,0 +1,16 @@
+package org.example;
+
+import kalix.javasdk.DeferredCall;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  
+
+  
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,31 @@
+package org.example;
+
+import kalix.javasdk.Context;
+import kalix.javasdk.DeferredCall;
+import kalix.javasdk.impl.GrpcDeferredCall;
+import kalix.javasdk.impl.InternalContext;
+import kalix.javasdk.impl.MetadataImpl;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  
+
+  
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import kalix.javasdk.Kalix;
+import kalix.javasdk.view.ViewCreationContext;
+import org.example.view.CustomerOrdersView;
+import org.example.view.CustomerOrdersViewModel;
+import org.example.view.CustomerOrdersViewProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class KalixFactory {
+
+  public static Kalix withComponents(
+      Function<ViewCreationContext, CustomerOrdersView> createCustomerOrdersView) {
+    Kalix kalix = new Kalix();
+    return kalix
+      .register(CustomerOrdersViewProvider.of(createCustomerOrdersView));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.java
@@ -8,6 +8,24 @@ import kalix.javasdk.view.View;
 
 public abstract class AbstractCustomerOrdersView extends View {
 
+  @Override
+  public Object emptyState() {
+    switch (updateContext().viewTable()) {
+      case "customers":
+        return emptyCustomerState();
+
+      case "products":
+        return emptyProductState();
+
+      default:
+        return null;
+    }
+  }
+
+  public abstract CustomerOrdersViewModel.CustomerState emptyCustomerState();
+
+  public abstract CustomerOrdersViewModel.ProductState emptyProductState();
+
   public abstract View.UpdateEffect<CustomerOrdersViewModel.CustomerState> updateCustomerCreated(
     CustomerOrdersViewModel.CustomerState state, CustomerOrdersViewModel.CustomerCreated customerCreated);
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.java
@@ -1,0 +1,20 @@
+package org.example.view;
+
+import kalix.javasdk.view.View;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public abstract class AbstractCustomerOrdersView extends View {
+
+  public abstract View.UpdateEffect<CustomerOrdersViewModel.CustomerState> updateCustomerCreated(
+    CustomerOrdersViewModel.CustomerState state, CustomerOrdersViewModel.CustomerCreated customerCreated);
+
+  public abstract View.UpdateEffect<CustomerOrdersViewModel.CustomerState> updateCustomerNameChanged(
+    CustomerOrdersViewModel.CustomerState state, CustomerOrdersViewModel.CustomerNameChanged customerNameChanged);
+
+  public abstract View.UpdateEffect<CustomerOrdersViewModel.ProductState> updateProduct(
+    CustomerOrdersViewModel.ProductState state, CustomerOrdersViewModel.ProductCreated productCreated);
+
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.java
@@ -1,0 +1,72 @@
+package org.example.view;
+
+import com.google.protobuf.Descriptors;
+import kalix.javasdk.view.ViewCreationContext;
+import kalix.javasdk.view.ViewOptions;
+import kalix.javasdk.view.ViewProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class CustomerOrdersViewProvider implements ViewProvider<CustomerOrdersView> {
+
+  private final Function<ViewCreationContext, CustomerOrdersView> viewFactory;
+  private final String viewId;
+  private final ViewOptions options;
+
+  /** Factory method of CustomerOrdersView */
+  public static CustomerOrdersViewProvider of(
+      Function<ViewCreationContext, CustomerOrdersView> viewFactory) {
+    return new CustomerOrdersViewProvider(viewFactory, "CustomerOrders", ViewOptions.defaults());
+  }
+
+  private CustomerOrdersViewProvider(
+      Function<ViewCreationContext, CustomerOrdersView> viewFactory,
+      String viewId,
+      ViewOptions options) {
+    this.viewFactory = viewFactory;
+    this.viewId = viewId;
+    this.options = options;
+  }
+
+  @Override
+  public String viewId() {
+    return viewId;
+  }
+
+  @Override
+  public final ViewOptions options() {
+    return options;
+  }
+
+  public final CustomerOrdersViewProvider withOptions(ViewOptions options) {
+    return new CustomerOrdersViewProvider(viewFactory, viewId, options);
+  }
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  public CustomerOrdersViewProvider withViewId(String viewId) {
+    return new CustomerOrdersViewProvider(viewFactory, viewId, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CustomerOrdersViewModel.getDescriptor().findServiceByName("CustomerOrders");
+  }
+
+  @Override
+  public final CustomerOrdersViewRouter newRouter(ViewCreationContext context) {
+    return new CustomerOrdersViewRouter(viewFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {CustomerOrdersViewModel.getDescriptor()};
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.java
@@ -1,0 +1,65 @@
+package org.example.view;
+
+import kalix.javasdk.impl.view.UpdateHandlerNotFound;
+import kalix.javasdk.impl.view.ViewRouter;
+import kalix.javasdk.view.View;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class CustomerOrdersViewRouter extends ViewRouter<CustomerOrdersView> {
+
+  public CustomerOrdersViewRouter(CustomerOrdersView view) {
+    super(view);
+  }
+
+  @Override
+  public <S> View.UpdateEffect<S> handleUpdate(
+      String eventName,
+      S state,
+      Object event) {
+
+    switch (eventName) {
+      case "UpdateCustomerCreated":
+        return (View.UpdateEffect<S>)
+            view().updateCustomerCreated(
+                (CustomerOrdersViewModel.CustomerState) state,
+                (CustomerOrdersViewModel.CustomerCreated) event);
+
+      case "UpdateCustomerNameChanged":
+        return (View.UpdateEffect<S>)
+            view().updateCustomerNameChanged(
+                (CustomerOrdersViewModel.CustomerState) state,
+                (CustomerOrdersViewModel.CustomerNameChanged) event);
+
+      case "UpdateProduct":
+        return (View.UpdateEffect<S>)
+            view().updateProduct(
+                (CustomerOrdersViewModel.ProductState) state,
+                (CustomerOrdersViewModel.ProductCreated) event);
+
+      default:
+        throw new UpdateHandlerNotFound(eventName);
+    }
+  }
+
+  @Override
+  public String viewTable(String eventName, Object event) {
+    switch (eventName) {
+      case "UpdateCustomerCreated":
+        return "customers";
+
+      case "UpdateCustomerNameChanged":
+        return "customers";
+
+      case "UpdateProduct":
+        return "products";
+
+      default:
+        return "";
+    }
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import kalix.javasdk.Kalix;
+import org.example.view.CustomerOrdersView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static Kalix createKalix() {
+    // The KalixFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new Kalix()` instance.
+    return KalixFactory.withComponents(
+      CustomerOrdersView::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Kalix service");
+    createKalix().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.java
@@ -1,0 +1,49 @@
+package org.example.view;
+
+import kalix.javasdk.view.View;
+import kalix.javasdk.view.ViewContext;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+// This is the implementation for the View Service described in your customer_orders.proto file.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CustomerOrdersView extends AbstractCustomerOrdersView {
+
+  public CustomerOrdersView(ViewContext context) {}
+
+  @Override
+  public Object emptyState() {
+    switch (updateContext().viewTable()) {
+      case "customers":
+        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'customers'");
+
+      case "products":
+        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'products'");
+
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public View.UpdateEffect<CustomerOrdersViewModel.CustomerState> updateCustomerCreated(
+    CustomerOrdersViewModel.CustomerState state, CustomerOrdersViewModel.CustomerCreated customerCreated) {
+    throw new UnsupportedOperationException("Update handler for 'UpdateCustomerCreated' not implemented yet");
+  }
+
+  @Override
+  public View.UpdateEffect<CustomerOrdersViewModel.CustomerState> updateCustomerNameChanged(
+    CustomerOrdersViewModel.CustomerState state, CustomerOrdersViewModel.CustomerNameChanged customerNameChanged) {
+    throw new UnsupportedOperationException("Update handler for 'UpdateCustomerNameChanged' not implemented yet");
+  }
+
+  @Override
+  public View.UpdateEffect<CustomerOrdersViewModel.ProductState> updateProduct(
+    CustomerOrdersViewModel.ProductState state, CustomerOrdersViewModel.ProductCreated productCreated) {
+    throw new UnsupportedOperationException("Update handler for 'UpdateProduct' not implemented yet");
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.java
@@ -14,17 +14,13 @@ public class CustomerOrdersView extends AbstractCustomerOrdersView {
   public CustomerOrdersView(ViewContext context) {}
 
   @Override
-  public Object emptyState() {
-    switch (updateContext().viewTable()) {
-      case "customers":
-        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'customers'");
+  public CustomerOrdersViewModel.CustomerState emptyCustomerState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'customers'");
+  }
 
-      case "products":
-        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'products'");
-
-      default:
-        return null;
-    }
+  @Override
+  public CustomerOrdersViewModel.ProductState emptyProductState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'products'");
   }
 
   @Override

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
@@ -1,0 +1,124 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.view;
+
+import "kalix/annotations.proto";
+
+option java_outer_classname = "CustomerOrdersViewModel";
+
+message CustomerOrdersRequest {
+  string customer_id = 1;
+}
+
+message CustomerOrder {
+  string order_id = 1;
+  string customer_id = 2;
+  string product_id = 3;
+  string product_name = 4;
+  int32 quantity = 5;
+  string name = 6;
+  string email = 7;
+}
+
+message CustomerCreated {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message CustomerNameChanged {
+  string customer_id = 1;
+  string new_name = 3;
+}
+
+message CustomerState {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message ProductCreated {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message ProductState {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message OrderState {
+  string order_id = 1;
+  string product_id = 2;
+  string customer_id = 3;
+  int32 quantity = 4;
+}
+
+service CustomerOrders {
+  option (kalix.codegen) = {
+    view: {}
+  };
+
+  rpc UpdateCustomerCreated(CustomerCreated) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateCustomerNameChanged(CustomerNameChanged) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateProduct(ProductCreated) returns (ProductState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "products"
+    };
+    option (kalix.method).view.update = {
+      table: "products",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateOrder(OrderState) returns (OrderState) {
+    option (kalix.method).eventing.in = {
+      value_entity: "orders"
+    };
+    option (kalix.method).view.update = {
+      table: "orders"
+    };
+  }
+
+  rpc Get(CustomerOrdersRequest) returns (stream CustomerOrder) {
+    option (kalix.method).view.query = {
+      query: "SELECT * "
+             "FROM customers "
+             "JOIN orders ON orders.customer_id = customers.customer_id "
+             "JOIN products ON products.product_id = orders.product_id "
+             "WHERE customers.customer_id = :customer_id"
+    };
+  }
+}

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/AbstractKalixGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/AbstractKalixGenerator.scala
@@ -28,7 +28,7 @@ import protocgen.{ CodeGenApp, CodeGenRequest, CodeGenResponse }
 abstract class AbstractKalixGenerator extends CodeGenApp {
   val enableDebug = "enableDebug"
   def rootPackage(packageName: String) = s"rootPackage=$packageName"
-  val rootPackageRegex = """rootPackage=(\w+)""".r
+  val rootPackageRegex = """rootPackage=([\w.]+)""".r
   def extractRootPackage(parameter: String): Option[String] =
     rootPackageRegex.findFirstMatchIn(parameter).map(found => found.group(1))
 

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
@@ -70,6 +70,10 @@ object ViewServiceSourceGenerator {
         }
       }
 
+    val viewTableCases = view.transformedUpdates.map { cmd =>
+      s"""case "${cmd.name}" => "${cmd.viewTable}""""
+    }
+
     File.scala(
       view.messageType.parent.scalaPackage,
       view.routerName,
@@ -92,6 +96,13 @@ object ViewServiceSourceGenerator {
         |
         |      case _ =>
         |        throw new UpdateHandlerNotFound(eventName)
+        |    }
+        |  }
+        |
+        |  override def viewTable(eventName: String, event: Any): String = {
+        |    eventName match {
+        |      ${Format.indent(viewTableCases, 6)}
+        |      case _ => ""
         |    }
         |  }
         |
@@ -172,7 +183,8 @@ object ViewServiceSourceGenerator {
       if (view.transformedUpdates.isEmpty)
         ""
       else {
-        val stateType = typeName(view.transformedUpdates.head.outputType)
+        val stateType =
+          if (view.transformedUpdates.size == 1) typeName(view.transformedUpdates.head.outputType) else "Any"
         s"""|  override def emptyState: $stateType =
             |    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
             |""".stripMargin

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.scala
@@ -6,9 +6,9 @@ import kalix.scalasdk.view.View
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-abstract class AbstractMyUserByNameView extends View[UserState] {
+abstract class AbstractMyUserByNameView extends View {
 
-  override def emptyState: UserState =
+  override def emptyState: Any =
     null // emptyState is only used with transform_updates=true
 
   

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.scala
@@ -24,7 +24,7 @@ class MyUserByNameViewProvider private(
     viewFactory: ViewCreationContext => MyUserByNameView,
     override val viewId: String,
     override val options: ViewOptions)
-  extends ViewProvider[UserState, MyUserByNameView] {
+  extends ViewProvider[MyUserByNameView] {
 
   /**
    * Use a custom view identifier. By default, the viewId is the same as the proto service name.

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.scala
@@ -9,12 +9,12 @@ import kalix.scalasdk.view.View
 // DO NOT EDIT
 
 class MyUserByNameViewRouter(view: MyUserByNameView)
-  extends ViewRouter[UserState, MyUserByNameView](view) {
+  extends ViewRouter[MyUserByNameView](view) {
 
-  override def handleUpdate(
+  override def handleUpdate[S](
       eventName: String,
-      state: UserState,
-      event: Any): View.UpdateEffect[UserState] = {
+      state: S,
+      event: Any): View.UpdateEffect[S] = {
 
     eventName match {
       

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.scala
@@ -24,4 +24,11 @@ class MyUserByNameViewRouter(view: MyUserByNameView)
     }
   }
 
+  override def viewTable(eventName: String, event: Any): String = {
+    eventName match {
+      
+      case _ => ""
+    }
+  }
+
 }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.scala
@@ -6,9 +6,9 @@ import kalix.scalasdk.view.View
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-abstract class AbstractUserByNameView extends View[UserState] {
+abstract class AbstractUserByNameView extends View {
 
-  override def emptyState: UserState =
+  override def emptyState: Any =
     null // emptyState is only used with transform_updates=true
 
   

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.scala
@@ -24,7 +24,7 @@ class UserByNameViewProvider private(
     viewFactory: ViewCreationContext => UserByNameView,
     override val viewId: String,
     override val options: ViewOptions)
-  extends ViewProvider[UserState, UserByNameView] {
+  extends ViewProvider[UserByNameView] {
 
   /**
    * Use a custom view identifier. By default, the viewId is the same as the proto service name.

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.scala
@@ -9,12 +9,12 @@ import kalix.scalasdk.view.View
 // DO NOT EDIT
 
 class UserByNameViewRouter(view: UserByNameView)
-  extends ViewRouter[UserState, UserByNameView](view) {
+  extends ViewRouter[UserByNameView](view) {
 
-  override def handleUpdate(
+  override def handleUpdate[S](
       eventName: String,
-      state: UserState,
-      event: Any): View.UpdateEffect[UserState] = {
+      state: S,
+      event: Any): View.UpdateEffect[S] = {
 
     eventName match {
       

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.scala
@@ -24,4 +24,11 @@ class UserByNameViewRouter(view: UserByNameView)
     }
   }
 
+  override def viewTable(eventName: String, event: Any): String = {
+    eventName match {
+      
+      case _ => ""
+    }
+  }
+
 }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.scala
@@ -6,9 +6,9 @@ import kalix.scalasdk.view.View
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-abstract class AbstractUserByNameView extends View[UserState] {
+abstract class AbstractUserByNameView extends View {
 
-  override def emptyState: UserState =
+  override def emptyState: Any =
     null // emptyState is only used with transform_updates=true
 
   

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.scala
@@ -24,7 +24,7 @@ class UserByNameViewProvider private(
     viewFactory: ViewCreationContext => UserByNameViewImpl,
     override val viewId: String,
     override val options: ViewOptions)
-  extends ViewProvider[UserState, UserByNameViewImpl] {
+  extends ViewProvider[UserByNameViewImpl] {
 
   /**
    * Use a custom view identifier. By default, the viewId is the same as the proto service name.

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.scala
@@ -24,4 +24,11 @@ class UserByNameViewRouter(view: UserByNameViewImpl)
     }
   }
 
+  override def viewTable(eventName: String, event: Any): String = {
+    eventName match {
+      
+      case _ => ""
+    }
+  }
+
 }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.scala
@@ -9,12 +9,12 @@ import kalix.scalasdk.view.View
 // DO NOT EDIT
 
 class UserByNameViewRouter(view: UserByNameViewImpl)
-  extends ViewRouter[UserState, UserByNameViewImpl](view) {
+  extends ViewRouter[UserByNameViewImpl](view) {
 
-  override def handleUpdate(
+  override def handleUpdate[S](
       eventName: String,
-      state: UserState,
-      event: Any): View.UpdateEffect[UserState] = {
+      state: S,
+      event: Any): View.UpdateEffect[S] = {
 
     eventName match {
       

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.scala
@@ -1,0 +1,24 @@
+package org.example
+
+
+
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+trait Components {
+ import Components._
+
+
+
+}
+
+object Components{
+
+
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.scala
@@ -1,0 +1,26 @@
+package org.example
+
+import kalix.scalasdk.Context
+import kalix.scalasdk.impl.InternalContext
+
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+final class ComponentsImpl(context: InternalContext) extends Components {
+
+  def this(context: Context) =
+    this(context.asInstanceOf[InternalContext])
+
+  private def getGrpcClient[T](serviceClass: Class[T]): T =
+    context.getComponentGrpcClient(serviceClass)
+
+
+
+
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.scala
@@ -1,0 +1,20 @@
+package org.example
+
+import kalix.scalasdk.Kalix
+import kalix.scalasdk.view.ViewCreationContext
+import org.example.view.CustomerOrdersView
+import org.example.view.CustomerOrdersViewProvider
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+object KalixFactory {
+
+  def withComponents(
+      createCustomerOrdersView: ViewCreationContext => CustomerOrdersView): Kalix = {
+    val kalix = Kalix()
+    kalix
+      .register(CustomerOrdersViewProvider(createCustomerOrdersView))
+  }
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.scala
@@ -1,0 +1,20 @@
+package org.example.view
+
+import kalix.scalasdk.view.View
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+abstract class AbstractCustomerOrdersView extends View {
+
+
+  def updateCustomerCreated(
+    state: CustomerState, customerCreated: CustomerCreated): View.UpdateEffect[CustomerState]
+
+  def updateCustomerNameChanged(
+    state: CustomerState, customerNameChanged: CustomerNameChanged): View.UpdateEffect[CustomerState]
+
+  def updateProduct(
+    state: ProductState, productCreated: ProductCreated): View.UpdateEffect[ProductState]
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.scala
@@ -8,6 +8,17 @@ import kalix.scalasdk.view.View
 
 abstract class AbstractCustomerOrdersView extends View {
 
+  override def emptyState: Any = {
+    updateContext().viewTable match {
+      case "customers" => emptyCustomerState
+      case "products" => emptyProductState
+      case _ => null
+    }
+  }
+
+  def emptyCustomerState: CustomerState
+
+  def emptyProductState: ProductState
 
   def updateCustomerCreated(
     state: CustomerState, customerCreated: CustomerCreated): View.UpdateEffect[CustomerState]

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.scala
@@ -1,0 +1,48 @@
+package org.example.view
+
+import com.google.protobuf.Descriptors
+import com.google.protobuf.EmptyProto
+import kalix.javasdk.impl.view.UpdateHandlerNotFound
+import kalix.scalasdk.impl.view.ViewRouter
+import kalix.scalasdk.view.View
+import kalix.scalasdk.view.ViewCreationContext
+import kalix.scalasdk.view.ViewOptions
+import kalix.scalasdk.view.ViewProvider
+
+import scala.collection.immutable.Seq
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+object CustomerOrdersViewProvider {
+  def apply(viewFactory: ViewCreationContext => CustomerOrdersView): CustomerOrdersViewProvider =
+    new CustomerOrdersViewProvider(viewFactory, viewId = "CustomerOrders", options = ViewOptions.defaults)
+}
+
+class CustomerOrdersViewProvider private(
+    viewFactory: ViewCreationContext => CustomerOrdersView,
+    override val viewId: String,
+    override val options: ViewOptions)
+  extends ViewProvider[CustomerOrdersView] {
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  def withViewId(viewId: String): CustomerOrdersViewProvider =
+    new CustomerOrdersViewProvider(viewFactory, viewId, options)
+
+  def withOptions(newOptions: ViewOptions): CustomerOrdersViewProvider =
+    new CustomerOrdersViewProvider(viewFactory, viewId, newOptions)
+
+  override final def serviceDescriptor: Descriptors.ServiceDescriptor =
+    CustomerOrdersProto.javaDescriptor.findServiceByName("CustomerOrders")
+
+  override final def newRouter(context: ViewCreationContext): CustomerOrdersViewRouter =
+    new CustomerOrdersViewRouter(viewFactory(context))
+
+  override final def additionalDescriptors: Seq[Descriptors.FileDescriptor] =
+    CustomerOrdersProto.javaDescriptor ::
+    Nil
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.scala
@@ -1,0 +1,52 @@
+package org.example.view
+
+import kalix.javasdk.impl.view.UpdateHandlerNotFound
+import kalix.scalasdk.impl.view.ViewRouter
+import kalix.scalasdk.view.View
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+class CustomerOrdersViewRouter(view: CustomerOrdersView)
+  extends ViewRouter[CustomerOrdersView](view) {
+
+  override def handleUpdate[S](
+      eventName: String,
+      state: S,
+      event: Any): View.UpdateEffect[S] = {
+
+    eventName match {
+      case "UpdateCustomerCreated" =>
+        view.updateCustomerCreated(
+          state.asInstanceOf[CustomerState],
+          event.asInstanceOf[CustomerCreated]
+        ).asInstanceOf[View.UpdateEffect[S]]
+
+      case "UpdateCustomerNameChanged" =>
+        view.updateCustomerNameChanged(
+          state.asInstanceOf[CustomerState],
+          event.asInstanceOf[CustomerNameChanged]
+        ).asInstanceOf[View.UpdateEffect[S]]
+
+      case "UpdateProduct" =>
+        view.updateProduct(
+          state.asInstanceOf[ProductState],
+          event.asInstanceOf[ProductCreated]
+        ).asInstanceOf[View.UpdateEffect[S]]
+
+      case _ =>
+        throw new UpdateHandlerNotFound(eventName)
+    }
+  }
+
+  override def viewTable(eventName: String, event: Any): String = {
+    eventName match {
+      case "UpdateCustomerCreated" => "customers"
+      case "UpdateCustomerNameChanged" => "customers"
+      case "UpdateProduct" => "products"
+      case _ => ""
+    }
+  }
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.scala
@@ -1,0 +1,29 @@
+package org.example
+
+import kalix.scalasdk.Kalix
+import org.example.view.CustomerOrdersView
+import org.slf4j.LoggerFactory
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+object Main {
+
+  private val log = LoggerFactory.getLogger("org.example.Main")
+
+  def createKalix(): Kalix = {
+    // The KalixFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `Kalix()` instance.
+    KalixFactory.withComponents(
+      new CustomerOrdersView(_))
+  }
+
+  def main(args: Array[String]): Unit = {
+    log.info("starting the Kalix service")
+    createKalix().start()
+  }
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.scala
@@ -1,0 +1,34 @@
+package org.example.view
+
+import kalix.scalasdk.view.View.UpdateEffect
+import kalix.scalasdk.view.ViewContext
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+class CustomerOrdersView(context: ViewContext) extends AbstractCustomerOrdersView {
+
+  override def emptyState: Any = {
+    updateContext.viewTable match {
+      case "customers" =>
+        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'customers'");
+      case "products" =>
+        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'products'");
+      case _ => null
+    }
+  }
+
+  override def updateCustomerCreated(
+    state: CustomerState, customerCreated: CustomerCreated): UpdateEffect[CustomerState] =
+    throw new UnsupportedOperationException("Update handler for 'UpdateCustomerCreated' not implemented yet")
+
+  override def updateCustomerNameChanged(
+    state: CustomerState, customerNameChanged: CustomerNameChanged): UpdateEffect[CustomerState] =
+    throw new UnsupportedOperationException("Update handler for 'UpdateCustomerNameChanged' not implemented yet")
+
+  override def updateProduct(
+    state: ProductState, productCreated: ProductCreated): UpdateEffect[ProductState] =
+    throw new UnsupportedOperationException("Update handler for 'UpdateProduct' not implemented yet")
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.scala
@@ -10,15 +10,11 @@ import kalix.scalasdk.view.ViewContext
 
 class CustomerOrdersView(context: ViewContext) extends AbstractCustomerOrdersView {
 
-  override def emptyState: Any = {
-    updateContext.viewTable match {
-      case "customers" =>
-        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'customers'");
-      case "products" =>
-        throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'products'");
-      case _ => null
-    }
-  }
+  override def emptyCustomerState: CustomerState =
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'customers'");
+
+  override def emptyProductState: ProductState =
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state for 'products'");
 
   override def updateCustomerCreated(
     state: CustomerState, customerCreated: CustomerCreated): UpdateEffect[CustomerState] =

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
@@ -1,0 +1,122 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.view;
+
+import "kalix/annotations.proto";
+
+message CustomerOrdersRequest {
+  string customer_id = 1;
+}
+
+message CustomerOrder {
+  string order_id = 1;
+  string customer_id = 2;
+  string product_id = 3;
+  string product_name = 4;
+  int32 quantity = 5;
+  string name = 6;
+  string email = 7;
+}
+
+message CustomerCreated {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message CustomerNameChanged {
+  string customer_id = 1;
+  string new_name = 3;
+}
+
+message CustomerState {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message ProductCreated {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message ProductState {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message OrderState {
+  string order_id = 1;
+  string product_id = 2;
+  string customer_id = 3;
+  int32 quantity = 4;
+}
+
+service CustomerOrders {
+  option (kalix.codegen) = {
+    view: {}
+  };
+
+  rpc UpdateCustomerCreated(CustomerCreated) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateCustomerNameChanged(CustomerNameChanged) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateProduct(ProductCreated) returns (ProductState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "products"
+    };
+    option (kalix.method).view.update = {
+      table: "products",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateOrder(OrderState) returns (OrderState) {
+    option (kalix.method).eventing.in = {
+      value_entity: "orders"
+    };
+    option (kalix.method).view.update = {
+      table: "orders"
+    };
+  }
+
+  rpc Get(CustomerOrdersRequest) returns (stream CustomerOrder) {
+    option (kalix.method).view.query = {
+      query: "SELECT * "
+             "FROM customers "
+             "JOIN orders ON orders.customer_id = customers.customer_id "
+             "JOIN products ON products.product_id = orders.product_id "
+             "WHERE customers.customer_id = :customer_id"
+    };
+  }
+}

--- a/samples/spring-customer-registry-views-quickstart/src/main/java/customer/view/CustomerByEmailView.java
+++ b/samples/spring-customer-registry-views-quickstart/src/main/java/customer/view/CustomerByEmailView.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @ViewId("view_customers_by_email")
 @Table("customers_by_email")
 @Subscribe.ValueEntity(CustomerEntity.class)
-public class CustomerByEmailView extends View<Customer> {
+public class CustomerByEmailView extends View {
 
   @GetMapping("/customer/by_email/{email}")
   @Query("SELECT * FROM customers_by_email WHERE email = :email")

--- a/samples/spring-customer-registry-views-quickstart/src/main/java/customer/view/CustomerByNameView.java
+++ b/samples/spring-customer-registry-views-quickstart/src/main/java/customer/view/CustomerByNameView.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @ViewId("view_customers_by_name") // <1>
 @Table("customers_by_name")  // <2>
 @Subscribe.ValueEntity(CustomerEntity.class) // <3>
-public class CustomerByNameView extends View<Customer> { // <4>
+public class CustomerByNameView extends View { // <4>
 
   @GetMapping("/customer/by_name/{customer_name}")   // <5>
   @Query("SELECT * FROM customers_by_name WHERE name = :customer_name") // <6>

--- a/samples/spring-eventsourced-customer-registry-subscriber/src/main/java/customer/views/CustomersByNameView.java
+++ b/samples/spring-eventsourced-customer-registry-subscriber/src/main/java/customer/views/CustomersByNameView.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Flux;
     // tag::view[]
     id = "customer_events" // <3>
 )
-public class CustomersByNameView extends View<Customer> {
+public class CustomersByNameView extends View {
 
   public UpdateEffect<Customer> onEvent( // <4>
       CustomerPublicEvent.Created created) {
@@ -35,7 +35,7 @@ public class CustomersByNameView extends View<Customer> {
 
   public UpdateEffect<Customer> onEvent(
       CustomerPublicEvent.NameChanged nameChanged) {
-    var updated = viewState().withName(nameChanged.newName());
+    var updated = ((Customer) viewState()).withName(nameChanged.newName());
     return effects().updateState(updated);
   }
 

--- a/samples/spring-eventsourced-customer-registry/src/main/java/customer/view/CustomerByEmailView.java
+++ b/samples/spring-eventsourced-customer-registry/src/main/java/customer/view/CustomerByEmailView.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @ViewId("view_customers_by_email")
 @Table("customers_by_email")
-public class CustomerByEmailView extends View<CustomerView> {
+public class CustomerByEmailView extends View {
 
   @GetMapping("/customer/by_email/{email}")
   @Query("SELECT * FROM customers_by_email WHERE email = :email")
@@ -28,11 +28,11 @@ public class CustomerByEmailView extends View<CustomerView> {
 
   @Subscribe.EventSourcedEntity(CustomerEntity.class)
   public UpdateEffect<CustomerView> onEvent(CustomerEvent.NameChanged event) {
-    return effects().updateState(viewState().withName(event.newName()));
+    return effects().updateState(((CustomerView) viewState()).withName(event.newName()));
   }
 
   @Subscribe.EventSourcedEntity(CustomerEntity.class)
   public UpdateEffect<CustomerView> onEvent(CustomerEvent.AddressChanged event) {
-    return effects().updateState(viewState().withAddress(event.address()));
+    return effects().updateState(((CustomerView) viewState()).withAddress(event.address()));
   }
 }

--- a/samples/spring-eventsourced-customer-registry/src/main/java/customer/view/CustomerByNameView.java
+++ b/samples/spring-eventsourced-customer-registry/src/main/java/customer/view/CustomerByNameView.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @ViewId("view_customers_by_name") // <1>
 @Table("customers_by_name")
-public class CustomerByNameView extends View<CustomerView> {
+public class CustomerByNameView extends View {
 
   @GetMapping("/customer/by_name/{customer_name}")
   @Query("SELECT * FROM customers_by_name WHERE name = :customer_name")
@@ -29,12 +29,12 @@ public class CustomerByNameView extends View<CustomerView> {
 
   @Subscribe.EventSourcedEntity(CustomerEntity.class)
   public UpdateEffect<CustomerView> onEvent(CustomerEvent.NameChanged event) {
-    return effects().updateState(viewState().withName(event.newName())); // <2>
+    return effects().updateState(((CustomerView) viewState()).withName(event.newName())); // <2>
   }
 
   @Subscribe.EventSourcedEntity(CustomerEntity.class)
   public UpdateEffect<CustomerView> onEvent(CustomerEvent.AddressChanged event) {
-    return effects().updateState(viewState().withAddress(event.address()));
+    return effects().updateState(((CustomerView) viewState()).withAddress(event.address()));
   }
 }
 // end::class[]

--- a/samples/spring-valueentity-customer-registry/src/main/java/com/example/view/CustomerSummaryByName.java
+++ b/samples/spring-valueentity-customer-registry/src/main/java/com/example/view/CustomerSummaryByName.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @ViewId("view_summary_customer_by_name")
 // tag::class[]
 @Table("customers")
-public class CustomerSummaryByName extends View<CustomerSummary> { // <1>
+public class CustomerSummaryByName extends View { // <1>
 
   @Subscribe.ValueEntity(CustomerEntity.class) // <2>
   public UpdateEffect<CustomerSummary> onChange(Customer customer) { // <3>

--- a/samples/spring-valueentity-customer-registry/src/main/java/com/example/view/CustomersResponseByName.java
+++ b/samples/spring-valueentity-customer-registry/src/main/java/com/example/view/CustomersResponseByName.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Table("customers_by_name")
 // tag::class[]
 @Subscribe.ValueEntity(CustomerEntity.class)
-public class CustomersResponseByName extends View<Customer> { // <1>
+public class CustomersResponseByName extends View { // <1>
 
   @GetMapping("/wrapped/by_name/{customerName}")   // <2>
   @Query("SELECT * AS results FROM customers_by_name WHERE name = :customerName") // <3>

--- a/samples/spring-valueentity-customer-registry/src/main/java/com/example/view/CustomersStreamByName.java
+++ b/samples/spring-valueentity-customer-registry/src/main/java/com/example/view/CustomersStreamByName.java
@@ -15,7 +15,7 @@ import reactor.core.publisher.Flux;
 // tag::class[]
 @Table("customers")
 @Subscribe.ValueEntity(CustomerEntity.class)
-public class CustomersStreamByName extends View<Customer> { // <1>
+public class CustomersStreamByName extends View { // <1>
 
   @GetMapping("/summary/by_name/{customerName}")   // <2>
   @Query(

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/Kalix.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/Kalix.java
@@ -460,7 +460,7 @@ public final class Kalix {
    *
    * @return This stateful service builder.
    */
-  public Kalix register(ViewProvider<?, ?> provider) {
+  public Kalix register(ViewProvider<?> provider) {
     return provider
         .alternativeCodec()
         .map(

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/impl/ViewFactory.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/impl/ViewFactory.java
@@ -32,5 +32,5 @@ public interface ViewFactory {
    * @param context The context.
    * @return The handler for the given context.
    */
-  ViewRouter<?, ?> create(ViewCreationContext context);
+  ViewRouter<?> create(ViewCreationContext context);
 }

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/view/UpdateContext.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/view/UpdateContext.java
@@ -32,4 +32,7 @@ public interface UpdateContext extends ViewContext, MetadataContext {
 
   /** The name of the event being handled. */
   String eventName();
+
+  /** The view table being updated. */
+  String viewTable();
 }

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/view/ViewProvider.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/view/ViewProvider.java
@@ -22,7 +22,7 @@ import com.google.protobuf.Descriptors;
 
 import java.util.Optional;
 
-public interface ViewProvider<S, V extends View<S>> {
+public interface ViewProvider<V extends View> {
 
   Descriptors.ServiceDescriptor serviceDescriptor();
 
@@ -30,7 +30,7 @@ public interface ViewProvider<S, V extends View<S>> {
 
   ViewOptions options();
 
-  ViewRouter<S, V> newRouter(ViewCreationContext context);
+  ViewRouter<V> newRouter(ViewCreationContext context);
 
   Descriptors.FileDescriptor[] additionalDescriptors();
 

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewEffectImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewEffectImpl.scala
@@ -25,12 +25,12 @@ object ViewUpdateEffectImpl {
   case object Ignore extends PrimaryUpdateEffect[Any]
   case class Error[T](description: String) extends PrimaryUpdateEffect[T]
 
-  private val _builder = new View.UpdateEffect.Builder[Any] {
-    override def updateState(newState: Any): View.UpdateEffect[Any] = Update(newState)
-    override def deleteState(): View.UpdateEffect[Any] = Delete.asInstanceOf[PrimaryUpdateEffect[Any]]
-    override def ignore(): View.UpdateEffect[Any] = Ignore.asInstanceOf[PrimaryUpdateEffect[Any]]
-    override def error(description: String): View.UpdateEffect[Any] = Error(description)
+  private val _builder = new View.UpdateEffect.Builder {
+    override def updateState[S](newState: S): View.UpdateEffect[S] = Update(newState)
+    override def deleteState[S](): View.UpdateEffect[S] = Delete.asInstanceOf[PrimaryUpdateEffect[S]]
+    override def ignore[S](): View.UpdateEffect[S] = Ignore.asInstanceOf[PrimaryUpdateEffect[S]]
+    override def error[S](description: String): View.UpdateEffect[S] = Error(description)
   }
-  def builder[S](): View.UpdateEffect.Builder[S] =
-    _builder.asInstanceOf[View.UpdateEffect.Builder[S]]
+
+  def builder(): View.UpdateEffect.Builder = _builder
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewRouter.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewRouter.scala
@@ -42,4 +42,6 @@ abstract class ViewRouter[V <: View](protected val view: V) {
 
   def handleUpdate[S](commandName: String, state: S, event: Any): View.UpdateEffect[S]
 
+  def viewTable(commandName: String, event: Any): String
+
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewRouter.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewRouter.scala
@@ -20,16 +20,13 @@ import kalix.javasdk.view.{ UpdateContext, View }
 
 import java.util.Optional
 
-abstract class ViewRouter[S, V <: View[S]](protected val view: V) {
+abstract class ViewRouter[V <: View](protected val view: V) {
 
   /** INTERNAL API */
   final def _internalHandleUpdate(state: Option[Any], event: Any, context: UpdateContext): View.UpdateEffect[_] = {
-    val stateOrEmpty: S = state match {
-      case Some(preExisting) => preExisting.asInstanceOf[S]
-      case None              => view.emptyState()
-    }
     try {
       view._internalSetUpdateContext(Optional.of(context))
+      val stateOrEmpty: Any = state.getOrElse(view.emptyState())
       handleUpdate(context.eventName(), stateOrEmpty, event)
     } catch {
       case missing: UpdateHandlerNotFound =>
@@ -43,6 +40,6 @@ abstract class ViewRouter[S, V <: View[S]](protected val view: V) {
     }
   }
 
-  def handleUpdate(commandName: String, state: S, event: Any): View.UpdateEffect[S]
+  def handleUpdate[S](commandName: String, state: S, event: Any): View.UpdateEffect[S]
 
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
@@ -96,9 +96,7 @@ final class ViewsImpl(system: ActorSystem, _services: Map[String, ViewService], 
                   "and not reach the user function")
 
               // FIXME should we really create a new handler instance per incoming command ???
-              val handler = service.factory.get
-                .create(new ViewContextImpl(service.viewId))
-                .asInstanceOf[ViewRouter[Any, View[Any]]]
+              val handler = service.factory.get.create(new ViewContextImpl(service.viewId))
 
               val state: Option[Any] =
                 receiveEvent.bySubjectLookupResult.flatMap(row =>

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
@@ -104,8 +104,9 @@ final class ViewsImpl(system: ActorSystem, _services: Map[String, ViewService], 
 
               val commandName = receiveEvent.commandName
               val msg = service.messageCodec.decodeMessage(receiveEvent.payload.get)
+              val viewTable = handler.viewTable(commandName, msg)
               val metadata = new MetadataImpl(receiveEvent.metadata.map(_.entries.toVector).getOrElse(Nil))
-              val context = new UpdateContextImpl(service.viewId, commandName, metadata)
+              val context = new UpdateContextImpl(service.viewId, viewTable, commandName, metadata)
 
               val effect =
                 try {
@@ -156,6 +157,7 @@ final class ViewsImpl(system: ActorSystem, _services: Map[String, ViewService], 
 
   private final class UpdateContextImpl(
       override val viewId: String,
+      override val viewTable: String,
       override val eventName: String,
       override val metadata: Metadata)
       extends AbstractContext(system)

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/Kalix.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/Kalix.scala
@@ -137,7 +137,7 @@ class Kalix private (private[kalix] val delegate: javasdk.Kalix) {
    * @return
    *   This stateful service builder.
    */
-  def register[S, V <: View[S]](provider: ViewProvider[S, V]): Kalix =
+  def register[V <: View](provider: ViewProvider[V]): Kalix =
     Kalix(delegate.register(new JavaViewProviderAdapter(provider)))
 
   /**

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewAdapters.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewAdapters.scala
@@ -66,6 +66,8 @@ private[scalasdk] class JavaViewRouterAdapter[V <: View](javaSdkView: javasdk.vi
       case effect: ViewUpdateEffectImpl.PrimaryUpdateEffect[S] => effect.toJavaSdk
     }
   }
+
+  override def viewTable(commandName: String, event: Any): String = scalaSdkHandler.viewTable(commandName, event)
 }
 
 private[scalasdk] final class ScalaViewCreationContextAdapter(javaSdkContext: javasdk.view.ViewCreationContext)
@@ -89,6 +91,9 @@ private[scalasdk] final class ScalaUpdateContextAdapter(val javaSdkContext: java
 
   override def viewId: String =
     javaSdkContext.viewId()
+
+  override def viewTable: String =
+    javaSdkContext.viewTable()
 
   override def materializer(): Materializer = javaSdkContext.materializer()
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewRouter.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewRouter.scala
@@ -23,4 +23,5 @@ import kalix.scalasdk.view.View
  */
 abstract class ViewRouter[V <: View](val view: V) {
   def handleUpdate[S](commandName: String, state: S, event: Any): View.UpdateEffect[S]
+  def viewTable(commandName: String, event: Any): String
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewRouter.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewRouter.scala
@@ -21,6 +21,6 @@ import kalix.scalasdk.view.View
 /**
  * INTERNAL API, but used by generated code.
  */
-abstract class ViewRouter[S, V <: View[S]](val view: V) {
-  def handleUpdate(commandName: String, state: S, event: Any): View.UpdateEffect[S]
+abstract class ViewRouter[V <: View](val view: V) {
+  def handleUpdate[S](commandName: String, state: S, event: Any): View.UpdateEffect[S]
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/UpdateContext.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/UpdateContext.scala
@@ -29,4 +29,7 @@ trait UpdateContext extends ViewContext with MetadataContext {
 
   /** The name of the event being handled. */
   def eventName: String
+
+  /** The view table being updated. */
+  def viewTable: String
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/ViewProvider.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/ViewProvider.scala
@@ -21,14 +21,14 @@ import scala.collection.immutable.Seq
 
 import kalix.scalasdk.impl.view.ViewRouter
 
-trait ViewProvider[S, V <: View[S]] {
+trait ViewProvider[V <: View] {
   def serviceDescriptor: Descriptors.ServiceDescriptor
 
   def viewId: String
 
   def options: ViewOptions
 
-  def newRouter(context: ViewCreationContext): ViewRouter[S, V]
+  def newRouter(context: ViewCreationContext): ViewRouter[V]
 
   def additionalDescriptors: Seq[Descriptors.FileDescriptor]
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/views/CountersByValue.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/views/CountersByValue.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Table("counters_by_value")
-public class CountersByValue extends View<Counter> {
+public class CountersByValue extends View {
 
   @Override
   public Counter emptyState() {
@@ -40,13 +40,13 @@ public class CountersByValue extends View<Counter> {
 
   @Subscribe.EventSourcedEntity(CounterEntity.class)
   public UpdateEffect<Counter> onEvent(CounterEvent.ValueIncreased event) {
-    Counter counter = viewState();
+    Counter counter = (Counter) viewState();
     return effects().updateState(counter.onValueIncreased(event));
   }
 
   @Subscribe.EventSourcedEntity(CounterEntity.class)
   public UpdateEffect<Counter> onEvent(CounterEvent.ValueMultiplied event) {
-    Counter counter = viewState();
+    Counter counter = (Counter) viewState();
     return effects().updateState(counter.onValueMultiplied(event));
   }
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/views/CountersByValueSubscriptions.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/views/CountersByValueSubscriptions.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Flux;
 
 // With Multiple Subscriptions
 @Table("counters_by_value_ms")
-public class CountersByValueSubscriptions extends View<Counter> {
+public class CountersByValueSubscriptions extends View {
 
   @Override
   public Counter emptyState() {
@@ -42,11 +42,11 @@ public class CountersByValueSubscriptions extends View<Counter> {
 
   @Subscribe.EventSourcedEntity(CounterEntity.class)
   public UpdateEffect<Counter> onEvent(CounterEvent.ValueIncreased event) {
-    return effects().updateState(viewState().onValueIncreased(event));
+    return effects().updateState(((Counter) viewState()).onValueIncreased(event));
   }
 
   @Subscribe.EventSourcedEntity(CounterEntity.class)
   public UpdateEffect<Counter> onEvent(CounterEvent.ValueMultiplied event) {
-    return effects().updateState(viewState().onValueMultiplied(event));
+    return effects().updateState(((Counter) viewState()).onValueMultiplied(event));
   }
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/views/CountersByValueWithIgnore.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/views/CountersByValueWithIgnore.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 @Table("counters_by_value_with_ignore")
 @Subscribe.EventSourcedEntity(value = CounterEntity.class, ignoreUnknown = true)
-public class CountersByValueWithIgnore extends View<Counter> {
+public class CountersByValueWithIgnore extends View {
 
   @Override
   public Counter emptyState() {
@@ -40,7 +40,7 @@ public class CountersByValueWithIgnore extends View<Counter> {
   }
 
   public UpdateEffect<Counter> onValueIncreased(CounterEvent.ValueIncreased event){
-    Counter counter = viewState();
+    Counter counter = (Counter) viewState();
     return effects().updateState(counter.onValueIncreased(event));
   }
 }

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/views/UserWithVersionView.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/views/UserWithVersionView.java
@@ -26,12 +26,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Table("user_view")
-public class UserWithVersionView extends View<UserWithVersion> {
+public class UserWithVersionView extends View {
 
   @Subscribe.ValueEntity(UserEntity.class)
   public UpdateEffect<UserWithVersion> onChange(User user) {
     if (viewState() == null) return effects().updateState(new UserWithVersion(user.email, 1));
-    else return effects().updateState(new UserWithVersion(user.email, viewState().version + 1));
+    else return effects().updateState(new UserWithVersion(user.email, ((UserWithVersion) viewState()).version + 1));
   }
 
   @Subscribe.ValueEntity(value = UserEntity.class, handleDeletes = true)

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/views/UsersByEmail.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/views/UsersByEmail.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Table("users_by_email")
 @Subscribe.ValueEntity(UserEntity.class)
-public class UsersByEmail extends View<User> {
+public class UsersByEmail extends View {
 
   @GetMapping("/users/by_email/{email}")
   @Query("SELECT * FROM users_by_email WHERE email = :email")

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/views/UsersByName.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/views/UsersByName.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Flux;
 
 @Table("users_by_name")
 @Subscribe.ValueEntity(value = UserEntity.class, handleDeletes = true)
-public class UsersByName extends View<User> {
+public class UsersByName extends View {
 
   @GetMapping("/users/by-name/{name}")
   @Query("SELECT * FROM users_by_name WHERE name = :name")

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Table.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Table.java
@@ -19,7 +19,7 @@ package kalix.springsdk.annotations;
 import java.lang.annotation.*;
 
 /** Annotation for providing a table name for View-type Kalix components. */
-@Target({ElementType.TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Table {

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/view/ReflectiveViewProvider.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/view/ReflectiveViewProvider.java
@@ -32,7 +32,7 @@ import kalix.springsdk.impl.view.ReflectiveViewRouter;
 import java.util.Optional;
 import java.util.function.Function;
 
-public class ReflectiveViewProvider<S, V extends View<S>> implements ViewProvider<S, V> {
+public class ReflectiveViewProvider<V extends View> implements ViewProvider<V> {
   private final Function<ViewCreationContext, V> factory;
 
   private final String viewId;
@@ -44,7 +44,7 @@ public class ReflectiveViewProvider<S, V extends View<S>> implements ViewProvide
 
   private final SpringSdkMessageCodec messageCodec;
 
-  public static <S, V extends View<S>> ReflectiveViewProvider<S, V> of(
+  public static <V extends View> ReflectiveViewProvider<V> of(
       Class<V> cls, SpringSdkMessageCodec messageCodec, Function<ViewCreationContext, V> factory) {
 
     String viewId =
@@ -88,7 +88,7 @@ public class ReflectiveViewProvider<S, V extends View<S>> implements ViewProvide
   }
 
   @Override
-  public ViewRouter<S, V> newRouter(ViewCreationContext context) {
+  public ViewRouter<V> newRouter(ViewCreationContext context) {
     V view = factory.apply(context);
     return new ReflectiveViewRouter<>(view, componentDescriptor.commandHandlers(), ComponentDescriptorFactory.findIgnore(view.getClass()));
   }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixServer.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixServer.scala
@@ -73,7 +73,7 @@ object KalixServer {
     classOf[EventSourcedEntity[_]] ::
     classOf[ValueEntity[_]] ::
     classOf[ReplicatedEntity[_]] ::
-    classOf[View[_]] ::
+    classOf[View] ::
     Nil
 
   private val kalixComponentsNames = kalixComponents.map(_.getName)
@@ -248,9 +248,9 @@ case class KalixServer(applicationContext: ApplicationContext, config: Config) {
         kalixClient.registerComponent(valueEntity.serviceDescriptor())
       }
 
-      if (classOf[View[_]].isAssignableFrom(clz)) {
+      if (classOf[View].isAssignableFrom(clz)) {
         logger.info(s"Registering View provider for [${clz.getName}]")
-        val view = viewProvider(clz.asInstanceOf[Class[View[Nothing]]])
+        val view = viewProvider(clz.asInstanceOf[Class[View]])
         kalix.register(view)
         kalixClient.registerComponent(view.serviceDescriptor())
       }
@@ -325,7 +325,7 @@ case class KalixServer(applicationContext: ApplicationContext, config: Config) {
         kalixBeanFactory.getBean(clz)
       })
 
-  private def viewProvider[S, V <: View[S]](clz: Class[V]): ViewProvider[S, V] =
+  private def viewProvider[V <: View](clz: Class[V]): ViewProvider[V] =
     ReflectiveViewProvider.of(
       clz,
       messageCodec,

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/view/ReflectiveViewRouter.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/view/ReflectiveViewRouter.scala
@@ -25,6 +25,7 @@ import kalix.javasdk.impl.view.ViewRouter
 import kalix.javasdk.impl.view.ViewUpdateEffectImpl
 import kalix.javasdk.view.View
 import kalix.springsdk.impl.CommandHandler
+import kalix.springsdk.impl.ComponentDescriptorFactory.findTableName
 import kalix.springsdk.impl.InvocationContext
 
 class ReflectiveViewRouter[V <: View](view: V, commandHandlers: Map[String, CommandHandler], ignoreUnknown: Boolean)
@@ -80,4 +81,10 @@ class ReflectiveViewRouter[V <: View](view: V, commandHandlers: Map[String, Comm
     }
   }
 
+  override def viewTable(commandName: String, event: Any): String = {
+    commandHandlerLookup(commandName).lookupInvoker(event.asInstanceOf[ScalaPbAny].typeUrl) match {
+      case Some(invoker) => findTableName(view.getClass, invoker.method)
+      case None          => ""
+    }
+  }
 }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/badwiring/view/IllDefinedView.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/badwiring/view/IllDefinedView.java
@@ -22,4 +22,4 @@ import org.springframework.stereotype.Component;
 
 @Table("test")
 @Component
-public class IllDefinedView extends View<String> {}
+public class IllDefinedView extends View {}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/subscriptions/PubSubTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/subscriptions/PubSubTestModels.java
@@ -206,7 +206,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
 
   @Table(value = "employee_table")
   @Subscribe.EventSourcedEntity(value = EmployeeEntity.class, ignoreUnknown = true)
-  public static class SubscribeOnTypeToEventSourcedEvents extends View<Employee> {
+  public static class SubscribeOnTypeToEventSourcedEvents extends View {
 
       public UpdateEffect<Employee> onCreate(EmployeeEvent.EmployeeCreated evt) {
         return effects()
@@ -214,7 +214,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
       }
 
       public UpdateEffect<Employee> onEmailUpdate(EmployeeEvent.EmployeeEmailUpdated eeu) {
-        var employee = viewState();
+        var employee = (Employee) viewState();
         return effects().updateState(new Employee(employee.firstName, employee.lastName, eeu.email));
       }
 
@@ -254,7 +254,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
 
     @Table(value = "employee_table")
     @Subscribe.Stream(service = "employee_service", id = "employee_events")
-    public static class EventStreamSubscriptionView extends View<Employee> {
+    public static class EventStreamSubscriptionView extends View {
 
       public UpdateEffect<Employee> onCreate(EmployeeEvent.EmployeeCreated evt) {
         return effects()
@@ -262,7 +262,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
       }
 
       public UpdateEffect<Employee> onEmailUpdate(EmployeeEvent.EmployeeEmailUpdated eeu) {
-        var employee = viewState();
+        var employee = (Employee) viewState();
         return effects().updateState(new Employee(employee.firstName, employee.lastName, eeu.email));
       }
 

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/view/ViewTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/view/ViewTestModels.java
@@ -35,7 +35,7 @@ public class ViewTestModels {
   @Table(value = "users_view")
   @Subscribe.ValueEntity(
       UserEntity.class) // when types are annotated, it's implicitly a transform = false
-  public static class UserByEmailWithGet extends View<User> {
+  public static class UserByEmailWithGet extends View {
 
     @Query("SELECT * FROM users_view WHERE email = :email")
     @GetMapping("/users/{email}")
@@ -51,7 +51,7 @@ public class ViewTestModels {
 
   @Table(value = "users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class UserByEmailWithPost extends View<User> {
+  public static class UserByEmailWithPost extends View {
 
     @Query("SELECT * FROM users_view WHERE email = :email")
     @PostMapping("/users/by-email")
@@ -62,7 +62,7 @@ public class ViewTestModels {
 
   @Table(value = "users_view")
   @Subscribe.ValueEntity(value = UserEntity.class, handleDeletes = true)
-  public static class UserByNameEmailWithPost extends View<User> {
+  public static class UserByNameEmailWithPost extends View {
 
     // mixing request body and path variable
     @Query("SELECT * FROM users_view WHERE email = :email")
@@ -73,7 +73,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class TransformedUserView extends View<TransformedUser> {
+  public static class TransformedUserView extends View {
 
     // when methods are annotated, it's implicitly a transform = true
     @Subscribe.ValueEntity(UserEntity.class)
@@ -90,7 +90,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class TransformedUserViewWithDeletes extends View<TransformedUser> {
+  public static class TransformedUserViewWithDeletes extends View {
 
     @Subscribe.ValueEntity(UserEntity.class)
     public UpdateEffect<TransformedUser> onChange(User user) {
@@ -111,7 +111,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class TransformedUserViewWithJWT extends View<TransformedUser> {
+  public static class TransformedUserViewWithJWT extends View {
 
     // when methods are annotated, it's implicitly a transform = true
     @Subscribe.ValueEntity(UserEntity.class)
@@ -132,7 +132,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class TransformedUserViewUsingState extends View<TransformedUser> {
+  public static class TransformedUserViewUsingState extends View {
 
     // when methods are annotated, it's implicitly a transform = true
     @Subscribe.ValueEntity(UserEntity.class)
@@ -154,7 +154,7 @@ public class ViewTestModels {
    */
   @Table("users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class ViewWithSubscriptionsInMixedLevels extends View<TransformedUser> {
+  public static class ViewWithSubscriptionsInMixedLevels extends View {
 
     // when methods are annotated, it's implicitly a transform = true
     @Subscribe.ValueEntity(UserEntity.class)
@@ -172,7 +172,7 @@ public class ViewTestModels {
 
   @Table("users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class ViewWithSubscriptionsInMixedLevelsHandleDelete extends View<User> {
+  public static class ViewWithSubscriptionsInMixedLevelsHandleDelete extends View {
 
     @Subscribe.ValueEntity(value = UserEntity.class, handleDeletes = true)
     public UpdateEffect<User> onDelete() {
@@ -187,7 +187,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class ViewWithoutSubscriptionButWithHandleDelete extends View<TransformedUser> {
+  public static class ViewWithoutSubscriptionButWithHandleDelete extends View {
 
     @Subscribe.ValueEntity(value = UserEntity.class, handleDeletes = true)
     public UpdateEffect<TransformedUser> onDelete() {
@@ -202,7 +202,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class ViewDuplicatedHandleDeletesAnnotations extends View<TransformedUser> {
+  public static class ViewDuplicatedHandleDeletesAnnotations extends View {
 
     @Subscribe.ValueEntity(UserEntity.class)
     public UpdateEffect<TransformedUser> onChange(User user) {
@@ -228,7 +228,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class ViewWithHandleDeletesFalseOnMethodLevel extends View<TransformedUser> {
+  public static class ViewWithHandleDeletesFalseOnMethodLevel extends View {
 
     @Subscribe.ValueEntity(UserEntity.class)
     public UpdateEffect<TransformedUser> onChange(User user) {
@@ -249,7 +249,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class ViewDuplicatedSubscriptions extends View<TransformedUser> {
+  public static class ViewDuplicatedSubscriptions extends View {
 
     @Subscribe.ValueEntity(UserEntity.class)
     public UpdateEffect<TransformedUser> onChange(User user) {
@@ -276,7 +276,7 @@ public class ViewTestModels {
   }
 
   @Table("users_view")
-  public static class ViewWithMissingSubscriptionForHandleDeletes extends View<TransformedUser> {
+  public static class ViewWithMissingSubscriptionForHandleDeletes extends View {
 
     @Subscribe.ValueEntity(UserEntity.class)
     public UpdateEffect<TransformedUser> onChange(User user) {
@@ -305,11 +305,11 @@ public class ViewTestModels {
 
   @Table("users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class ViewWithNoQuery extends View<TransformedUser> {}
+  public static class ViewWithNoQuery extends View {}
 
   @Table("users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class ViewWithTwoQueries extends View<TransformedUser> {
+  public static class ViewWithTwoQueries extends View {
 
     @Query("SELECT * FROM users_view WHERE email = :email")
     @PostMapping("/users/by-email")
@@ -327,7 +327,7 @@ public class ViewTestModels {
 
   @Table(value = "users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class UserByEmailWithPostRequestBodyOnly extends View<User> {
+  public static class UserByEmailWithPostRequestBodyOnly extends View {
 
     // not path variables, only request body
     @Query("SELECT * FROM users_view WHERE email = :email")
@@ -339,7 +339,7 @@ public class ViewTestModels {
 
   @Table(value = "users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class UserByNameStreamed extends View<User> {
+  public static class UserByNameStreamed extends View {
 
     @Query("SELECT * FROM users_view WHERE name = :name")
     @GetMapping("/users/{name}")
@@ -349,7 +349,7 @@ public class ViewTestModels {
   }
   
   @Table(value = "employees_view")
-  public static class SubscribeToEventSourcedEvents extends View<Employee> {
+  public static class SubscribeToEventSourcedEvents extends View {
 
     @Subscribe.EventSourcedEntity(EventSourcedEntitiesTestModels.EmployeeEntity.class)
     public UpdateEffect<Employee> onEvent(EmployeeEvent evt) {
@@ -366,7 +366,7 @@ public class ViewTestModels {
   }
 
   @Table(value = "employees_view")
-  public static class SubscribeToEventSourcedEventsWithMethodWithState extends View<Employee> {
+  public static class SubscribeToEventSourcedEventsWithMethodWithState extends View {
 
     @Subscribe.EventSourcedEntity(EventSourcedEntitiesTestModels.EmployeeEntity.class)
     public UpdateEffect<Employee> onEvent(Employee employee, EmployeeEvent evt) {
@@ -384,7 +384,7 @@ public class ViewTestModels {
 
   @Table(value = "employees_view")
   @Acl(allow = @Acl.Matcher(service = "test"))
-  public static class ViewWithServiceLevelAcl extends View<Employee> {
+  public static class ViewWithServiceLevelAcl extends View {
     @Query("SELECT * FROM employees_view WHERE email = :email")
     @PostMapping("/employees/by-email/{email}")
     public Employee getEmployeeByEmail(@PathVariable String email) {
@@ -393,7 +393,7 @@ public class ViewTestModels {
   }
 
   @Table(value = "employees_view")
-  public static class ViewWithMethodLevelAcl extends View<Employee> {
+  public static class ViewWithMethodLevelAcl extends View {
     @Query("SELECT * FROM employees_view WHERE email = :email")
     @PostMapping("/employees/by-email/{email}")
     @Acl(allow = @Acl.Matcher(service = "test"))
@@ -404,7 +404,7 @@ public class ViewTestModels {
 
   @Table(value = "users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class UserByEmailWithStreamUpdates extends View<User> {
+  public static class UserByEmailWithStreamUpdates extends View {
 
     @Query(value = "SELECT * FROM users_view WHERE email = :email", streamUpdates = true)
     @PostMapping("/users/by-email")
@@ -415,7 +415,7 @@ public class ViewTestModels {
 
   @Table(value = "users_view_collection")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class UserByEmailWithCollectionReturn extends View<User> {
+  public static class UserByEmailWithCollectionReturn extends View {
 
     @Query(value = "SELECT * AS users FROM users_view WHERE name = :name")
     @PostMapping("/users/by-name/{name}")
@@ -426,7 +426,7 @@ public class ViewTestModels {
 
   @Table(value = "users_view")
   @Subscribe.ValueEntity(UserEntity.class)
-  public static class IllDefineUserByEmailWithStreamUpdates extends View<User> {
+  public static class IllDefineUserByEmailWithStreamUpdates extends View {
 
     @Query(value = "SELECT * FROM users_view WHERE email = :email", streamUpdates = true)
     @PostMapping("/users/by-email")

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ViewDescriptorFactorySpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ViewDescriptorFactorySpec.scala
@@ -387,15 +387,20 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
     }
 
     "fail if no query method found" in {
-      intercept[InvalidComponentException] {
+      intercept[ServiceIntrospectionException] {
         descriptorFor[ViewWithNoQuery]
-      }
+      }.getMessage should be(
+        "On kalix.springsdk.testmodels.view.ViewTestModels$ViewWithNoQuery: " +
+        "No valid query method found. " +
+        "Views should have a method annotated with @Query and exposed by a REST annotation")
     }
 
     "fail if more than one query method is found" in {
-      intercept[InvalidComponentException] {
+      intercept[ServiceIntrospectionException] {
         descriptorFor[ViewWithTwoQueries]
-      }
+      }.getMessage should be(
+        "On kalix.springsdk.testmodels.view.ViewTestModels$ViewWithTwoQueries: " +
+        "Views can have only one method annotated with @Query, found 2.")
     }
   }
 


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix/issues/7323

WIP for supporting views with multiple tables. Remove the state type parameter for views. Effects builder works at a method level now. Source compatible for protocol-first views with code generation. Breaking change for code-first and Spring SDK.

Still to do:

- [x] figure out what will happen with `emptyState` and whether there's a multi-table version of this
- [ ] switch Spring SDK back to a state parameter on update methods (currently an untyped `viewState`)
- [ ] finish off and check the internal changes for Spring SDK
- [ ] validate multiple tables work, while still compatible with existing single table views for protocol-first