### PR TITLE
feat: support views with multiple tables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,7 @@ lazy val sdkSpring = project
     Compile / akkaGrpcGeneratedSources := Seq(AkkaGrpc.Server),
     Compile / akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Scala),
     Test / javacOptions ++= Seq("-parameters", "--release", "17"), // for Jackson
+    Test / scalacOptions ++= Seq("-release", "17"),
     IntegrationTest / javacOptions += "-parameters", // for Jackson
     inTask(doc)(
       Seq(

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/Types.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/Types.scala
@@ -22,6 +22,7 @@ object Types {
   object View {
     val UpdateHandlerNotFound = ClassMessageType("kalix.javasdk.impl.view.UpdateHandlerNotFound")
     val ViewRouter = ClassMessageType("kalix.javasdk.impl.view.ViewRouter")
+    val ViewMultiTableRouter = ClassMessageType("kalix.javasdk.impl.view.ViewMultiTableRouter")
     val View = ClassMessageType("kalix.javasdk.view.View")
     val ViewProvider = ClassMessageType("kalix.javasdk.view.ViewProvider")
     val ViewCreationContext = ClassMessageType("kalix.javasdk.view.ViewCreationContext")

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.java
@@ -8,11 +8,6 @@ import kalix.javasdk.view.View;
 
 public abstract class AbstractMyUserByNameView extends View<UserViewModel.UserState> {
 
-  @Override
-  public UserViewModel.UserState emptyState() {
-    return null; // emptyState is only used with transform_updates=true
-  }
-
 
 }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class MyUserByNameViewProvider implements ViewProvider<UserViewModel.UserState, MyUserByNameView> {
+public class MyUserByNameViewProvider implements ViewProvider {
 
   private final Function<ViewCreationContext, MyUserByNameView> viewFactory;
   private final String viewId;

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.java
@@ -8,11 +8,6 @@ import kalix.javasdk.view.View;
 
 public abstract class AbstractUserByNameView extends View<UserViewModel.UserState> {
 
-  @Override
-  public UserViewModel.UserState emptyState() {
-    return null; // emptyState is only used with transform_updates=true
-  }
-
 
 }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class UserByNameViewProvider implements ViewProvider<UserViewModel.UserState, UserByNameView> {
+public class UserByNameViewProvider implements ViewProvider {
 
   private final Function<ViewCreationContext, UserByNameView> viewFactory;
   private final String viewId;

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.java
@@ -8,11 +8,9 @@ import kalix.javasdk.view.View;
 
 public abstract class AbstractUserByNameView extends View<UserViewModel.UserState> {
 
-  @Override
-  public UserViewModel.UserState emptyState() {
-    return null; // emptyState is only used with transform_updates=true
-  }
-
+  public abstract View.UpdateEffect<UserViewModel.UserState> updateCustomer(
+      UserViewModel.UserState state,
+      UserViewModel.UserState userState);
 
 }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public class UserByNameViewProvider implements ViewProvider<UserViewModel.UserState, UserByNameViewImpl> {
+public class UserByNameViewProvider implements ViewProvider {
 
   private final Function<ViewCreationContext, UserByNameViewImpl> viewFactory;
   private final String viewId;

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
@@ -21,6 +21,10 @@ public class UserByNameViewRouter extends ViewRouter<UserViewModel.UserState, Us
       Object event) {
 
     switch (eventName) {
+      case "UpdateCustomer":
+        return view().updateCustomer(
+            state,
+            (UserViewModel.UserState) event);
 
       default:
         throw new UpdateHandlerNotFound(eventName);

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/view/UserByNameViewImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/view/UserByNameViewImpl.java
@@ -1,5 +1,6 @@
 package org.example.view;
 
+import kalix.javasdk.view.View;
 import kalix.javasdk.view.ViewContext;
 
 // This class was initially generated based on the .proto definition by Kalix tooling.
@@ -12,6 +13,16 @@ public class UserByNameViewImpl extends AbstractUserByNameView {
 
   public UserByNameViewImpl(ViewContext context) {}
 
+  @Override
+  public UserViewModel.UserState emptyState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state");
+  }
+
+  @Override
+  public View.UpdateEffect<UserViewModel.UserState> updateCustomer(
+      UserViewModel.UserState state,
+      UserViewModel.UserState userState) {
+    throw new UnsupportedOperationException("Update handler for 'UpdateCustomer' not implemented yet");
+  }
 
 }
-

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/proto/example-views.proto
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/proto/example-views.proto
@@ -20,7 +20,6 @@ option java_outer_classname = "UserViewModel";
 
 import "kalix/annotations.proto";
 
-
 message ByNameRequest {
   string user_name = 1;
 }
@@ -38,11 +37,10 @@ service UserByNameView {
     view: {}
   };
 
-
   rpc UpdateCustomer(UserState) returns (UserState) {
-
     option (kalix.method).view.update = {
       table: "users"
+      transform_updates: true
     };
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.java
@@ -1,0 +1,16 @@
+package org.example;
+
+import kalix.javasdk.DeferredCall;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  
+
+  
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,31 @@
+package org.example;
+
+import kalix.javasdk.Context;
+import kalix.javasdk.DeferredCall;
+import kalix.javasdk.impl.GrpcDeferredCall;
+import kalix.javasdk.impl.InternalContext;
+import kalix.javasdk.impl.MetadataImpl;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  
+
+  
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import kalix.javasdk.Kalix;
+import kalix.javasdk.view.ViewCreationContext;
+import org.example.view.CustomerOrdersView;
+import org.example.view.CustomerOrdersViewModel;
+import org.example.view.CustomerOrdersViewProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class KalixFactory {
+
+  public static Kalix withComponents(
+      Function<ViewCreationContext, CustomerOrdersView> createCustomerOrdersView) {
+    Kalix kalix = new Kalix();
+    return kalix
+      .register(CustomerOrdersViewProvider.of(createCustomerOrdersView));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.java
@@ -1,0 +1,53 @@
+package org.example.view;
+
+import kalix.javasdk.view.View;
+import kalix.javasdk.view.ViewContext;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public abstract class AbstractCustomerOrdersView {
+
+  private AbstractCustomersViewTable customersViewTable;
+  private AbstractProductsViewTable productsViewTable;
+
+  public AbstractCustomerOrdersView(ViewContext context) {
+    customersViewTable = createCustomersViewTable(context);
+    productsViewTable = createProductsViewTable(context);
+  }
+
+  public AbstractCustomersViewTable customersViewTable() {
+    return customersViewTable;
+  }
+
+  public abstract AbstractCustomersViewTable createCustomersViewTable(ViewContext context);
+
+  public static abstract class AbstractCustomersViewTable extends View<CustomerOrdersViewModel.Customer> {
+
+    public abstract View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerCreated(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerCreated customerCreated);
+
+    public abstract View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerNameChanged(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerNameChanged customerNameChanged);
+
+  }
+
+  public AbstractProductsViewTable productsViewTable() {
+    return productsViewTable;
+  }
+
+  public abstract AbstractProductsViewTable createProductsViewTable(ViewContext context);
+
+  public static abstract class AbstractProductsViewTable extends View<CustomerOrdersViewModel.Product> {
+
+    public abstract View.UpdateEffect<CustomerOrdersViewModel.Product> updateProduct(
+        CustomerOrdersViewModel.Product state,
+        CustomerOrdersViewModel.ProductCreated productCreated);
+
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.java
@@ -1,0 +1,72 @@
+package org.example.view;
+
+import com.google.protobuf.Descriptors;
+import kalix.javasdk.view.ViewCreationContext;
+import kalix.javasdk.view.ViewOptions;
+import kalix.javasdk.view.ViewProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class CustomerOrdersViewProvider implements ViewProvider {
+
+  private final Function<ViewCreationContext, CustomerOrdersView> viewFactory;
+  private final String viewId;
+  private final ViewOptions options;
+
+  /** Factory method of CustomerOrdersView */
+  public static CustomerOrdersViewProvider of(
+      Function<ViewCreationContext, CustomerOrdersView> viewFactory) {
+    return new CustomerOrdersViewProvider(viewFactory, "CustomerOrders", ViewOptions.defaults());
+  }
+
+  private CustomerOrdersViewProvider(
+      Function<ViewCreationContext, CustomerOrdersView> viewFactory,
+      String viewId,
+      ViewOptions options) {
+    this.viewFactory = viewFactory;
+    this.viewId = viewId;
+    this.options = options;
+  }
+
+  @Override
+  public String viewId() {
+    return viewId;
+  }
+
+  @Override
+  public final ViewOptions options() {
+    return options;
+  }
+
+  public final CustomerOrdersViewProvider withOptions(ViewOptions options) {
+    return new CustomerOrdersViewProvider(viewFactory, viewId, options);
+  }
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  public CustomerOrdersViewProvider withViewId(String viewId) {
+    return new CustomerOrdersViewProvider(viewFactory, viewId, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CustomerOrdersViewModel.getDescriptor().findServiceByName("CustomerOrders");
+  }
+
+  @Override
+  public final CustomerOrdersViewRouter newRouter(ViewCreationContext context) {
+    return new CustomerOrdersViewRouter(viewFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {CustomerOrdersViewModel.getDescriptor()};
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.java
@@ -1,0 +1,97 @@
+package org.example.view;
+
+import kalix.javasdk.impl.view.UpdateHandlerNotFound;
+import kalix.javasdk.impl.view.ViewMultiTableRouter;
+import kalix.javasdk.impl.view.ViewRouter;
+import kalix.javasdk.view.View;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class CustomerOrdersViewRouter extends ViewMultiTableRouter {
+
+  private CustomersViewTableRouter customersViewTableRouter;
+  private ProductsViewTableRouter productsViewTableRouter;
+
+  public CustomerOrdersViewRouter(CustomerOrdersView view) {
+    customersViewTableRouter = new CustomersViewTableRouter(view.customersViewTable());
+    productsViewTableRouter = new ProductsViewTableRouter(view.productsViewTable());
+  }
+
+  public static class CustomersViewTableRouter extends ViewRouter<CustomerOrdersViewModel.Customer, AbstractCustomerOrdersView.AbstractCustomersViewTable> {
+
+    public CustomersViewTableRouter(AbstractCustomerOrdersView.AbstractCustomersViewTable view) {
+      super(view);
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Customer> handleUpdate(
+        String eventName,
+        CustomerOrdersViewModel.Customer state,
+        Object event) {
+
+      switch (eventName) {
+        case "UpdateCustomerCreated":
+          return view().updateCustomerCreated(
+              state,
+              (CustomerOrdersViewModel.CustomerCreated) event);
+
+        case "UpdateCustomerNameChanged":
+          return view().updateCustomerNameChanged(
+              state,
+              (CustomerOrdersViewModel.CustomerNameChanged) event);
+
+        default:
+          throw new UpdateHandlerNotFound(eventName);
+      }
+    }
+
+  }
+
+  public static class ProductsViewTableRouter extends ViewRouter<CustomerOrdersViewModel.Product, AbstractCustomerOrdersView.AbstractProductsViewTable> {
+
+    public ProductsViewTableRouter(AbstractCustomerOrdersView.AbstractProductsViewTable view) {
+      super(view);
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Product> handleUpdate(
+        String eventName,
+        CustomerOrdersViewModel.Product state,
+        Object event) {
+
+      switch (eventName) {
+        case "UpdateProduct":
+          return view().updateProduct(
+              state,
+              (CustomerOrdersViewModel.ProductCreated) event);
+
+        default:
+          throw new UpdateHandlerNotFound(eventName);
+      }
+    }
+
+  }
+
+
+  @Override
+  public ViewRouter<?, ?> viewRouter(String eventName, Object event) {
+    switch (eventName) {
+      case "UpdateCustomerCreated":
+        return customersViewTableRouter;
+
+      case "UpdateCustomerNameChanged":
+        return customersViewTableRouter;
+
+      case "UpdateProduct":
+        return productsViewTableRouter;
+
+      default:
+        throw new UpdateHandlerNotFound(eventName);
+    }
+  }
+
+}
+
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import kalix.javasdk.Kalix;
+import org.example.view.CustomerOrdersView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static Kalix createKalix() {
+    // The KalixFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new Kalix()` instance.
+    return KalixFactory.withComponents(
+      CustomerOrdersView::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Kalix service");
+    createKalix().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.java
@@ -1,0 +1,72 @@
+package org.example.view;
+
+import kalix.javasdk.view.View;
+import kalix.javasdk.view.ViewContext;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+// This is the implementation for the View Service described in your customer_orders.proto file.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CustomerOrdersView extends AbstractCustomerOrdersView {
+
+  public CustomerOrdersView(ViewContext context) {
+    super(context);
+  }
+
+  @Override
+  public CustomersViewTable createCustomersViewTable(ViewContext context) {
+    return new CustomersViewTable(context);
+  }
+
+  public static class CustomersViewTable extends AbstractCustomersViewTable {
+
+    public CustomersViewTable(ViewContext context) {}
+
+    @Override
+    public CustomerOrdersViewModel.Customer emptyState() {
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state");
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerCreated(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerCreated customerCreated) {
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerCreated' not implemented yet");
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerNameChanged(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerNameChanged customerNameChanged) {
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerNameChanged' not implemented yet");
+    }
+
+  }
+
+  @Override
+  public ProductsViewTable createProductsViewTable(ViewContext context) {
+    return new ProductsViewTable(context);
+  }
+
+  public static class ProductsViewTable extends AbstractProductsViewTable {
+
+    public ProductsViewTable(ViewContext context) {}
+
+    @Override
+    public CustomerOrdersViewModel.Product emptyState() {
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state");
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Product> updateProduct(
+        CustomerOrdersViewModel.Product state,
+        CustomerOrdersViewModel.ProductCreated productCreated) {
+      throw new UnsupportedOperationException("Update handler for 'UpdateProduct' not implemented yet");
+    }
+
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
@@ -1,0 +1,124 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.view;
+
+import "kalix/annotations.proto";
+
+option java_outer_classname = "CustomerOrdersViewModel";
+
+message CustomerOrdersRequest {
+  string customer_id = 1;
+}
+
+message CustomerOrder {
+  string order_id = 1;
+  string customer_id = 2;
+  string product_id = 3;
+  string product_name = 4;
+  int32 quantity = 5;
+  string name = 6;
+  string email = 7;
+}
+
+message CustomerCreated {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message CustomerNameChanged {
+  string customer_id = 1;
+  string new_name = 3;
+}
+
+message Customer {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message ProductCreated {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message Product {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message Order {
+  string order_id = 1;
+  string product_id = 2;
+  string customer_id = 3;
+  int32 quantity = 4;
+}
+
+service CustomerOrders {
+  option (kalix.codegen) = {
+    view: {}
+  };
+
+  rpc UpdateCustomerCreated(CustomerCreated) returns (Customer) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateCustomerNameChanged(CustomerNameChanged) returns (Customer) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateProduct(ProductCreated) returns (Product) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "products"
+    };
+    option (kalix.method).view.update = {
+      table: "products",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateOrder(Order) returns (Order) {
+    option (kalix.method).eventing.in = {
+      value_entity: "orders"
+    };
+    option (kalix.method).view.update = {
+      table: "orders"
+    };
+  }
+
+  rpc Get(CustomerOrdersRequest) returns (stream CustomerOrder) {
+    option (kalix.method).view.query = {
+      query: "SELECT * "
+          "FROM customers "
+          "JOIN orders ON orders.customer_id = customers.customer_id "
+          "JOIN products ON products.product_id = orders.product_id "
+          "WHERE customers.customer_id = :customer_id"
+    };
+  }
+}

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/AbstractKalixGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/AbstractKalixGenerator.scala
@@ -28,7 +28,7 @@ import protocgen.{ CodeGenApp, CodeGenRequest, CodeGenResponse }
 abstract class AbstractKalixGenerator extends CodeGenApp {
   val enableDebug = "enableDebug"
   def rootPackage(packageName: String) = s"rootPackage=$packageName"
-  val rootPackageRegex = """rootPackage=(\w+)""".r
+  val rootPackageRegex = """rootPackage=([\w.]+)""".r
   def extractRootPackage(parameter: String): Option[String] =
     rootPackageRegex.findFirstMatchIn(parameter).map(found => found.group(1))
 

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
@@ -18,6 +18,8 @@ package kalix.codegen.scalasdk.impl
 
 import kalix.codegen.File
 import kalix.codegen.Format
+import kalix.codegen.Imports
+import kalix.codegen.MessageType
 import kalix.codegen.ModelBuilder
 
 /**
@@ -47,42 +49,57 @@ object ViewServiceSourceGenerator {
         otherImports = Seq(
           "kalix.javasdk.impl.view.UpdateHandlerNotFound",
           "kalix.scalasdk.impl.view.ViewRouter",
-          "kalix.scalasdk.view.View"),
+          "kalix.scalasdk.view.View") ++
+          (if (view.tables.size > 1) Seq("kalix.scalasdk.impl.view.ViewMultiTableRouter") else Seq.empty),
         packageImports = Nil)
-
-    val cases = view.transformedUpdates
-      .map { cmd =>
-        val methodName = cmd.name
-        if (cmd.handleDeletes) {
-          s"""|case "$methodName" =>
-              |  view.${lowerFirst(methodName)}(
-              |      state)
-              |""".stripMargin
-        } else {
-          s"""|case "$methodName" =>
-              |  view.${lowerFirst(methodName)}(
-              |      state,
-              |      event.asInstanceOf[${typeName(cmd.inputType)}])
-              |""".stripMargin
-        }
-      }
 
     File.scala(
       view.messageType.parent.scalaPackage,
       view.routerName,
       s"""|package ${view.messageType.parent.scalaPackage}
-        |
-        |${writeImports(imports)}
-        |
-        |$managedComment
-        |
-        |class ${view.routerName}(view: ${view.className})
-        |  extends ViewRouter[${typeName(view.state.messageType)}, ${view.className}](view) {
+          |
+          |${writeImports(imports)}
+          |
+          |$managedComment
+          |
+          |${viewRouterContent(view)}
+          |""".stripMargin)
+  }
+
+  private[codegen] def viewRouterContent(view: ModelBuilder.ViewService)(implicit imports: Imports): String = {
+    if (view.tables.size > 1) viewRouterMultiTable(view)
+    else viewRouterClass(view.routerName, view.className, view.state.messageType, view.transformedUpdates)
+  }
+
+  private[codegen] def viewRouterClass(
+      className: String,
+      viewClassName: String,
+      stateType: MessageType,
+      transformedUpdates: Iterable[ModelBuilder.Command])(implicit imports: Imports): String = {
+
+    val cases = transformedUpdates.map { cmd =>
+      val methodName = cmd.name
+      if (cmd.handleDeletes) {
+        s"""|case "$methodName" =>
+            |  view.${lowerFirst(methodName)}(
+            |      state)
+            |""".stripMargin
+      } else {
+        s"""|case "$methodName" =>
+            |  view.${lowerFirst(methodName)}(
+            |      state,
+            |      event.asInstanceOf[${typeName(cmd.inputType)}])
+            |""".stripMargin
+      }
+    }
+
+    s"""|class $className(view: $viewClassName)
+        |  extends ViewRouter[${typeName(stateType)}, ${viewClassName}](view) {
         |
         |  override def handleUpdate(
         |      eventName: String,
-        |      state: ${typeName(view.state.messageType)},
-        |      event: Any): View.UpdateEffect[${typeName(view.state.messageType)}] = {
+        |      state: ${typeName(stateType)},
+        |      event: Any): View.UpdateEffect[${typeName(stateType)}] = {
         |
         |    eventName match {
         |      ${Format.indent(cases, 6)}
@@ -93,7 +110,58 @@ object ViewServiceSourceGenerator {
         |  }
         |
         |}
-        |""".stripMargin)
+        |""".stripMargin
+  }
+
+  private[codegen] def viewRouterMultiTable(view: ModelBuilder.ViewService)(implicit imports: Imports): String = {
+    val routerClasses = view.tables.flatMap { table =>
+      val transformedUpdates = view.tableTransformedUpdates(table)
+      if (transformedUpdates.isEmpty) None
+      else {
+        val className = view.tableClassName(table)
+        val stateType = view.tableType(table)
+        Some(
+          viewRouterClass(
+            s"${className}Router",
+            s"Abstract${view.className}#Abstract$className",
+            stateType,
+            transformedUpdates))
+      }
+    }
+    val routerInstances = view.tables.flatMap { table =>
+      if (view.tableTransformedUpdates(table).isEmpty) None
+      else {
+        val className = view.tableClassName(table)
+        Some(s"""|private val ${lowerFirst(className)}Router =
+                 |  new ${view.routerName}.${className}Router(view.$className)
+                 |""".stripMargin)
+      }
+    }
+    val routerCases = view.transformedUpdates.map { update =>
+      val className = view.tableClassName(update.viewTable)
+      s"""|case "${update.name}" =>
+          |  ${lowerFirst(className)}Router
+          |""".stripMargin
+    }
+    s"""|object ${view.routerName} {
+        |  ${Format.indent(routerClasses, 2)}
+        |}
+        |
+        |class ${view.routerName}(view: ${view.className}) extends ViewMultiTableRouter {
+        |
+        |  ${Format.indent(routerInstances, 2)}
+        |
+        |  override def viewRouter(eventName: String, event: Any): ViewRouter[_, _] = {
+        |    eventName match {
+        |      ${Format.indent(routerCases, 6)}
+        |
+        |      case _ =>
+        |        throw new UpdateHandlerNotFound(eventName)
+        |    }
+        |  }
+        |
+        |}
+        |""".stripMargin
   }
 
   private[codegen] def viewProvider(view: ModelBuilder.ViewService): File = {
@@ -118,91 +186,126 @@ object ViewServiceSourceGenerator {
       view.messageType.parent.scalaPackage,
       view.providerName,
       s"""|package ${view.messageType.parent.scalaPackage}
-        |
-        |${writeImports(imports)}
-        |
-        |$managedComment
-        |
-        |object ${view.providerName} {
-        |  def apply(viewFactory: ViewCreationContext => ${view.className}): ${view.providerName} =
-        |    new ${view.providerName}(viewFactory, viewId = "${view.viewId}", options = ViewOptions.defaults)
-        |}
-        |
-        |class ${view.providerName} private(
-        |    viewFactory: ViewCreationContext => ${view.className},
-        |    override val viewId: String,
-        |    override val options: ViewOptions)
-        |  extends ViewProvider[${typeName(view.state.messageType)}, ${view.className}] {
-        |
-        |  /**
-        |   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
-        |   * A different identifier can be needed when making rolling updates with changes to the view definition.
-        |   */
-        |  def withViewId(viewId: String): ${view.providerName} =
-        |    new ${view.providerName}(viewFactory, viewId, options)
-        |
-        |  def withOptions(newOptions: ViewOptions): ${view.providerName} =
-        |    new ${view.providerName}(viewFactory, viewId, newOptions)
-        |
-        |  override final def serviceDescriptor: Descriptors.ServiceDescriptor =
-        |    ${typeName(view.messageType.descriptorImport)}.javaDescriptor.findServiceByName("${view.messageType.protoName}")
-        |
-        |  override final def newRouter(context: ViewCreationContext): ${view.routerName} =
-        |    new ${view.routerName}(viewFactory(context))
-        |
-        |  override final def additionalDescriptors: Seq[Descriptors.FileDescriptor] =
-        |    ${typeName(view.messageType.descriptorImport)}.javaDescriptor ::
-        |    Nil
-        |}
-        |""".stripMargin)
+          |
+          |${writeImports(imports)}
+          |
+          |$managedComment
+          |
+          |object ${view.providerName} {
+          |  def apply(viewFactory: ViewCreationContext => ${view.className}): ${view.providerName} =
+          |    new ${view.providerName}(viewFactory, viewId = "${view.viewId}", options = ViewOptions.defaults)
+          |}
+          |
+          |class ${view.providerName} private(
+          |    viewFactory: ViewCreationContext => ${view.className},
+          |    override val viewId: String,
+          |    override val options: ViewOptions)
+          |  extends ViewProvider {
+          |
+          |  /**
+          |   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+          |   * A different identifier can be needed when making rolling updates with changes to the view definition.
+          |   */
+          |  def withViewId(viewId: String): ${view.providerName} =
+          |    new ${view.providerName}(viewFactory, viewId, options)
+          |
+          |  def withOptions(newOptions: ViewOptions): ${view.providerName} =
+          |    new ${view.providerName}(viewFactory, viewId, newOptions)
+          |
+          |  override final def serviceDescriptor: Descriptors.ServiceDescriptor =
+          |    ${typeName(view.messageType.descriptorImport)}.javaDescriptor.findServiceByName("${view.messageType.protoName}")
+          |
+          |  override final def newRouter(context: ViewCreationContext): ${view.routerName} =
+          |    new ${view.routerName}(viewFactory(context))
+          |
+          |  override final def additionalDescriptors: Seq[Descriptors.FileDescriptor] =
+          |    ${typeName(view.messageType.descriptorImport)}.javaDescriptor ::
+          |    Nil
+          |}
+          |""".stripMargin)
   }
 
   private[codegen] def viewSource(view: ModelBuilder.ViewService): File = {
     implicit val imports =
       generateImports(
-        Seq(view.state.messageType) ++ view.commandTypes,
+        view.stateTypes ++ view.commandTypes,
         view.messageType.parent.scalaPackage,
         otherImports = Seq("kalix.scalasdk.view.View.UpdateEffect", "kalix.scalasdk.view.ViewContext"),
         packageImports = Nil)
-
-    val emptyState =
-      if (view.transformedUpdates.isEmpty)
-        ""
-      else
-        s"""|  override def emptyState: ${typeName(view.state.messageType)} =
-            |    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
-            |""".stripMargin
-
-    val handlers = view.transformedUpdates.map { update =>
-      val stateType = typeName(update.outputType)
-      if (update.handleDeletes) {
-        s"""override def ${lowerFirst(update.name)}(
-           |  state: $stateType): UpdateEffect[$stateType] =
-           |  throw new UnsupportedOperationException("Delete handler for '${update.name}' not implemented yet")
-           |""".stripMargin
-      } else {
-        s"""override def ${lowerFirst(update.name)}(
-           |  state: $stateType, ${lowerFirst(update.inputType.name)}: ${typeName(update.inputType)}): UpdateEffect[$stateType] =
-           |  throw new UnsupportedOperationException("Update handler for '${update.name}' not implemented yet")
-           |""".stripMargin
-      }
-    }
 
     File.scala(
       view.messageType.parent.scalaPackage,
       view.className,
       s"""|package ${view.messageType.parent.scalaPackage}
-        |
-        |${writeImports(imports)}
-        |
-        |$unmanagedComment
-        |
-        |class ${view.className}(context: ViewContext) extends ${view.abstractViewName} {
-        |
-        |$emptyState
-        |  ${Format.indent(handlers, 2)}
-        |}
-        |""".stripMargin)
+          |
+          |${writeImports(imports)}
+          |
+          |$unmanagedComment
+          |
+          |class ${view.className}(context: ViewContext) extends ${view.abstractViewName}${viewSourceContent(view)}
+          |""".stripMargin)
+  }
+
+  private[codegen] def viewSourceContent(view: ModelBuilder.ViewService)(implicit imports: Imports): String = {
+    if (view.transformedUpdates.isEmpty) ""
+    else {
+      val content =
+        if (view.tables.size > 1) viewSourceMultiTable(view)
+        else viewSourceMethods(view.state.messageType, view.transformedUpdates)
+      s"""| {
+          |$content
+          |}""".stripMargin
+    }
+  }
+
+  private[codegen] def viewSourceMethods(stateType: MessageType, transformedUpdates: Iterable[ModelBuilder.Command])(
+      implicit imports: Imports): String = {
+
+    val emptyStateMethod =
+      s"""|override def emptyState: ${typeName(stateType)} =
+          |  throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
+          |""".stripMargin
+
+    val handlerMethods = transformedUpdates.toSeq.map { update =>
+      val stateType = typeName(update.outputType)
+      if (update.handleDeletes) {
+        s"""|override def ${lowerFirst(update.name)}(
+            |    state: $stateType): UpdateEffect[$stateType] =
+            |  throw new UnsupportedOperationException("Delete handler for '${update.name}' not implemented yet")
+            |""".stripMargin
+      } else {
+        s"""|override def ${lowerFirst(update.name)}(
+            |    state: $stateType,
+            |    ${lowerFirst(update.inputType.name)}: ${typeName(update.inputType)}): UpdateEffect[$stateType] =
+            |  throw new UnsupportedOperationException("Update handler for '${update.name}' not implemented yet")
+            |""".stripMargin
+      }
+    }
+
+    val methods = emptyStateMethod +: handlerMethods
+
+    s"""|
+        |  ${Format.indent(methods, 2)}
+        |""".stripMargin
+  }
+
+  private[codegen] def viewSourceMultiTable(view: ModelBuilder.ViewService)(implicit imports: Imports): String = {
+    val viewTables = view.tables.flatMap { table =>
+      val transformedUpdates = view.tableTransformedUpdates(table)
+      if (transformedUpdates.isEmpty) None
+      else {
+        val className = view.tableClassName(table)
+        val stateType = view.tableType(table)
+        val methods = viewSourceMethods(stateType, transformedUpdates)
+        Some(s"""|object $className extends Abstract$className {
+                 |$methods
+                 |}
+                 |""".stripMargin)
+      }
+    }
+    s"""|
+        |  ${Format.indent(viewTables, 2)}
+        |""".stripMargin
   }
 
   private[codegen] def abstractView(view: ModelBuilder.ViewService): File = {
@@ -213,42 +316,71 @@ object ViewServiceSourceGenerator {
         otherImports = Seq("kalix.scalasdk.view.View"),
         packageImports = Nil)
 
-    val emptyState =
-      if (view.transformedUpdates.isEmpty)
-        s"""|  override def emptyState: ${typeName(view.state.messageType)} =
-            |    null // emptyState is only used with transform_updates=true
-            |""".stripMargin
-      else
-        ""
-
-    val handlers = view.transformedUpdates.map { update =>
-      val stateType = typeName(update.outputType)
-      if (update.handleDeletes) {
-        s"""def ${lowerFirst(update.name)}(
-           |  state: $stateType): View.UpdateEffect[$stateType]""".stripMargin
-      } else {
-        s"""def ${lowerFirst(update.name)}(
-           |  state: $stateType, ${lowerFirst(update.inputType.name)}: ${typeName(
-          update.inputType)}): View.UpdateEffect[$stateType]""".stripMargin
-      }
-
-    }
-
     File.scala(
       view.messageType.parent.scalaPackage,
       view.abstractViewName,
       s"""|package ${view.messageType.parent.scalaPackage}
+          |
+          |${writeImports(imports)}
+          |
+          |$managedComment
+          |
+          |${abstractViewContent(view)}
+          |""".stripMargin)
+  }
+
+  private[codegen] def abstractViewContent(view: ModelBuilder.ViewService)(implicit imports: Imports): String = {
+    if (view.tables.size > 1) abstractViewMultiTable(view)
+    else abstractViewClass(view.abstractViewName, view.state.messageType, view.transformedUpdates)
+  }
+
+  private[codegen] def abstractViewClass(
+      className: String,
+      stateType: MessageType,
+      transformedUpdates: Iterable[ModelBuilder.Command])(implicit imports: Imports): String = {
+
+    val methods = transformedUpdates.map { update =>
+      val stateType = typeName(update.outputType)
+      if (update.handleDeletes) {
+        s"""|def ${lowerFirst(update.name)}(
+            |    state: $stateType): View.UpdateEffect[$stateType]
+            |""".stripMargin
+      } else {
+        s"""|def ${lowerFirst(update.name)}(
+            |    state: $stateType,
+            |    ${lowerFirst(update.inputType.name)}: ${typeName(update.inputType)}): View.UpdateEffect[$stateType]
+            |""".stripMargin
+      }
+    }
+
+    val content =
+      if (methods.isEmpty) ""
+      else
+        s"""| {
+            |  ${Format.indent(methods, 2)}
+            |}""".stripMargin
+
+    s"""abstract class $className extends View[${typeName(stateType)}]$content"""
+  }
+
+  private[codegen] def abstractViewMultiTable(view: ModelBuilder.ViewService)(implicit imports: Imports): String = {
+    val viewTables = view.tables.flatMap { table =>
+      val transformedUpdates = view.tableTransformedUpdates(table)
+      if (transformedUpdates.isEmpty) None
+      else {
+        val className = view.tableClassName(table)
+        val stateType = view.tableType(table)
+        Some(s"""|def $className: Abstract$className
+                 |
+                 |${abstractViewClass(s"Abstract$className", stateType, transformedUpdates)}
+                 |""".stripMargin)
+      }
+    }
+    s"""|abstract class ${view.abstractViewName} {
         |
-        |${writeImports(imports)}
+        |  ${Format.indent(viewTables, 2)}
         |
-        |$managedComment
-        |
-        |abstract class ${view.abstractViewName} extends View[${typeName(view.state.messageType)}] {
-        |
-        |$emptyState
-        |  ${Format.indent(handlers, 2)}
-        |}
-        |""".stripMargin)
+        |}""".stripMargin
   }
 
 }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.scala
@@ -6,4 +6,7 @@ import kalix.scalasdk.view.View
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-abstract class AbstractMyUserByNameView extends View[UserState]
+abstract class AbstractMyUserByNameView extends View[UserState] {
+  override def emptyState: UserState =
+    null // emptyState is only used with transform_updates=true
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.scala
@@ -6,10 +6,4 @@ import kalix.scalasdk.view.View
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-abstract class AbstractMyUserByNameView extends View[UserState] {
-
-  override def emptyState: UserState =
-    null // emptyState is only used with transform_updates=true
-
-  
-}
+abstract class AbstractMyUserByNameView extends View[UserState]

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.scala
@@ -24,7 +24,7 @@ class MyUserByNameViewProvider private(
     viewFactory: ViewCreationContext => MyUserByNameView,
     override val viewId: String,
     override val options: ViewOptions)
-  extends ViewProvider[UserState, MyUserByNameView] {
+  extends ViewProvider {
 
   /**
    * Use a custom view identifier. By default, the viewId is the same as the proto service name.

--- a/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-unmanaged/org/example/named/view/MyUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/named-new-style/generated-unmanaged/org/example/named/view/MyUserByNameView.scala
@@ -8,8 +8,4 @@ import kalix.scalasdk.view.ViewContext
 // As long as this file exists it will not be overwritten: you can maintain it yourself,
 // or delete it so it is regenerated as needed.
 
-class MyUserByNameView(context: ViewContext) extends AbstractMyUserByNameView {
-
-
-  
-}
+class MyUserByNameView(context: ViewContext) extends AbstractMyUserByNameView

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.scala
@@ -6,10 +6,4 @@ import kalix.scalasdk.view.View
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-abstract class AbstractUserByNameView extends View[UserState] {
-
-  override def emptyState: UserState =
-    null // emptyState is only used with transform_updates=true
-
-  
-}
+abstract class AbstractUserByNameView extends View[UserState]

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.scala
@@ -6,4 +6,7 @@ import kalix.scalasdk.view.View
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-abstract class AbstractUserByNameView extends View[UserState]
+abstract class AbstractUserByNameView extends View[UserState] {
+  override def emptyState: UserState =
+    null // emptyState is only used with transform_updates=true
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.scala
@@ -24,7 +24,7 @@ class UserByNameViewProvider private(
     viewFactory: ViewCreationContext => UserByNameView,
     override val viewId: String,
     override val options: ViewOptions)
-  extends ViewProvider[UserState, UserByNameView] {
+  extends ViewProvider {
 
   /**
    * Use a custom view identifier. By default, the viewId is the same as the proto service name.

--- a/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-unmanaged/org/example/unnamed/view/UserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-unmanaged/org/example/unnamed/view/UserByNameView.scala
@@ -8,8 +8,4 @@ import kalix.scalasdk.view.ViewContext
 // As long as this file exists it will not be overwritten: you can maintain it yourself,
 // or delete it so it is regenerated as needed.
 
-class UserByNameView(context: ViewContext) extends AbstractUserByNameView {
-
-
-  
-}
+class UserByNameView(context: ViewContext) extends AbstractUserByNameView

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.scala
@@ -7,9 +7,7 @@ import kalix.scalasdk.view.View
 // DO NOT EDIT
 
 abstract class AbstractUserByNameView extends View[UserState] {
-
-  override def emptyState: UserState =
-    null // emptyState is only used with transform_updates=true
-
-  
+  def updateCustomer(
+      state: UserState,
+      userState: UserState): View.UpdateEffect[UserState]
 }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.scala
@@ -24,7 +24,7 @@ class UserByNameViewProvider private(
     viewFactory: ViewCreationContext => UserByNameViewImpl,
     override val viewId: String,
     override val options: ViewOptions)
-  extends ViewProvider[UserState, UserByNameViewImpl] {
+  extends ViewProvider {
 
   /**
    * Use a custom view identifier. By default, the viewId is the same as the proto service name.

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.scala
@@ -17,7 +17,10 @@ class UserByNameViewRouter(view: UserByNameViewImpl)
       event: Any): View.UpdateEffect[UserState] = {
 
     eventName match {
-      
+      case "UpdateCustomer" =>
+        view.updateCustomer(
+            state,
+            event.asInstanceOf[UserState])
 
       case _ =>
         throw new UpdateHandlerNotFound(eventName)

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/view/UserByNameViewImpl.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/view/UserByNameViewImpl.scala
@@ -10,6 +10,12 @@ import kalix.scalasdk.view.ViewContext
 
 class UserByNameViewImpl(context: ViewContext) extends AbstractUserByNameView {
 
+  override def emptyState: UserState =
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
 
-  
+  override def updateCustomer(
+      state: UserState,
+      userState: UserState): UpdateEffect[UserState] =
+    throw new UnsupportedOperationException("Update handler for 'UpdateCustomer' not implemented yet")
+
 }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/proto/example-views.proto
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-in-name-new-style/proto/example-views.proto
@@ -20,7 +20,6 @@ option java_outer_classname = "UserViewModel";
 
 import "kalix/annotations.proto";
 
-
 message ByNameRequest {
   string user_name = 1;
 }
@@ -38,11 +37,10 @@ service UserByNameView {
     view: {}
   };
 
-
   rpc UpdateCustomer(UserState) returns (UserState) {
-
     option (kalix.method).view.update = {
-      table: "users"
+      table: "users",
+      transform_updates: true
     };
   }
 

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/Components.scala
@@ -1,0 +1,24 @@
+package org.example
+
+
+
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+trait Components {
+ import Components._
+
+
+
+}
+
+object Components{
+
+
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/ComponentsImpl.scala
@@ -1,0 +1,26 @@
+package org.example
+
+import kalix.scalasdk.Context
+import kalix.scalasdk.impl.InternalContext
+
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+final class ComponentsImpl(context: InternalContext) extends Components {
+
+  def this(context: Context) =
+    this(context.asInstanceOf[InternalContext])
+
+  private def getGrpcClient[T](serviceClass: Class[T]): T =
+    context.getComponentGrpcClient(serviceClass)
+
+
+
+
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.scala
@@ -1,0 +1,20 @@
+package org.example
+
+import kalix.scalasdk.Kalix
+import kalix.scalasdk.view.ViewCreationContext
+import org.example.view.CustomerOrdersView
+import org.example.view.CustomerOrdersViewProvider
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+object KalixFactory {
+
+  def withComponents(
+      createCustomerOrdersView: ViewCreationContext => CustomerOrdersView): Kalix = {
+    val kalix = Kalix()
+    kalix
+      .register(CustomerOrdersViewProvider(createCustomerOrdersView))
+  }
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractCustomerOrdersView.scala
@@ -1,0 +1,31 @@
+package org.example.view
+
+import kalix.scalasdk.view.View
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+abstract class AbstractCustomerOrdersView {
+
+  def CustomersViewTable: AbstractCustomersViewTable
+
+  abstract class AbstractCustomersViewTable extends View[CustomerState] {
+    def updateCustomerCreated(
+        state: CustomerState,
+        customerCreated: CustomerCreated): View.UpdateEffect[CustomerState]
+
+    def updateCustomerNameChanged(
+        state: CustomerState,
+        customerNameChanged: CustomerNameChanged): View.UpdateEffect[CustomerState]
+  }
+
+  def ProductsViewTable: AbstractProductsViewTable
+
+  abstract class AbstractProductsViewTable extends View[ProductState] {
+    def updateProduct(
+        state: ProductState,
+        productCreated: ProductCreated): View.UpdateEffect[ProductState]
+  }
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewProvider.scala
@@ -1,0 +1,48 @@
+package org.example.view
+
+import com.google.protobuf.Descriptors
+import com.google.protobuf.EmptyProto
+import kalix.javasdk.impl.view.UpdateHandlerNotFound
+import kalix.scalasdk.impl.view.ViewRouter
+import kalix.scalasdk.view.View
+import kalix.scalasdk.view.ViewCreationContext
+import kalix.scalasdk.view.ViewOptions
+import kalix.scalasdk.view.ViewProvider
+
+import scala.collection.immutable.Seq
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+object CustomerOrdersViewProvider {
+  def apply(viewFactory: ViewCreationContext => CustomerOrdersView): CustomerOrdersViewProvider =
+    new CustomerOrdersViewProvider(viewFactory, viewId = "CustomerOrders", options = ViewOptions.defaults)
+}
+
+class CustomerOrdersViewProvider private(
+    viewFactory: ViewCreationContext => CustomerOrdersView,
+    override val viewId: String,
+    override val options: ViewOptions)
+  extends ViewProvider {
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  def withViewId(viewId: String): CustomerOrdersViewProvider =
+    new CustomerOrdersViewProvider(viewFactory, viewId, options)
+
+  def withOptions(newOptions: ViewOptions): CustomerOrdersViewProvider =
+    new CustomerOrdersViewProvider(viewFactory, viewId, newOptions)
+
+  override final def serviceDescriptor: Descriptors.ServiceDescriptor =
+    CustomerOrdersProto.javaDescriptor.findServiceByName("CustomerOrders")
+
+  override final def newRouter(context: ViewCreationContext): CustomerOrdersViewRouter =
+    new CustomerOrdersViewRouter(viewFactory(context))
+
+  override final def additionalDescriptors: Seq[Descriptors.FileDescriptor] =
+    CustomerOrdersProto.javaDescriptor ::
+    Nil
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/CustomerOrdersViewRouter.scala
@@ -1,0 +1,85 @@
+package org.example.view
+
+import kalix.javasdk.impl.view.UpdateHandlerNotFound
+import kalix.scalasdk.impl.view.ViewMultiTableRouter
+import kalix.scalasdk.impl.view.ViewRouter
+import kalix.scalasdk.view.View
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+object CustomerOrdersViewRouter {
+  class CustomersViewTableRouter(view: AbstractCustomerOrdersView#AbstractCustomersViewTable)
+    extends ViewRouter[CustomerState, AbstractCustomerOrdersView#AbstractCustomersViewTable](view) {
+
+    override def handleUpdate(
+        eventName: String,
+        state: CustomerState,
+        event: Any): View.UpdateEffect[CustomerState] = {
+
+      eventName match {
+        case "UpdateCustomerCreated" =>
+          view.updateCustomerCreated(
+              state,
+              event.asInstanceOf[CustomerCreated])
+
+        case "UpdateCustomerNameChanged" =>
+          view.updateCustomerNameChanged(
+              state,
+              event.asInstanceOf[CustomerNameChanged])
+
+        case _ =>
+          throw new UpdateHandlerNotFound(eventName)
+      }
+    }
+
+  }
+
+  class ProductsViewTableRouter(view: AbstractCustomerOrdersView#AbstractProductsViewTable)
+    extends ViewRouter[ProductState, AbstractCustomerOrdersView#AbstractProductsViewTable](view) {
+
+    override def handleUpdate(
+        eventName: String,
+        state: ProductState,
+        event: Any): View.UpdateEffect[ProductState] = {
+
+      eventName match {
+        case "UpdateProduct" =>
+          view.updateProduct(
+              state,
+              event.asInstanceOf[ProductCreated])
+
+        case _ =>
+          throw new UpdateHandlerNotFound(eventName)
+      }
+    }
+
+  }
+}
+
+class CustomerOrdersViewRouter(view: CustomerOrdersView) extends ViewMultiTableRouter {
+
+  private val customersViewTableRouter =
+    new CustomerOrdersViewRouter.CustomersViewTableRouter(view.CustomersViewTable)
+
+  private val productsViewTableRouter =
+    new CustomerOrdersViewRouter.ProductsViewTableRouter(view.ProductsViewTable)
+
+  override def viewRouter(eventName: String, event: Any): ViewRouter[_, _] = {
+    eventName match {
+      case "UpdateCustomerCreated" =>
+        customersViewTableRouter
+
+      case "UpdateCustomerNameChanged" =>
+        customersViewTableRouter
+
+      case "UpdateProduct" =>
+        productsViewTableRouter
+
+      case _ =>
+        throw new UpdateHandlerNotFound(eventName)
+    }
+  }
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.scala
@@ -1,0 +1,29 @@
+package org.example
+
+import kalix.scalasdk.Kalix
+import org.example.view.CustomerOrdersView
+import org.slf4j.LoggerFactory
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+object Main {
+
+  private val log = LoggerFactory.getLogger("org.example.Main")
+
+  def createKalix(): Kalix = {
+    // The KalixFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `Kalix()` instance.
+    KalixFactory.withComponents(
+      new CustomerOrdersView(_))
+  }
+
+  def main(args: Array[String]): Unit = {
+    log.info("starting the Kalix service")
+    createKalix().start()
+  }
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/CustomerOrdersView.scala
@@ -1,0 +1,42 @@
+package org.example.view
+
+import kalix.scalasdk.view.View.UpdateEffect
+import kalix.scalasdk.view.ViewContext
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+class CustomerOrdersView(context: ViewContext) extends AbstractCustomerOrdersView {
+
+  object CustomersViewTable extends AbstractCustomersViewTable {
+
+    override def emptyState: CustomerState =
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
+
+    override def updateCustomerCreated(
+        state: CustomerState,
+        customerCreated: CustomerCreated): UpdateEffect[CustomerState] =
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerCreated' not implemented yet")
+
+    override def updateCustomerNameChanged(
+        state: CustomerState,
+        customerNameChanged: CustomerNameChanged): UpdateEffect[CustomerState] =
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerNameChanged' not implemented yet")
+
+  }
+
+  object ProductsViewTable extends AbstractProductsViewTable {
+
+    override def emptyState: ProductState =
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
+
+    override def updateProduct(
+        state: ProductState,
+        productCreated: ProductCreated): UpdateEffect[ProductState] =
+      throw new UnsupportedOperationException("Update handler for 'UpdateProduct' not implemented yet")
+
+  }
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
@@ -1,0 +1,122 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.view;
+
+import "kalix/annotations.proto";
+
+message CustomerOrdersRequest {
+  string customer_id = 1;
+}
+
+message CustomerOrder {
+  string order_id = 1;
+  string customer_id = 2;
+  string product_id = 3;
+  string product_name = 4;
+  int32 quantity = 5;
+  string name = 6;
+  string email = 7;
+}
+
+message CustomerCreated {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message CustomerNameChanged {
+  string customer_id = 1;
+  string new_name = 3;
+}
+
+message CustomerState {
+  string customer_id = 1;
+  string email = 2;
+  string name = 3;
+}
+
+message ProductCreated {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message ProductState {
+  string product_id = 1;
+  string product_name = 2;
+}
+
+message OrderState {
+  string order_id = 1;
+  string product_id = 2;
+  string customer_id = 3;
+  int32 quantity = 4;
+}
+
+service CustomerOrders {
+  option (kalix.codegen) = {
+    view: {}
+  };
+
+  rpc UpdateCustomerCreated(CustomerCreated) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateCustomerNameChanged(CustomerNameChanged) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateProduct(ProductCreated) returns (ProductState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "products"
+    };
+    option (kalix.method).view.update = {
+      table: "products",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateOrder(OrderState) returns (OrderState) {
+    option (kalix.method).eventing.in = {
+      value_entity: "orders"
+    };
+    option (kalix.method).view.update = {
+      table: "orders"
+    };
+  }
+
+  rpc Get(CustomerOrdersRequest) returns (stream CustomerOrder) {
+    option (kalix.method).view.query = {
+      query: "SELECT * "
+             "FROM customers "
+             "JOIN orders ON orders.customer_id = customers.customer_id "
+             "JOIN products ON products.product_id = orders.product_id "
+             "WHERE customers.customer_id = :customer_id"
+    };
+  }
+}

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/Kalix.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/Kalix.java
@@ -460,7 +460,7 @@ public final class Kalix {
    *
    * @return This stateful service builder.
    */
-  public Kalix register(ViewProvider<?, ?> provider) {
+  public Kalix register(ViewProvider provider) {
     return provider
         .alternativeCodec()
         .map(

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/impl/ViewFactory.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/impl/ViewFactory.java
@@ -16,7 +16,7 @@
 
 package kalix.javasdk.impl;
 
-import kalix.javasdk.impl.view.ViewRouter;
+import kalix.javasdk.impl.view.ViewUpdateRouter;
 import kalix.javasdk.view.ViewCreationContext;
 
 /**
@@ -32,5 +32,5 @@ public interface ViewFactory {
    * @param context The context.
    * @return The handler for the given context.
    */
-  ViewRouter<?, ?> create(ViewCreationContext context);
+  ViewUpdateRouter create(ViewCreationContext context);
 }

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/view/ViewProvider.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/view/ViewProvider.java
@@ -16,13 +16,13 @@
 
 package kalix.javasdk.view;
 
-import kalix.javasdk.impl.MessageCodec;
-import kalix.javasdk.impl.view.ViewRouter;
 import com.google.protobuf.Descriptors;
+import kalix.javasdk.impl.MessageCodec;
+import kalix.javasdk.impl.view.ViewUpdateRouter;
 
 import java.util.Optional;
 
-public interface ViewProvider<S, V extends View<S>> {
+public interface ViewProvider {
 
   Descriptors.ServiceDescriptor serviceDescriptor();
 
@@ -30,7 +30,7 @@ public interface ViewProvider<S, V extends View<S>> {
 
   ViewOptions options();
 
-  ViewRouter<S, V> newRouter(ViewCreationContext context);
+  ViewUpdateRouter newRouter(ViewCreationContext context);
 
   Descriptors.FileDescriptor[] additionalDescriptors();
 

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewRouter.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewRouter.scala
@@ -20,10 +20,17 @@ import kalix.javasdk.view.{ UpdateContext, View }
 
 import java.util.Optional
 
-abstract class ViewRouter[S, V <: View[S]](protected val view: V) {
+abstract class ViewUpdateRouter {
+  def _internalHandleUpdate(state: Option[Any], event: Any, context: UpdateContext): View.UpdateEffect[_]
+}
+
+abstract class ViewRouter[S, V <: View[S]](protected val view: V) extends ViewUpdateRouter {
 
   /** INTERNAL API */
-  final def _internalHandleUpdate(state: Option[Any], event: Any, context: UpdateContext): View.UpdateEffect[_] = {
+  override final def _internalHandleUpdate(
+      state: Option[Any],
+      event: Any,
+      context: UpdateContext): View.UpdateEffect[_] = {
     val stateOrEmpty: S = state match {
       case Some(preExisting) => preExisting.asInstanceOf[S]
       case None              => view.emptyState()
@@ -44,5 +51,19 @@ abstract class ViewRouter[S, V <: View[S]](protected val view: V) {
   }
 
   def handleUpdate(commandName: String, state: S, event: Any): View.UpdateEffect[S]
+
+}
+
+abstract class ViewMultiTableRouter extends ViewUpdateRouter {
+
+  /** INTERNAL API */
+  override final def _internalHandleUpdate(
+      state: Option[Any],
+      event: Any,
+      context: UpdateContext): View.UpdateEffect[_] = {
+    viewRouter(context.eventName(), event)._internalHandleUpdate(state, event, context)
+  }
+
+  def viewRouter(eventName: String, event: Any): ViewRouter[_, _]
 
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/view/ViewsImpl.scala
@@ -96,9 +96,7 @@ final class ViewsImpl(system: ActorSystem, _services: Map[String, ViewService], 
                   "and not reach the user function")
 
               // FIXME should we really create a new handler instance per incoming command ???
-              val handler = service.factory.get
-                .create(new ViewContextImpl(service.viewId))
-                .asInstanceOf[ViewRouter[Any, View[Any]]]
+              val handler = service.factory.get.create(new ViewContextImpl(service.viewId))
 
               val state: Option[Any] =
                 receiveEvent.bySubjectLookupResult.flatMap(row =>

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/Kalix.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/Kalix.scala
@@ -137,7 +137,7 @@ class Kalix private (private[kalix] val delegate: javasdk.Kalix) {
    * @return
    *   This stateful service builder.
    */
-  def register[S, V <: View[S]](provider: ViewProvider[S, V]): Kalix =
+  def register(provider: ViewProvider): Kalix =
     Kalix(delegate.register(new JavaViewProviderAdapter(provider)))
 
   /**

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewRouter.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/view/ViewRouter.scala
@@ -21,6 +21,18 @@ import kalix.scalasdk.view.View
 /**
  * INTERNAL API, but used by generated code.
  */
-abstract class ViewRouter[S, V <: View[S]](val view: V) {
+abstract class ViewUpdateRouter
+
+/**
+ * INTERNAL API, but used by generated code.
+ */
+abstract class ViewRouter[S, V <: View[S]](val view: V) extends ViewUpdateRouter {
   def handleUpdate(commandName: String, state: S, event: Any): View.UpdateEffect[S]
+}
+
+/**
+ * INTERNAL API, but used by generated code.
+ */
+abstract class ViewMultiTableRouter extends ViewUpdateRouter {
+  def viewRouter(eventName: String, event: Any): ViewRouter[_, _]
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/View.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/View.scala
@@ -96,9 +96,8 @@ abstract class View[S] {
 
   /**
    * @return
-   *   an empty state object or `null` to hand to the process method when an event for a previously unknown subject id
-   *   is seen.
+   *   an empty state object to hand to the process method when an event for a previously unknown subject id is seen.
    */
-  def emptyState: S = null.asInstanceOf[S]
+  def emptyState: S
 
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/View.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/View.scala
@@ -99,6 +99,6 @@ abstract class View[S] {
    *   an empty state object or `null` to hand to the process method when an event for a previously unknown subject id
    *   is seen.
    */
-  def emptyState: S
+  def emptyState: S = null.asInstanceOf[S]
 
 }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/ViewProvider.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/view/ViewProvider.scala
@@ -19,16 +19,16 @@ package kalix.scalasdk.view
 import com.google.protobuf.Descriptors
 import scala.collection.immutable.Seq
 
-import kalix.scalasdk.impl.view.ViewRouter
+import kalix.scalasdk.impl.view.ViewUpdateRouter
 
-trait ViewProvider[S, V <: View[S]] {
+trait ViewProvider {
   def serviceDescriptor: Descriptors.ServiceDescriptor
 
   def viewId: String
 
   def options: ViewOptions
 
-  def newRouter(context: ViewCreationContext): ViewRouter[S, V]
+  def newRouter(context: ViewCreationContext): ViewUpdateRouter
 
   def additionalDescriptors: Seq[Descriptors.FileDescriptor]
 }

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/view/ReflectiveViewProvider.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/view/ReflectiveViewProvider.java
@@ -32,7 +32,7 @@ import kalix.springsdk.impl.view.ReflectiveViewRouter;
 import java.util.Optional;
 import java.util.function.Function;
 
-public class ReflectiveViewProvider<S, V extends View<S>> implements ViewProvider<S, V> {
+public class ReflectiveViewProvider<S, V extends View<S>> implements ViewProvider {
   private final Function<ViewCreationContext, V> factory;
 
   private final String viewId;

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixServer.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixServer.scala
@@ -325,8 +325,8 @@ case class KalixServer(applicationContext: ApplicationContext, config: Config) {
         kalixBeanFactory.getBean(clz)
       })
 
-  private def viewProvider[S, V <: View[S]](clz: Class[V]): ViewProvider[S, V] =
-    ReflectiveViewProvider.of(
+  private def viewProvider[S, V <: View[S]](clz: Class[V]): ViewProvider =
+    ReflectiveViewProvider.of[S, V](
       clz,
       messageCodec,
       context => {


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix/issues/7323 and replaces #1280

Support multi-table views for protocol-first and code generation, using a nested class approach. Single-table views remain unchanged, while multi-table views sit on top of this with an inner class for each view table and an extra level of routing for updates.

Samples and docs for advanced views in #1268 rebased on these changes (temporarily) and updated to use both event sourced entity with transform updates and value entity, to demonstrate what it looks like in an actual example. Leaving the samples and tests for multi-table views in that docs PR.

Spring SDK changes will be done separately.