### PR TITLE
chore: decrease CI pipeline run time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1423,7 +1423,7 @@ workflows:
             - publish-local
       - spring-sdk-integration-tests:
           requires:
-            - tests
+            - checks
 
       # individual samples as jobs to allow parallelizing them
       - sample-java-customer-registry-quickstart:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
             git checkout -b $BRANCH
             git config user.name "Kalix Bot"
             git config user.email "kalix.github@lightbend.com"
-            git commit . -m "Bump SDK versions to $SDK_VERSION"
+            git commit . -m "chore: bump SDK versions to $SDK_VERSION"
             git remote add origin-rw https://$GITHUB_TOKEN@github.com/lightbend/kalix-jvm-sdk
             git push --set-upstream origin-rw $BRANCH
             

--- a/docs/release-issue-template.md
+++ b/docs/release-issue-template.md
@@ -3,7 +3,7 @@
 ### Prepare
 
 - [ ] Make sure all important PRs have been merged
-- [ ] Check that the [latest build](https://app.circleci.com/pipelines/github/lightbend/kalix-jvm-sdk) successfully finished
+- [ ] Check that the [latest build](https://app.circleci.com/pipelines/github/lightbend/kalix-jvm-sdk?branch=main) successfully finished
 - [ ] Make sure a version of the proxy that supports the protocol version the SDK expects has been deployed to production
 
 You can see the proxy version on prod [on grafana](https://lightbendcloud.grafana.net/d/2n4jVuw7z/prod-kalix-metrics?orgId=1) or using [various other methods](https://github.com/lightbend/kalix/wiki/Versioning-and-how-to-determine-what-version-is-running).


### PR DESCRIPTION
This actually reverts something I did some months ago I think.

Current CI pipeline takes about ~11mins which I think is a bit too much. Making `tests` and `IT tests` run in parallel  should reduce that to about ~8mins. 