### PR TITLE
chore(spring-sdk): improve msg for null serialization error

### DIFF
--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/AnySupport.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/AnySupport.scala
@@ -372,7 +372,7 @@ class AnySupport(
         ScalaPbAny(typeUrlPrefix + "/" + scalaPbMessage.companion.scalaDescriptor.fullName, scalaPbMessage.toByteString)
 
       case null =>
-        throw SerializationException(s"Don't know how to serialize object of type null.")
+        throw NullSerializationException
 
       case _ if ClassToPrimitives.contains(value.getClass) =>
         val primitive = ClassToPrimitives(value.getClass)
@@ -472,6 +472,7 @@ class AnySupport(
 }
 
 final case class SerializationException(msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
+object NullSerializationException extends RuntimeException("Don't know how to serialize object of type null.")
 
 /**
  * INTERNAL API

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/SpringSdkMessageCodec.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/SpringSdkMessageCodec.scala
@@ -18,11 +18,11 @@ package kalix.springsdk.impl
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
-
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => JavaPbAny }
 import kalix.javasdk.JsonSupport
 import kalix.javasdk.impl.MessageCodec
+import kalix.javasdk.impl.NullSerializationException
 import kalix.springsdk.annotations.TypeName
 
 private[springsdk] class SpringSdkMessageCodec extends MessageCodec {
@@ -32,11 +32,15 @@ private[springsdk] class SpringSdkMessageCodec extends MessageCodec {
   /**
    * In the Spring SDK, output data are encoded to Json.
    */
-  override def encodeScala(value: Any): ScalaPbAny =
+  override def encodeScala(value: Any): ScalaPbAny = {
+    if (value == null) throw NullSerializationException
     ScalaPbAny.fromJavaProto(JsonSupport.encodeJson(value, lookupTypeHint(value)))
+  }
 
-  override def encodeJava(value: Any): JavaPbAny =
+  override def encodeJava(value: Any): JavaPbAny = {
+    if (value == null) throw NullSerializationException
     JsonSupport.encodeJson(value, lookupTypeHint(value))
+  }
 
   private def lookupTypeHint(value: Any): String =
     lookupTypeHint(value.getClass)

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/SpringSdkMessageCodecSpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/SpringSdkMessageCodecSpec.scala
@@ -17,9 +17,6 @@
 package kalix.springsdk.impl
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeName
 import kalix.javasdk.JsonSupport
 import kalix.springsdk.annotations.TypeName
 import kalix.springsdk.impl.SpringSdkMessageCodecSpec.SimpleClass
@@ -116,6 +113,20 @@ class SpringSdkMessageCodecSpec extends AnyWordSpec with Matchers {
         val encodedElephant = messageCodec.encodeScala(Elephant("Dumbo", 1))
         encodedElephant.typeUrl shouldBe jsonTypeUrlWith("Elephant")
       }
+    }
+
+    "throw if receiving null (scala)" in {
+      val failed = intercept[RuntimeException] {
+        messageCodec.encodeScala(null)
+      }
+      failed.getMessage shouldBe "Don't know how to serialize object of type null."
+    }
+
+    "throw if receiving null (java)" in {
+      val failed = intercept[RuntimeException] {
+        messageCodec.encodeJava(null)
+      }
+      failed.getMessage shouldBe "Don't know how to serialize object of type null."
     }
   }
 }


### PR DESCRIPTION
For spring-sdk, when a `null` is returned as reply from user function, we log this:
```
2023-01-19 15:16:16,564 ERROR customer.api.CustomerEntity - Terminating entity due to unexpected failure
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "value" is null
        at kalix.springsdk.impl.SpringSdkMessageCodec.lookupTypeHint(SpringSdkMessageCodec.scala:42)
```

This MR replaces the above by:
```
2023-01-19 22:15:58,056 ERROR customer.api.CustomerEntity - Terminating entity due to unexpected failure
kalix.javasdk.impl.SerializationException: Don't know how to serialize object of type null.
	at kalix.springsdk.impl.SpringSdkMessageCodec.encodeJava(SpringSdkMessageCodec.scala:43)
(..)
```

Same message as used currently for java/scala sdks.
