### PR TITLE
bump: spring boot in java spring client sample to 2.7.8

### DIFF
--- a/samples/java-valueentity-counter-spring-client/pom.xml
+++ b/samples/java-valueentity-counter-spring-client/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.7.8</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Make fossa happy.. bump to 3.0.2 is not straight forward so hopefully this suffices for now.