### PR TITLE
bump: kalix-proxy 1.0.29

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Kalix {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 0
-    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.0.28")
+    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.0.29")
   }
 
   // changing the Scala version of the Java SDK affects end users

--- a/samples/java-customer-registry-kafka-quickstart/docker-compose.yml
+++ b/samples/java-customer-registry-kafka-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=kafka
     ports:
       - "9000:9000"

--- a/samples/java-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-customer-registry-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-customer-registry-views-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-eventsourced-counter/docker-compose.yml
+++ b/samples/java-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/java-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # note the ports being different from other sample docker-compose files to allow this service to run
   # on the same local machine as the scala-customer-registry-
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.http-port=9001 -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9001:9001"

--- a/samples/java-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/java-eventsourced-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-eventsourced-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-fibonacci-action/docker-compose.yml
+++ b/samples/java-fibonacci-action/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-first-service/docker-compose.yml
+++ b/samples/java-first-service/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-reliable-timers/docker-compose.yml
+++ b/samples/java-reliable-timers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-replicatedentity-examples/docker-compose.yml
+++ b/samples/java-replicatedentity-examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/java-replicatedentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-shopping-cart-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-valueentity-counter/docker-compose.yml
+++ b/samples/java-valueentity-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-valueentity-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/java-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-valueentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-customer-registry-quickstart/docker-compose.yml
+++ b/samples/scala-customer-registry-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-eventsourced-counter/docker-compose.yml
+++ b/samples/scala-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/scala-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # note the ports being different from other sample docker-compose files to allow this service to run
   # on the same local machine as the scala-customer-registry-
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.http-port=9001 -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9001:9001"

--- a/samples/scala-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/scala-eventsourced-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/scala-eventsourced-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-fibonacci-action/docker-compose.yml
+++ b/samples/scala-fibonacci-action/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-first-service/docker-compose.yml
+++ b/samples/scala-first-service/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-reliable-timers/docker-compose.yml
+++ b/samples/scala-reliable-timers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-replicatedentity-examples/docker-compose.yml
+++ b/samples/scala-replicatedentity-examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-replicatedentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-valueentity-counter/docker-compose.yml
+++ b/samples/scala-valueentity-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-valueentity-customer-registry/docker-compose.yml
+++ b/samples/scala-valueentity-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/scala-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-valueentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-customer-registry-quickstart/docker-compose.yml
+++ b/samples/spring-customer-registry-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/spring-customer-registry-views-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-doc-snippets/docker-compose.yml
+++ b/samples/spring-doc-snippets/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-eventsourced-counter/docker-compose.yml
+++ b/samples/spring-eventsourced-counter/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/spring-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # note the ports being different from other sample docker-compose files to allow this service to run
   # on the same local machine as the scala-customer-registry-
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.http-port=9001 -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9001:9001"

--- a/samples/spring-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/spring-eventsourced-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/spring-eventsourced-shopping-cart/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-fibonacci-action/docker-compose.yml
+++ b/samples/spring-fibonacci-action/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-reliable-timers/docker-compose.yml
+++ b/samples/spring-reliable-timers/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-valueentity-counter/docker-compose.yml
+++ b/samples/spring-valueentity-counter/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-valueentity-customer-registry/docker-compose.yml
+++ b/samples/spring-valueentity-customer-registry/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/spring-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/spring-valueentity-shopping-cart/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.28
+    image: gcr.io/kalix-public/kalix-proxy:1.0.29
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-proxy/issues/1776

Note: proxy release to prod shouldn't be needed before this update, mainly for the dev proxy.