### PR TITLE
chore: fix java snipped for paging in query

### DIFF
--- a/docs/src/modules/java/partials/query-syntax-paging.adoc
+++ b/docs/src/modules/java/partials/query-syntax-paging.adoc
@@ -60,7 +60,7 @@ With the query return type like this:
 
 [source,java,indent=0]
 ----
-public record Response(List<Customer> customers, string next_page_token) { }
+public record Response(List<Customer> customers, String next_page_token) { }
 ----
 // tag::grpc[]
 


### PR DESCRIPTION
Quick fix for a fragment that was using `string` instead of `String`. 

I think this page may need some extra love. For instance, that same message has field name `next_page_token` instead of camelCase `nextPageToken`. 

This page is sharing some examples with the gRPC SDK hence the usage of snake_case. 

