### PR TITLE
cleansing

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
@@ -73,7 +73,7 @@ object ActionTestKitGenerator {
         |  }
         |
         |  public static $testKitClassName of(Function<ActionCreationContext, $className> actionFactory) {
-        |    return new $testKitClassName(actionFactory, MockRegistry.EMPTY);
+        |    return new $testKitClassName(actionFactory, MockRegistryImpl.empty);
         |  }
         |
         |  public static $testKitClassName of(Function<ActionCreationContext, $className> actionFactory, MockRegistry mockRegistry) {

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
@@ -33,7 +33,7 @@ public final class MyServiceNamedActionTestKit {
   }
 
   public static MyServiceNamedActionTestKit of(Function<ActionCreationContext, MyServiceNamedAction> actionFactory) {
-    return new MyServiceNamedActionTestKit(actionFactory, MockRegistry.EMPTY);
+    return new MyServiceNamedActionTestKit(actionFactory, MockRegistryImpl.empty);
   }
 
   public static MyServiceNamedActionTestKit of(Function<ActionCreationContext, MyServiceNamedAction> actionFactory, MockRegistry mockRegistry) {

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -33,7 +33,7 @@ public final class MyServiceActionTestKit {
   }
 
   public static MyServiceActionTestKit of(Function<ActionCreationContext, MyServiceAction> actionFactory) {
-    return new MyServiceActionTestKit(actionFactory, MockRegistry.EMPTY);
+    return new MyServiceActionTestKit(actionFactory, MockRegistryImpl.empty);
   }
 
   public static MyServiceActionTestKit of(Function<ActionCreationContext, MyServiceAction> actionFactory, MockRegistry mockRegistry) {

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -33,7 +33,7 @@ public final class MyServiceActionTestKit {
   }
 
   public static MyServiceActionTestKit of(Function<ActionCreationContext, MyServiceAction> actionFactory) {
-    return new MyServiceActionTestKit(actionFactory, MockRegistry.EMPTY);
+    return new MyServiceActionTestKit(actionFactory, MockRegistryImpl.empty);
   }
 
   public static MyServiceActionTestKit of(Function<ActionCreationContext, MyServiceAction> actionFactory, MockRegistry mockRegistry) {

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
@@ -31,7 +31,7 @@ public final class MyServiceActionImplTestKit {
   }
 
   public static MyServiceActionImplTestKit of(Function<ActionCreationContext, MyServiceActionImpl> actionFactory) {
-    return new MyServiceActionImplTestKit(actionFactory, MockRegistry.EMPTY);
+    return new MyServiceActionImplTestKit(actionFactory, MockRegistryImpl.empty);
   }
 
   public static MyServiceActionImplTestKit of(Function<ActionCreationContext, MyServiceActionImpl> actionFactory, MockRegistry mockRegistry) {

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/MockRegistry.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/MockRegistry.java
@@ -16,8 +16,6 @@
 
 package kalix.javasdk.testkit;
 
-import kalix.javasdk.testkit.impl.MockRegistryImpl;
-
 /**
  * This trait is meant to allow for unit testing when a service has cross-component or cross-service
  * calls. The set of mocks or stubs will be matched by its class type upon a call of an external
@@ -33,15 +31,4 @@ public interface MockRegistry {
    * @param <T> The service interface to be mocked.
    */
   <T> MockRegistry withMock(Class<T> clazz, T instance);
-
-  /**
-   * Returns an empty instance of MockRegistry that can be chained with `withMock`
-   *
-   * @return a new instance of MockRegistry
-   */
-  static MockRegistry create() {
-    return MockRegistryImpl.empty();
-  }
-
-  MockRegistry EMPTY = MockRegistryImpl.empty();
 }

--- a/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitActionContext.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitActionContext.scala
@@ -24,18 +24,18 @@ import kalix.javasdk.testkit.MockRegistry
 /**
  * INTERNAL API Used by the generated testkit
  */
-final class TestKitActionContext(metadata: Metadata, mockRegistry: MockRegistry = MockRegistry.EMPTY)
+final class TestKitActionContext(metadata: Metadata, mockRegistry: MockRegistry = MockRegistryImpl.empty)
     extends AbstractTestKitContext(mockRegistry)
     with ActionContext
     with ActionCreationContext
     with InternalContext {
 
   def this() = {
-    this(Metadata.EMPTY, MockRegistry.EMPTY)
+    this(Metadata.EMPTY, MockRegistryImpl.empty)
   }
 
   def this(metadata: Metadata) = {
-    this(metadata, MockRegistry.EMPTY)
+    this(metadata, MockRegistryImpl.empty)
   }
 
   override def metadata() = metadata

--- a/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitEventSourcedEntityContext.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitEventSourcedEntityContext.scala
@@ -25,12 +25,12 @@ import kalix.javasdk.testkit.MockRegistry
  */
 final class TestKitEventSourcedEntityContext(
     override val entityId: String,
-    mockRegistry: MockRegistry = MockRegistry.EMPTY)
+    mockRegistry: MockRegistry = MockRegistryImpl.empty)
     extends AbstractTestKitContext(mockRegistry)
     with EventSourcedEntityContext {
 
   def this(entityId: String) = {
-    this(entityId, MockRegistry.EMPTY)
+    this(entityId, MockRegistryImpl.empty)
   }
 
   override def materializer(): Materializer = throw new UnsupportedOperationException(

--- a/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitValueEntityCommandContext.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitValueEntityCommandContext.scala
@@ -28,7 +28,7 @@ final class TestKitValueEntityCommandContext(
     override val commandName: String = "stubCommandName",
     override val commandId: Long = 0L,
     override val metadata: Metadata = Metadata.EMPTY,
-    mockRegistry: MockRegistry = MockRegistry.EMPTY)
+    mockRegistry: MockRegistry = MockRegistryImpl.empty)
     extends AbstractTestKitContext(mockRegistry)
     with ValueEntityContext
     with CommandContext {

--- a/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitValueEntityContext.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitValueEntityContext.scala
@@ -23,12 +23,14 @@ import kalix.javasdk.valueentity.ValueEntityContext
 /**
  * INTERNAL API Used by the generated testkit
  */
-final class TestKitValueEntityContext(override val entityId: String, mockRegistry: MockRegistry = MockRegistry.EMPTY)
+final class TestKitValueEntityContext(
+    override val entityId: String,
+    mockRegistry: MockRegistry = MockRegistryImpl.empty)
     extends AbstractTestKitContext(mockRegistry)
     with ValueEntityContext {
 
   def this(entityId: String) = {
-    this(entityId, MockRegistry.EMPTY)
+    this(entityId, MockRegistryImpl.empty)
   }
 
   override def materializer(): Materializer = throw new UnsupportedOperationException(

--- a/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/ActionTestkit.java
+++ b/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/ActionTestkit.java
@@ -71,7 +71,7 @@ public class ActionTestkit<A extends Action> {
    * @param <R> The type of reply that is expected from invoking a command handler
    */
   public <R> ActionResult<R> call(Function<A, Action.Effect<R>> func) {
-    TestKitActionContext context = new TestKitActionContext(Metadata.EMPTY, MockRegistry.EMPTY);
+    TestKitActionContext context = new TestKitActionContext(Metadata.EMPTY, MockRegistryImpl.empty);
     return new ActionResultImpl<>(func.apply(createAction(context)));
   }
 
@@ -85,7 +85,7 @@ public class ActionTestkit<A extends Action> {
    * @param <R> The type of reply that is expected from invoking a command handler
    */
   public <R> Flux<ActionResult<R>> streamedCall(Function<A, Flux<Action.Effect<R>>> func){
-    TestKitActionContext var2 = new TestKitActionContext(Metadata.EMPTY, MockRegistry.EMPTY);
+    TestKitActionContext var2 = new TestKitActionContext(Metadata.EMPTY, MockRegistryImpl.empty);
     Flux<Action.Effect<R>> res =  func.apply(this.createAction(var2));
     return res.map( i -> new ActionResultImpl<R>(i));
   }


### PR DESCRIPTION
I found the interface depending on the implementation when working on https://github.com/lightbend/kalix-jvm-sdk/issues/1314 and I needed to break the dependency build only the java docs. WDYT?