### PR TITLE
fix: codegen for multi-table views with `View` in their name

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ViewServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ViewServiceSourceGenerator.scala
@@ -112,7 +112,7 @@ object ViewServiceSourceGenerator {
         Some(
           viewRouterClass(
             s"${className}Router",
-            s"Abstract${view.className}.Abstract$className",
+            s"${view.abstractViewName}.Abstract$className",
             stateType,
             transformedUpdates,
             static = true))

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.java
@@ -2,6 +2,8 @@ package org.example;
 
 import kalix.javasdk.Kalix;
 import kalix.javasdk.view.ViewCreationContext;
+import org.example.view.AnotherCustomerOrdersViewImpl;
+import org.example.view.AnotherCustomerOrdersViewProvider;
 import org.example.view.CustomerOrdersView;
 import org.example.view.CustomerOrdersViewModel;
 import org.example.view.CustomerOrdersViewProvider;
@@ -15,9 +17,11 @@ import java.util.function.Function;
 public final class KalixFactory {
 
   public static Kalix withComponents(
+      Function<ViewCreationContext, AnotherCustomerOrdersViewImpl> createAnotherCustomerOrdersViewImpl,
       Function<ViewCreationContext, CustomerOrdersView> createCustomerOrdersView) {
     Kalix kalix = new Kalix();
     return kalix
+      .register(AnotherCustomerOrdersViewProvider.of(createAnotherCustomerOrdersViewImpl))
       .register(CustomerOrdersViewProvider.of(createCustomerOrdersView));
   }
 }

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractAnotherCustomerOrdersView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractAnotherCustomerOrdersView.java
@@ -1,0 +1,53 @@
+package org.example.view;
+
+import kalix.javasdk.view.View;
+import kalix.javasdk.view.ViewContext;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public abstract class AbstractAnotherCustomerOrdersView {
+
+  private AbstractCustomersViewTable customersViewTable;
+  private AbstractProductsViewTable productsViewTable;
+
+  public AbstractAnotherCustomerOrdersView(ViewContext context) {
+    customersViewTable = createCustomersViewTable(context);
+    productsViewTable = createProductsViewTable(context);
+  }
+
+  public AbstractCustomersViewTable customersViewTable() {
+    return customersViewTable;
+  }
+
+  public abstract AbstractCustomersViewTable createCustomersViewTable(ViewContext context);
+
+  public static abstract class AbstractCustomersViewTable extends View<CustomerOrdersViewModel.Customer> {
+
+    public abstract View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerCreated(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerCreated customerCreated);
+
+    public abstract View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerNameChanged(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerNameChanged customerNameChanged);
+
+  }
+
+  public AbstractProductsViewTable productsViewTable() {
+    return productsViewTable;
+  }
+
+  public abstract AbstractProductsViewTable createProductsViewTable(ViewContext context);
+
+  public static abstract class AbstractProductsViewTable extends View<CustomerOrdersViewModel.Product> {
+
+    public abstract View.UpdateEffect<CustomerOrdersViewModel.Product> updateProduct(
+        CustomerOrdersViewModel.Product state,
+        CustomerOrdersViewModel.ProductCreated productCreated);
+
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewProvider.java
@@ -1,0 +1,72 @@
+package org.example.view;
+
+import com.google.protobuf.Descriptors;
+import kalix.javasdk.view.ViewCreationContext;
+import kalix.javasdk.view.ViewOptions;
+import kalix.javasdk.view.ViewProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class AnotherCustomerOrdersViewProvider implements ViewProvider {
+
+  private final Function<ViewCreationContext, AnotherCustomerOrdersViewImpl> viewFactory;
+  private final String viewId;
+  private final ViewOptions options;
+
+  /** Factory method of AnotherCustomerOrdersViewImpl */
+  public static AnotherCustomerOrdersViewProvider of(
+      Function<ViewCreationContext, AnotherCustomerOrdersViewImpl> viewFactory) {
+    return new AnotherCustomerOrdersViewProvider(viewFactory, "AnotherCustomerOrdersView", ViewOptions.defaults());
+  }
+
+  private AnotherCustomerOrdersViewProvider(
+      Function<ViewCreationContext, AnotherCustomerOrdersViewImpl> viewFactory,
+      String viewId,
+      ViewOptions options) {
+    this.viewFactory = viewFactory;
+    this.viewId = viewId;
+    this.options = options;
+  }
+
+  @Override
+  public String viewId() {
+    return viewId;
+  }
+
+  @Override
+  public final ViewOptions options() {
+    return options;
+  }
+
+  public final AnotherCustomerOrdersViewProvider withOptions(ViewOptions options) {
+    return new AnotherCustomerOrdersViewProvider(viewFactory, viewId, options);
+  }
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  public AnotherCustomerOrdersViewProvider withViewId(String viewId) {
+    return new AnotherCustomerOrdersViewProvider(viewFactory, viewId, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CustomerOrdersViewModel.getDescriptor().findServiceByName("AnotherCustomerOrdersView");
+  }
+
+  @Override
+  public final AnotherCustomerOrdersViewRouter newRouter(ViewCreationContext context) {
+    return new AnotherCustomerOrdersViewRouter(viewFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {CustomerOrdersViewModel.getDescriptor()};
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewRouter.java
@@ -1,0 +1,97 @@
+package org.example.view;
+
+import kalix.javasdk.impl.view.UpdateHandlerNotFound;
+import kalix.javasdk.impl.view.ViewMultiTableRouter;
+import kalix.javasdk.impl.view.ViewRouter;
+import kalix.javasdk.view.View;
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class AnotherCustomerOrdersViewRouter extends ViewMultiTableRouter {
+
+  private CustomersViewTableRouter customersViewTableRouter;
+  private ProductsViewTableRouter productsViewTableRouter;
+
+  public AnotherCustomerOrdersViewRouter(AnotherCustomerOrdersViewImpl view) {
+    customersViewTableRouter = new CustomersViewTableRouter(view.customersViewTable());
+    productsViewTableRouter = new ProductsViewTableRouter(view.productsViewTable());
+  }
+
+  public static class CustomersViewTableRouter extends ViewRouter<CustomerOrdersViewModel.Customer, AbstractAnotherCustomerOrdersView.AbstractCustomersViewTable> {
+
+    public CustomersViewTableRouter(AbstractAnotherCustomerOrdersView.AbstractCustomersViewTable view) {
+      super(view);
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Customer> handleUpdate(
+        String eventName,
+        CustomerOrdersViewModel.Customer state,
+        Object event) {
+
+      switch (eventName) {
+        case "UpdateCustomerCreated":
+          return view().updateCustomerCreated(
+              state,
+              (CustomerOrdersViewModel.CustomerCreated) event);
+
+        case "UpdateCustomerNameChanged":
+          return view().updateCustomerNameChanged(
+              state,
+              (CustomerOrdersViewModel.CustomerNameChanged) event);
+
+        default:
+          throw new UpdateHandlerNotFound(eventName);
+      }
+    }
+
+  }
+
+  public static class ProductsViewTableRouter extends ViewRouter<CustomerOrdersViewModel.Product, AbstractAnotherCustomerOrdersView.AbstractProductsViewTable> {
+
+    public ProductsViewTableRouter(AbstractAnotherCustomerOrdersView.AbstractProductsViewTable view) {
+      super(view);
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Product> handleUpdate(
+        String eventName,
+        CustomerOrdersViewModel.Product state,
+        Object event) {
+
+      switch (eventName) {
+        case "UpdateProduct":
+          return view().updateProduct(
+              state,
+              (CustomerOrdersViewModel.ProductCreated) event);
+
+        default:
+          throw new UpdateHandlerNotFound(eventName);
+      }
+    }
+
+  }
+
+
+  @Override
+  public ViewRouter<?, ?> viewRouter(String eventName) {
+    switch (eventName) {
+      case "UpdateCustomerCreated":
+        return customersViewTableRouter;
+
+      case "UpdateCustomerNameChanged":
+        return customersViewTableRouter;
+
+      case "UpdateProduct":
+        return productsViewTableRouter;
+
+      default:
+        throw new UpdateHandlerNotFound(eventName);
+    }
+  }
+
+}
+
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.java
@@ -1,6 +1,7 @@
 package org.example;
 
 import kalix.javasdk.Kalix;
+import org.example.view.AnotherCustomerOrdersViewImpl;
 import org.example.view.CustomerOrdersView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +21,7 @@ public final class Main {
     // If you prefer, you may remove this and manually register these components in a
     // `new Kalix()` instance.
     return KalixFactory.withComponents(
+      AnotherCustomerOrdersViewImpl::new,
       CustomerOrdersView::new);
   }
 

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/AnotherCustomerOrdersViewImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/AnotherCustomerOrdersViewImpl.java
@@ -1,0 +1,72 @@
+package org.example.view;
+
+import kalix.javasdk.view.View;
+import kalix.javasdk.view.ViewContext;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+// This is the implementation for the View Service described in your customer_orders.proto file.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class AnotherCustomerOrdersViewImpl extends AbstractAnotherCustomerOrdersView {
+
+  public AnotherCustomerOrdersViewImpl(ViewContext context) {
+    super(context);
+  }
+
+  @Override
+  public CustomersViewTable createCustomersViewTable(ViewContext context) {
+    return new CustomersViewTable(context);
+  }
+
+  public static class CustomersViewTable extends AbstractCustomersViewTable {
+
+    public CustomersViewTable(ViewContext context) {}
+
+    @Override
+    public CustomerOrdersViewModel.Customer emptyState() {
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state");
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerCreated(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerCreated customerCreated) {
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerCreated' not implemented yet");
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Customer> updateCustomerNameChanged(
+        CustomerOrdersViewModel.Customer state,
+        CustomerOrdersViewModel.CustomerNameChanged customerNameChanged) {
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerNameChanged' not implemented yet");
+    }
+
+  }
+
+  @Override
+  public ProductsViewTable createProductsViewTable(ViewContext context) {
+    return new ProductsViewTable(context);
+  }
+
+  public static class ProductsViewTable extends AbstractProductsViewTable {
+
+    public ProductsViewTable(ViewContext context) {}
+
+    @Override
+    public CustomerOrdersViewModel.Product emptyState() {
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state");
+    }
+
+    @Override
+    public View.UpdateEffect<CustomerOrdersViewModel.Product> updateProduct(
+        CustomerOrdersViewModel.Product state,
+        CustomerOrdersViewModel.ProductCreated productCreated) {
+      throw new UnsupportedOperationException("Update handler for 'UpdateProduct' not implemented yet");
+    }
+
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
@@ -122,3 +122,59 @@ service CustomerOrders {
     };
   }
 }
+
+// with `View` in the name
+service AnotherCustomerOrdersView {
+  option (kalix.codegen) = {
+    view: {}
+  };
+
+  rpc UpdateCustomerCreated(CustomerCreated) returns (Customer) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateCustomerNameChanged(CustomerNameChanged) returns (Customer) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateProduct(ProductCreated) returns (Product) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "products"
+    };
+    option (kalix.method).view.update = {
+      table: "products",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateOrder(Order) returns (Order) {
+    option (kalix.method).eventing.in = {
+      value_entity: "orders"
+    };
+    option (kalix.method).view.update = {
+      table: "orders"
+    };
+  }
+
+  rpc Get(CustomerOrdersRequest) returns (stream CustomerOrder) {
+    option (kalix.method).view.query = {
+      query: "SELECT * "
+          "FROM customers "
+          "JOIN orders ON orders.customer_id = customers.customer_id "
+          "JOIN products ON products.product_id = orders.product_id "
+          "WHERE customers.customer_id = :customer_id"
+    };
+  }
+}

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
@@ -123,7 +123,7 @@ object ViewServiceSourceGenerator {
         Some(
           viewRouterClass(
             s"${className}Router",
-            s"Abstract${view.className}#Abstract$className",
+            s"${view.abstractViewName}#Abstract$className",
             stateType,
             transformedUpdates))
       }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/KalixFactory.scala
@@ -2,6 +2,8 @@ package org.example
 
 import kalix.scalasdk.Kalix
 import kalix.scalasdk.view.ViewCreationContext
+import org.example.view.AnotherCustomerOrdersViewImpl
+import org.example.view.AnotherCustomerOrdersViewProvider
 import org.example.view.CustomerOrdersView
 import org.example.view.CustomerOrdersViewProvider
 
@@ -12,9 +14,11 @@ import org.example.view.CustomerOrdersViewProvider
 object KalixFactory {
 
   def withComponents(
+      createAnotherCustomerOrdersViewImpl: ViewCreationContext => AnotherCustomerOrdersViewImpl,
       createCustomerOrdersView: ViewCreationContext => CustomerOrdersView): Kalix = {
     val kalix = Kalix()
     kalix
+      .register(AnotherCustomerOrdersViewProvider(createAnotherCustomerOrdersViewImpl))
       .register(CustomerOrdersViewProvider(createCustomerOrdersView))
   }
 }

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractAnotherCustomerOrdersView.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AbstractAnotherCustomerOrdersView.scala
@@ -1,0 +1,31 @@
+package org.example.view
+
+import kalix.scalasdk.view.View
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+abstract class AbstractAnotherCustomerOrdersView {
+
+  def CustomersViewTable: AbstractCustomersViewTable
+
+  abstract class AbstractCustomersViewTable extends View[CustomerState] {
+    def updateCustomerCreated(
+        state: CustomerState,
+        customerCreated: CustomerCreated): View.UpdateEffect[CustomerState]
+
+    def updateCustomerNameChanged(
+        state: CustomerState,
+        customerNameChanged: CustomerNameChanged): View.UpdateEffect[CustomerState]
+  }
+
+  def ProductsViewTable: AbstractProductsViewTable
+
+  abstract class AbstractProductsViewTable extends View[ProductState] {
+    def updateProduct(
+        state: ProductState,
+        productCreated: ProductCreated): View.UpdateEffect[ProductState]
+  }
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewProvider.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewProvider.scala
@@ -1,0 +1,48 @@
+package org.example.view
+
+import com.google.protobuf.Descriptors
+import com.google.protobuf.EmptyProto
+import kalix.javasdk.impl.view.UpdateHandlerNotFound
+import kalix.scalasdk.impl.view.ViewRouter
+import kalix.scalasdk.view.View
+import kalix.scalasdk.view.ViewCreationContext
+import kalix.scalasdk.view.ViewOptions
+import kalix.scalasdk.view.ViewProvider
+
+import scala.collection.immutable.Seq
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+object AnotherCustomerOrdersViewProvider {
+  def apply(viewFactory: ViewCreationContext => AnotherCustomerOrdersViewImpl): AnotherCustomerOrdersViewProvider =
+    new AnotherCustomerOrdersViewProvider(viewFactory, viewId = "AnotherCustomerOrdersView", options = ViewOptions.defaults)
+}
+
+class AnotherCustomerOrdersViewProvider private(
+    viewFactory: ViewCreationContext => AnotherCustomerOrdersViewImpl,
+    override val viewId: String,
+    override val options: ViewOptions)
+  extends ViewProvider {
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  def withViewId(viewId: String): AnotherCustomerOrdersViewProvider =
+    new AnotherCustomerOrdersViewProvider(viewFactory, viewId, options)
+
+  def withOptions(newOptions: ViewOptions): AnotherCustomerOrdersViewProvider =
+    new AnotherCustomerOrdersViewProvider(viewFactory, viewId, newOptions)
+
+  override final def serviceDescriptor: Descriptors.ServiceDescriptor =
+    CustomerOrdersProto.javaDescriptor.findServiceByName("AnotherCustomerOrdersView")
+
+  override final def newRouter(context: ViewCreationContext): AnotherCustomerOrdersViewRouter =
+    new AnotherCustomerOrdersViewRouter(viewFactory(context))
+
+  override final def additionalDescriptors: Seq[Descriptors.FileDescriptor] =
+    CustomerOrdersProto.javaDescriptor ::
+    Nil
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewRouter.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-managed/org/example/view/AnotherCustomerOrdersViewRouter.scala
@@ -1,0 +1,86 @@
+package org.example.view
+
+import kalix.javasdk.impl.view.UpdateHandlerNotFound
+import kalix.scalasdk.impl.view.ViewMultiTableRouter
+import kalix.scalasdk.impl.view.ViewRouter
+import kalix.scalasdk.view.View
+
+// This code is managed by Kalix tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+object AnotherCustomerOrdersViewRouter {
+  class CustomersViewTableRouter(view: AbstractAnotherCustomerOrdersView#AbstractCustomersViewTable)
+    extends ViewRouter[CustomerState, AbstractAnotherCustomerOrdersView#AbstractCustomersViewTable](view) {
+
+    override def handleUpdate(
+        eventName: String,
+        state: CustomerState,
+        event: Any): View.UpdateEffect[CustomerState] = {
+
+      eventName match {
+        case "UpdateCustomerCreated" =>
+          view.updateCustomerCreated(
+              state,
+              event.asInstanceOf[CustomerCreated])
+
+        case "UpdateCustomerNameChanged" =>
+          view.updateCustomerNameChanged(
+              state,
+              event.asInstanceOf[CustomerNameChanged])
+
+        case _ =>
+          throw new UpdateHandlerNotFound(eventName)
+      }
+    }
+
+  }
+
+  class ProductsViewTableRouter(view: AbstractAnotherCustomerOrdersView#AbstractProductsViewTable)
+    extends ViewRouter[ProductState, AbstractAnotherCustomerOrdersView#AbstractProductsViewTable](view) {
+
+    override def handleUpdate(
+        eventName: String,
+        state: ProductState,
+        event: Any): View.UpdateEffect[ProductState] = {
+
+      eventName match {
+        case "UpdateProduct" =>
+          view.updateProduct(
+              state,
+              event.asInstanceOf[ProductCreated])
+
+        case _ =>
+          throw new UpdateHandlerNotFound(eventName)
+      }
+    }
+
+  }
+}
+
+class AnotherCustomerOrdersViewRouter(view: AnotherCustomerOrdersViewImpl) extends ViewMultiTableRouter {
+
+  private val customersViewTableRouter =
+    new AnotherCustomerOrdersViewRouter.CustomersViewTableRouter(view.CustomersViewTable)
+
+  private val productsViewTableRouter =
+    new AnotherCustomerOrdersViewRouter.ProductsViewTableRouter(view.ProductsViewTable)
+
+  override def viewRouter(eventName: String): ViewRouter[_, _] = {
+    eventName match {
+      case "UpdateCustomerCreated" =>
+        customersViewTableRouter
+
+      case "UpdateCustomerNameChanged" =>
+        customersViewTableRouter
+
+      case "UpdateProduct" =>
+        productsViewTableRouter
+
+      case _ =>
+        throw new UpdateHandlerNotFound(eventName)
+    }
+  }
+
+}
+

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/Main.scala
@@ -1,6 +1,7 @@
 package org.example
 
 import kalix.scalasdk.Kalix
+import org.example.view.AnotherCustomerOrdersViewImpl
 import org.example.view.CustomerOrdersView
 import org.slf4j.LoggerFactory
 
@@ -19,6 +20,7 @@ object Main {
     // If you prefer, you may remove this and manually register these components in a
     // `Kalix()` instance.
     KalixFactory.withComponents(
+      new AnotherCustomerOrdersViewImpl(_),
       new CustomerOrdersView(_))
   }
 

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/AnotherCustomerOrdersViewImpl.scala
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/generated-unmanaged/org/example/view/AnotherCustomerOrdersViewImpl.scala
@@ -1,0 +1,42 @@
+package org.example.view
+
+import kalix.scalasdk.view.View.UpdateEffect
+import kalix.scalasdk.view.ViewContext
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+class AnotherCustomerOrdersViewImpl(context: ViewContext) extends AbstractAnotherCustomerOrdersView {
+
+  object CustomersViewTable extends AbstractCustomersViewTable {
+
+    override def emptyState: CustomerState =
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
+
+    override def updateCustomerCreated(
+        state: CustomerState,
+        customerCreated: CustomerCreated): UpdateEffect[CustomerState] =
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerCreated' not implemented yet")
+
+    override def updateCustomerNameChanged(
+        state: CustomerState,
+        customerNameChanged: CustomerNameChanged): UpdateEffect[CustomerState] =
+      throw new UnsupportedOperationException("Update handler for 'UpdateCustomerNameChanged' not implemented yet")
+
+  }
+
+  object ProductsViewTable extends AbstractProductsViewTable {
+
+    override def emptyState: ProductState =
+      throw new UnsupportedOperationException("Not implemented yet, replace with your empty view state")
+
+    override def updateProduct(
+        state: ProductState,
+        productCreated: ProductCreated): UpdateEffect[ProductState] =
+      throw new UnsupportedOperationException("Update handler for 'UpdateProduct' not implemented yet")
+
+  }
+
+}

--- a/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
+++ b/codegen/scala-gen/src/test/resources/tests/view-service/view-multiple-tables/proto/customer_orders.proto
@@ -120,3 +120,59 @@ service CustomerOrders {
     };
   }
 }
+
+// with `View` in the name
+service AnotherCustomerOrdersView {
+  option (kalix.codegen) = {
+    view: {}
+  };
+
+  rpc UpdateCustomerCreated(CustomerCreated) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateCustomerNameChanged(CustomerNameChanged) returns (CustomerState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "customers"
+    };
+    option (kalix.method).view.update = {
+      table: "customers",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateProduct(ProductCreated) returns (ProductState) {
+    option (kalix.method).eventing.in = {
+      event_sourced_entity: "products"
+    };
+    option (kalix.method).view.update = {
+      table: "products",
+      transform_updates: true
+    };
+  }
+
+  rpc UpdateOrder(OrderState) returns (OrderState) {
+    option (kalix.method).eventing.in = {
+      value_entity: "orders"
+    };
+    option (kalix.method).view.update = {
+      table: "orders"
+    };
+  }
+
+  rpc Get(CustomerOrdersRequest) returns (stream CustomerOrder) {
+    option (kalix.method).view.query = {
+      query: "SELECT * "
+          "FROM customers "
+          "JOIN orders ON orders.customer_id = customers.customer_id "
+          "JOIN products ON products.product_id = orders.product_id "
+          "WHERE customers.customer_id = :customer_id"
+    };
+  }
+}


### PR DESCRIPTION
Resolves #1397

Use the correct name for the abstract view class, and add codegen tests for this.