### PR TITLE
chore: fix escaping in composite keys documentation

### DIFF
--- a/docs/src/modules/spring/partials/entity-keys.adoc
+++ b/docs/src/modules/spring/partials/entity-keys.adoc
@@ -15,12 +15,12 @@ For instance, `@EntityKey("id")` will instruct Kalix to look up a matching path 
 
 === Composite keys
 
-It's also possible to have composite keys. For example, `@EntityKey(\{"groupId", "id"})` defines a composite key made of `groupId` and `id`. In such a case, the endpoints for this entity will need to have both path variables, e.g.:  `@RequestMapping("/users/\{groupId}/\{id}")`.
+It's also possible to have composite keys. For example, `@EntityKey({"groupId", "id"})` defines a composite key made of `groupId` and `id`. In such a case, the endpoints for this entity will need to have both path variables, e.g.:  `@RequestMapping("/users/\{groupId}/\{id}")`.
 
 === Generated keys
 
 Finally, you can ask Kalix to generate an Entity key, this is typically useful when creating an Entity, and the key is a surrogate key. To indicate to Kalix that an Entity key should be generated rather than extracted from the path, be sure to annotate the corresponding command method with `@GenerateEntityKey`. Typically, an Entity has only one method annotated with `@GenerateEntityKey`. The one that creates the Entity. All other methods will have `@EntityKey` annotation in order to extract the surrogate key from the endpoint path.
 
-It will often be necessary to access the generated entity key from inside the entities code. This can be done using the link:{attachmentsdir}/api/kalix/javasdk/EntityContext.html#entityId()[`EntityContext.entityId` {tab-icon}, window="new"] method.
+It will often be necessary to access the generated entity key from inside the entities code. This can be done using the link:{attachmentsdir}/api/kalix/javasdk/EntityContext.html#entityId()[`EntityContext.entityId`{tab-icon},window="new"] method.
 
 NOTE: Kalix generates a UUID version 4 (random) keys. Only version 4 UUIDs are currently supported for generated Entity keys.


### PR DESCRIPTION
Notice a small espacing mistake on the entity keys doc