### PR TITLE
fix: CPU arch detection for docker build fix

### DIFF
--- a/samples/scala-customer-registry-quickstart/build.sbt
+++ b/samples/scala-customer-registry-quickstart/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-doc-snippets/build.sbt
+++ b/samples/scala-doc-snippets/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-eventsourced-counter/build.sbt
+++ b/samples/scala-eventsourced-counter/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-eventsourced-customer-registry-subscriber/build.sbt
+++ b/samples/scala-eventsourced-customer-registry-subscriber/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-eventsourced-customer-registry/build.sbt
+++ b/samples/scala-eventsourced-customer-registry/build.sbt
@@ -14,7 +14,8 @@ dockerRepository := sys.props.get("docker.registry")
 dockerEntrypoint := Seq("bin/main")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq(

--- a/samples/scala-eventsourced-shopping-cart/build.sbt
+++ b/samples/scala-eventsourced-shopping-cart/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-fibonacci-action/build.sbt
+++ b/samples/scala-fibonacci-action/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-first-service/build.sbt
+++ b/samples/scala-first-service/build.sbt
@@ -8,7 +8,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-reliable-timers/build.sbt
+++ b/samples/scala-reliable-timers/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-replicatedentity-examples/build.sbt
+++ b/samples/scala-replicatedentity-examples/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-replicatedentity-shopping-cart/build.sbt
+++ b/samples/scala-replicatedentity-shopping-cart/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-valueentity-counter/build.sbt
+++ b/samples/scala-valueentity-counter/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-valueentity-customer-registry/build.sbt
+++ b/samples/scala-valueentity-customer-registry/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."

--- a/samples/scala-valueentity-shopping-cart/build.sbt
+++ b/samples/scala-valueentity-shopping-cart/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq(

--- a/samples/scala-view-store/build.sbt
+++ b/samples/scala-view-store/build.sbt
@@ -12,7 +12,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq(


### PR DESCRIPTION
MacOS intel CPU (sometimes?) reports arch as x86_64 and not amd64 so check for both and cross build only if neither matches.