### PR TITLE
fix: Use the testcontainer host name for cross component calls

### DIFF
--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -194,6 +194,8 @@ public class KalixTestKit {
     ProxyInfoHolder holder = ProxyInfoHolder.get(runner.system());
     holder.overridePort(proxyContainer.getProxyPort());
     holder.overrideProxyHost(proxyContainer.getHost());
+    if (log.isDebugEnabled())
+      log.debug("TestKit using [{}:{}] for calls to proxy from service", proxyContainer.getHost(), proxyContainer.getProxyPort());
     return this;
   }
 

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -188,10 +188,12 @@ public class KalixTestKit {
     proxyContainer.start();
     started = true;
 
-    // the proxy will announce its default port, but to communicate with it,
-    // we need the use the port that testcontainers will expose
+    // the proxy will announce its host and default port, but to communicate with it,
+    // we need the use the port and host that testcontainers will expose
     // therefore, we set a port override in ProxyInfoHolder to allow for inter-component communication
-    ProxyInfoHolder.get(runner.system()).overridePort(proxyContainer.getProxyPort());
+    ProxyInfoHolder holder = ProxyInfoHolder.get(runner.system());
+    holder.overridePort(proxyContainer.getProxyPort());
+    holder.overrideProxyHost(proxyContainer.getHost());
     return this;
   }
 

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -93,7 +93,15 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
   /**
    * Change port disregarding what is announced in ProxyInfo This is required for the testkit because the port to use is
    * defined by testcontainers
+   *
+   * INTERNAL API
    */
   private[kalix] def overridePort(port: Int): Unit =
     _portOverride = Some(port)
+
+  /**
+   * INTERNAL API
+   */
+  private[kalix] def overrideProxyHost(host: String): Unit =
+    _proxyHostname = Some(host)
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -55,7 +55,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
         proxyInfo.internalProxyHostname
       }
 
-    // don't set if already overriden (by testkit)
+    // don't set if already overridden (by testkit)
     if (this._proxyHostname.isEmpty) {
       this._proxyHostname = Some(chosenProxyName)
     }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -62,7 +62,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
     _identificationInfo = proxyInfo.identificationInfo
 
     log.debug("Proxy hostname: [{}]", chosenProxyName)
-    log.debug("Proxy port to: [{}]", proxyInfo)
+    log.debug("Proxy port to: [{}]", proxyInfo.proxyPort)
     log.debug("Identification name: [{}]", proxyInfo.identificationInfo)
   }
 

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -55,7 +55,10 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
         proxyInfo.internalProxyHostname
       }
 
-    this._proxyHostname = Some(chosenProxyName)
+    // don't set if already overriden (by testkit)
+    if (this._proxyHostname.isEmpty) {
+      this._proxyHostname = Some(chosenProxyName)
+    }
 
     this._identificationInfo = proxyInfo.identificationInfo
 

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -27,7 +27,6 @@ import kalix.protocol.discovery.ProxyInfo
 import org.slf4j.LoggerFactory
 
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.atomic.AtomicReference
 
 object ProxyInfoHolder extends ExtensionId[ProxyInfoHolder] with ExtensionIdProvider {
   override def get(system: ActorSystem): ProxyInfoHolder = super.get(system)


### PR DESCRIPTION
References #1281