### PR TITLE
fix: convert Java Instant fields to proto Timestamp

### DIFF
--- a/docs/src/modules/java/partials/query-syntax-reference.adoc
+++ b/docs/src/modules/java/partials/query-syntax-reference.adoc
@@ -204,11 +204,11 @@ When modeling your queries, the following data types are supported:
 | Array
 | `Collection<T>` and derived
 
-// not supported at the moment, see https://github.com/lightbend/kalix-jvm-sdk/issues/1391
-//| Timestamp
-//| `Instant`
-
+| Timestamp
+| `java.time.Instant`
 |===
+
+NOTE: `Instant` are only supported for queries with a `@RequestBody`. It's currently not possible to pass an `Instant` as a `@PathVariable` or `@RequestParam`.
 
 ==== Optional fields
 

--- a/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/KalixConfigurationTest.java
+++ b/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/KalixConfigurationTest.java
@@ -16,6 +16,7 @@
 
 package kalix.springsdk.testkit;
 
+import kalix.javasdk.JsonSupport;
 import kalix.javasdk.testkit.KalixTestKit;
 import kalix.springsdk.KalixConfiguration;
 import kalix.springsdk.impl.KalixServer;
@@ -26,9 +27,9 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /** Spring test configuration for Kalix integration tests. */
@@ -52,6 +53,10 @@ public class KalixConfigurationTest {
     return WebClient.builder()
         .baseUrl("http://localhost:" + kalixTestKit.getPort())
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .codecs(configurer -> {
+          configurer.defaultCodecs().jackson2JsonEncoder(
+            new Jackson2JsonEncoder(JsonSupport.getObjectMapper(), MediaType.APPLICATION_JSON));
+        })
         .build();
   }
 

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/customer/CustomerEntity.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/valueentities/customer/CustomerEntity.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.wiring.valueentities.customer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import kalix.javasdk.valueentity.ValueEntity;
+import kalix.springsdk.annotations.EntityKey;
+import kalix.springsdk.annotations.EntityType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.time.Instant;
+
+@EntityType("customer")
+@EntityKey("id")
+@RequestMapping("/customers/{id}")
+public class CustomerEntity extends ValueEntity<CustomerEntity.Customer> {
+
+  public static class Customer{
+    final public String name;
+    final public Instant createdOn;
+
+    @JsonCreator
+    public Customer(@JsonProperty("name") String name, @JsonProperty("createdOn") Instant createdOn) {
+      this.name = name;
+      this.createdOn = createdOn;
+    }
+  }
+
+  @PutMapping
+  public Effect<String> create(@RequestBody Customer customer) {
+    return effects().updateState(customer).thenReply("Ok");
+  }
+
+  @GetMapping
+  public Effect<CustomerEntity.Customer> get() {
+    return effects().reply(currentState());
+  }
+}

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/views/CustomerByCreationTime.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/views/CustomerByCreationTime.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.wiring.views;
+
+import com.example.wiring.valueentities.customer.CustomerEntity;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import kalix.javasdk.view.View;
+import kalix.springsdk.annotations.Query;
+import kalix.springsdk.annotations.Subscribe;
+import kalix.springsdk.annotations.Table;
+import kalix.springsdk.annotations.ViewId;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import reactor.core.publisher.Flux;
+
+import java.time.Instant;
+
+
+@ViewId("view_customers_by_creation_time")
+@Table("customers_by_creation_time")
+@Subscribe.ValueEntity(CustomerEntity.class)
+public class CustomerByCreationTime extends View<CustomerEntity.Customer> {
+
+  public static class ByTimeRequest {
+    final public Instant createdOn;
+
+    @JsonCreator
+    public ByTimeRequest(@JsonProperty("createdOn") Instant createdOn) {
+      this.createdOn = createdOn;
+    }
+  }
+
+  @PostMapping("/customers/by_creation_time")
+  @Query("SELECT * FROM customers_by_creation_time WHERE createdOn >= :createdOn")
+  public Flux<CustomerEntity.Customer> getCustomerByTime(@RequestBody ByTimeRequest request) {
+    return null;
+  }
+
+}
+

--- a/sdk/spring-sdk/src/it/java/kalix/springsdk/KalixConfigurationTest.java
+++ b/sdk/spring-sdk/src/it/java/kalix/springsdk/KalixConfigurationTest.java
@@ -16,6 +16,7 @@
 
 package kalix.springsdk;
 
+import kalix.javasdk.JsonSupport;
 import kalix.javasdk.testkit.KalixTestKit;
 import kalix.springsdk.impl.KalixServer;
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Import(KalixConfiguration.class)
@@ -35,8 +37,10 @@ public class KalixConfigurationTest {
 
   private Logger logger = LoggerFactory.getLogger(getClass());
 
-  @Autowired private ApplicationContext applicationContext;
-  @Autowired private KalixConfiguration kalixConfiguration;
+  @Autowired
+  private ApplicationContext applicationContext;
+  @Autowired
+  private KalixConfiguration kalixConfiguration;
 
   @Bean
   public KalixServer kalixServer() {
@@ -45,13 +49,19 @@ public class KalixConfigurationTest {
     return new KalixServer(applicationContext, kalixConfiguration.config());
   }
 
-  /** WebClient pointing to the proxy. */
+  /**
+   * WebClient pointing to the proxy.
+   */
   @Bean
   public WebClient createWebClient(KalixTestKit kalixTestKit) {
     return WebClient.builder()
-        .baseUrl("http://localhost:" + kalixTestKit.getPort())
-        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-        .build();
+      .baseUrl("http://localhost:" + kalixTestKit.getPort())
+      .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+      .codecs(configurer -> {
+        configurer.defaultCodecs().jackson2JsonEncoder(
+          new Jackson2JsonEncoder(JsonSupport.getObjectMapper(), MediaType.APPLICATION_JSON));
+      })
+      .build();
   }
 
   @Bean

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ProtoDescriptorGenerator.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ProtoDescriptorGenerator.scala
@@ -21,6 +21,7 @@ import com.google.protobuf.AnyProto
 import com.google.protobuf.DescriptorProtos
 import com.google.protobuf.Descriptors
 import com.google.protobuf.EmptyProto
+import com.google.protobuf.TimestampProto
 import kalix.{ Annotations => KalixAnnotations }
 import org.slf4j.LoggerFactory
 
@@ -33,6 +34,7 @@ private[impl] object ProtoDescriptorGenerator {
     Array(
       AnyProto.getDescriptor,
       EmptyProto.getDescriptor,
+      TimestampProto.getDescriptor,
       HttpAnnotationsProto.getDescriptor,
       KalixAnnotations.getDescriptor)
 
@@ -51,6 +53,7 @@ private[impl] object ProtoDescriptorGenerator {
 
     protoBuilder.addDependency("google/protobuf/any.proto")
     protoBuilder.addDependency("google/protobuf/empty.proto")
+    protoBuilder.addDependency("google/protobuf/timestamp.proto")
     protoBuilder.addService(service)
     messages.foreach(protoBuilder.addMessageType)
 

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ViewDescriptorFactory.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/ViewDescriptorFactory.scala
@@ -75,6 +75,7 @@ private[impl] object ViewDescriptorFactory extends ComponentDescriptorFactory {
 
           val tableName: String = component.getAnnotation(classOf[Table]).value()
           val tableTypeDescriptor = ProtoMessageDescriptors.generateMessageDescriptors(tableType)
+
           val tableProtoMessageName = tableTypeDescriptor.mainMessageDescriptor.getName
 
           val hasMethodLevelEventSourcedEntitySubs = component.getMethods.exists(hasEventSourcedEntitySubscription)

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/WebClientProviderHolder.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/WebClientProviderHolder.scala
@@ -26,10 +26,12 @@ import akka.actor.Extension
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.annotation.InternalApi
+import kalix.javasdk.JsonSupport
 import kalix.javasdk.impl.ProxyInfoHolder
 import kalix.springsdk.WebClientProvider
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.web.reactive.function.client.ExchangeFilterFunctions
 import org.springframework.web.reactive.function.client.WebClient
 
@@ -94,6 +96,10 @@ private[springsdk] class WebClientProviderImpl(system: ExtendedActorSystem) exte
       WebClient.builder
         .baseUrl(s"http://$host:$port")
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .codecs(configurer => {
+          configurer.defaultCodecs.jackson2JsonEncoder(
+            new Jackson2JsonEncoder(JsonSupport.getObjectMapper, MediaType.APPLICATION_JSON))
+        })
         .filter(ExchangeFilterFunctions.limitResponseSize(MaxCrossServiceResponseContentLength))
 
     identificationHeader.foreach { case (key, value) =>

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/InstantEntryForArray.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/InstantEntryForArray.java
@@ -16,13 +16,6 @@
 
 package kalix.springsdk.testmodels;
 
-import java.util.List;
+import java.time.Instant;
 
-public class NestedMessage {
-  public String string;
-  public SimpleMessage simpleMessage;
-
-  public InstantWrapper instantWrapper;
-  public List<InstantEntryForList> instantsList;
-  public InstantEntryForArray[] instantArrays;
-}
+public record InstantEntryForArray(Instant instant) { }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/InstantEntryForList.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/InstantEntryForList.java
@@ -16,13 +16,6 @@
 
 package kalix.springsdk.testmodels;
 
-import java.util.List;
+import java.time.Instant;
 
-public class NestedMessage {
-  public String string;
-  public SimpleMessage simpleMessage;
-
-  public InstantWrapper instantWrapper;
-  public List<InstantEntryForList> instantsList;
-  public InstantEntryForArray[] instantArrays;
-}
+public record InstantEntryForList(Instant instant) { }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/InstantWrapper.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/InstantWrapper.java
@@ -16,13 +16,6 @@
 
 package kalix.springsdk.testmodels;
 
-import java.util.List;
+import java.time.Instant;
 
-public class NestedMessage {
-  public String string;
-  public SimpleMessage simpleMessage;
-
-  public InstantWrapper instantWrapper;
-  public List<InstantEntryForList> instantsList;
-  public InstantEntryForArray[] instantArrays;
-}
+public record InstantWrapper(Instant instant) { }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/SimpleMessage.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/SimpleMessage.java
@@ -16,6 +16,8 @@
 
 package kalix.springsdk.testmodels;
 
+import java.time.Instant;
+
 public class SimpleMessage {
   // all them primitives
   public char c;
@@ -38,4 +40,5 @@ public class SimpleMessage {
   // arrays
   public int[] iA;
   public String[] sA;
+  public Instant inst;
 }

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/valueentity/TimeTrackerEntity.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/valueentity/TimeTrackerEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.springsdk.testmodels.valueentity;
+
+import kalix.javasdk.valueentity.ValueEntity;
+import kalix.springsdk.annotations.EntityKey;
+import kalix.springsdk.annotations.EntityType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@EntityKey("timerId")
+@EntityType("timer")
+@RequestMapping("/timer/{timerId}")
+public class TimeTrackerEntity extends ValueEntity<TimeTrackerEntity.TimerState> {
+
+
+
+  public static class TimerState {
+
+    final public String name;
+    final public Instant createdTime;
+    final public List<TimerEntry> entries;
+
+    public TimerState(String name, Instant createdTime, List<TimerEntry> entries) {
+      this.name = name;
+      this.createdTime = createdTime;
+      this.entries = entries;
+    }
+  }
+  public static class TimerEntry {
+    final public Instant started;
+    final public Instant stopped = Instant.MAX;
+
+    public TimerEntry(Instant started) {
+      this.started = started;
+    }
+  }
+
+  @PostMapping()
+  public Effect<String> start(@PathVariable String timerId) {
+    if (currentState() == null)
+      return effects().updateState(new TimerState(timerId, Instant.now(), new ArrayList<>())).thenReply("Created");
+    else
+      return effects().error("Already created");
+  }
+}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/view/ViewTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/view/ViewTestModels.java
@@ -21,12 +21,7 @@ import kalix.springsdk.annotations.*;
 import kalix.springsdk.testmodels.eventsourcedentity.Employee;
 import kalix.springsdk.testmodels.eventsourcedentity.EmployeeEvent;
 import kalix.springsdk.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels;
-import kalix.springsdk.testmodels.valueentity.AssignedCounter;
-import kalix.springsdk.testmodels.valueentity.AssignedCounterState;
-import kalix.springsdk.testmodels.valueentity.Counter;
-import kalix.springsdk.testmodels.valueentity.CounterState;
-import kalix.springsdk.testmodels.valueentity.User;
-import kalix.springsdk.testmodels.valueentity.UserEntity;
+import kalix.springsdk.testmodels.valueentity.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -532,5 +527,17 @@ public class ViewTestModels {
     @Table("assigned")
     @Subscribe.ValueEntity(AssignedCounter.class)
     public static class Assigned extends View<AssignedCounterState> {}
+  }
+
+  @ViewId("time-tracker-view")
+  @Table("time-tracker-view")
+  @Subscribe.ValueEntity(TimeTrackerEntity.class)
+  public static class TimeTrackerView extends View<TimeTrackerEntity.TimerState> {
+
+    @Query(value = "SELECT * FROM time-tracker-view WHERE name = :name")
+    @PostMapping("/timer/query2")
+    public TimeTrackerEntity.TimerState query2() {
+      return null;
+    }
   }
 }

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/MessageDescriptorGeneratorSpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/MessageDescriptorGeneratorSpec.scala
@@ -16,7 +16,11 @@
 
 package kalix.springsdk.impl
 
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.{ Type => ProtoType }
+import kalix.springsdk.testmodels.InstantEntryForList
+import kalix.springsdk.testmodels.TimeEnum
 import kalix.springsdk.testmodels.TimeEnum
 import kalix.springsdk.testmodels.{ NestedMessage, SimpleMessage }
 import org.scalatest.matchers.should.Matchers
@@ -27,58 +31,105 @@ class MessageDescriptorGeneratorSpec extends AnyWordSpec with Matchers {
   "The message descriptor extraction" should {
     "create a schema for a simple message" in {
       val messageDescriptor = ProtoMessageDescriptors.generateMessageDescriptors(classOf[SimpleMessage])
-      val descriptor = messageDescriptor.mainMessageDescriptor
+      val descriptor: DescriptorProtos.DescriptorProto = messageDescriptor.mainMessageDescriptor
       descriptor.getName shouldBe "SimpleMessage"
-      // as ordered in message
-      val expectedFieldsAndTypesInOrder = Seq(
-        "c" -> ProtoType.TYPE_STRING,
-        "by" -> ProtoType.TYPE_INT32,
-        "n" -> ProtoType.TYPE_INT32,
-        "l" -> ProtoType.TYPE_INT64,
-        "d" -> ProtoType.TYPE_DOUBLE,
-        "f" -> ProtoType.TYPE_FLOAT,
-        "bo" -> ProtoType.TYPE_BOOL,
-        // boxed primitives
-        "cO" -> ProtoType.TYPE_STRING,
-        "bO" -> ProtoType.TYPE_INT32,
-        "nO" -> ProtoType.TYPE_INT32,
-        "lO" -> ProtoType.TYPE_INT64,
-        "dO" -> ProtoType.TYPE_DOUBLE,
-        "fO" -> ProtoType.TYPE_FLOAT,
-        "boO" -> ProtoType.TYPE_BOOL,
-        // common object types mapping to proto primitives
-        "s" -> ProtoType.TYPE_STRING,
-        // arrays
-        "iA" -> ProtoType.TYPE_INT32,
-        "sA" -> ProtoType.TYPE_STRING)
-
-      expectedFieldsAndTypesInOrder.zipWithIndex.foreach { case ((fieldName, protoType), index) =>
-        withClue(s"index $index") {
-          val field = descriptor.getField(index)
-          field.getNumber shouldBe (index + 1) // field numbering start at 1
-          field.getName shouldBe fieldName
-          field.getType shouldBe protoType
-        }
-      }
+      checkSimpleMessageFields(descriptor)
     }
 
     "create a schema for a message with nested objects" in {
       val messageDescriptor = ProtoMessageDescriptors.generateMessageDescriptors(classOf[NestedMessage])
       val descriptor = messageDescriptor.mainMessageDescriptor
       descriptor.getName shouldBe "NestedMessage"
-      val field1 = descriptor.getField(0) // note: not field number but 0 based index
-      field1.getName shouldBe "one"
-      val field2 = descriptor.getField(1)
-      field2.getName shouldBe "two"
-      field2.getType shouldBe ProtoType.TYPE_MESSAGE
-      // nested message field type?
 
-      messageDescriptor.additionalMessageDescriptors should have size 1
-      messageDescriptor.additionalMessageDescriptors.head.getName shouldBe "SimpleMessage"
+      val field0 = descriptor.getField(0) // note: not field number but 0 based index
+      field0.getName shouldBe "string"
+
+      val field1 = descriptor.getField(1)
+      field1.getName shouldBe "simpleMessage"
+      field1.getType shouldBe ProtoType.TYPE_MESSAGE
+
+      val field2 = descriptor.getField(2)
+      field2.getName shouldBe "instantWrapper"
+      field2.getType shouldBe ProtoType.TYPE_MESSAGE
+
+      val field3 = descriptor.getField(3)
+      field3.getName shouldBe "instantsList"
+      field3.getType shouldBe ProtoType.TYPE_MESSAGE
+      field3.getLabel shouldBe Label.LABEL_REPEATED
+
+      val field4 = descriptor.getField(4)
+      field4.getName shouldBe "instantArrays"
+      field4.getType shouldBe ProtoType.TYPE_MESSAGE
+      field4.getLabel shouldBe Label.LABEL_REPEATED
+
+      messageDescriptor.additionalMessageDescriptors should have size 4
+
+      val instantWrapper =
+        messageDescriptor.additionalMessageDescriptors.find(_.getName == "InstantWrapper").get
+      instantWrapper.getField(0).getType shouldBe ProtoType.TYPE_MESSAGE
+      instantWrapper.getField(0).getTypeName shouldBe "google.protobuf.Timestamp"
+
+      val instantEntryForList =
+        messageDescriptor.additionalMessageDescriptors.find(_.getName == "InstantEntryForList").get
+      instantEntryForList.getField(0).getType shouldBe ProtoType.TYPE_MESSAGE
+      instantEntryForList.getField(0).getTypeName shouldBe "google.protobuf.Timestamp"
+
+      val instantEntryForArray =
+        messageDescriptor.additionalMessageDescriptors.find(_.getName == "InstantEntryForArray").get
+      instantEntryForArray.getField(0).getType shouldBe ProtoType.TYPE_MESSAGE
+      instantEntryForArray.getField(0).getTypeName shouldBe "google.protobuf.Timestamp"
+
     }
 
     "create a schema for a message with Java Instant and enum doesn't break" in {
-      ProtoMessageDescriptors.generateMessageDescriptors(classOf[TimeEnum])
+      val messageDescriptor = ProtoMessageDescriptors.generateMessageDescriptors(classOf[TimeEnum])
+      val descriptor: DescriptorProtos.DescriptorProto = messageDescriptor.mainMessageDescriptor
+      descriptor.getName shouldBe "TimeEnum"
+
+      val field0 = descriptor.getField(0)
+      field0.getName shouldBe "time"
+      field0.getType shouldBe ProtoType.TYPE_MESSAGE
+      field0.getTypeName shouldBe "google.protobuf.Timestamp"
+
+      val field1 = descriptor.getField(1)
+      field1.getName shouldBe "lev"
+      field1.getType shouldBe ProtoType.TYPE_ENUM
+    }
+
+  }
+
+  private def checkSimpleMessageFields(descriptor: DescriptorProtos.DescriptorProto): Unit = {
+    val expectedFieldsAndTypesInOrder = Seq(
+      "c" -> ProtoType.TYPE_STRING,
+      "by" -> ProtoType.TYPE_INT32,
+      "n" -> ProtoType.TYPE_INT32,
+      "l" -> ProtoType.TYPE_INT64,
+      "d" -> ProtoType.TYPE_DOUBLE,
+      "f" -> ProtoType.TYPE_FLOAT,
+      "bo" -> ProtoType.TYPE_BOOL,
+      // boxed primitives
+      "cO" -> ProtoType.TYPE_STRING,
+      "bO" -> ProtoType.TYPE_INT32,
+      "nO" -> ProtoType.TYPE_INT32,
+      "lO" -> ProtoType.TYPE_INT64,
+      "dO" -> ProtoType.TYPE_DOUBLE,
+      "fO" -> ProtoType.TYPE_FLOAT,
+      "boO" -> ProtoType.TYPE_BOOL,
+      // common object types mapping to proto primitives
+      "s" -> ProtoType.TYPE_STRING,
+      // arrays
+      "iA" -> ProtoType.TYPE_INT32,
+      "sA" -> ProtoType.TYPE_STRING,
+      // Instant mapping to message
+      "inst" -> ProtoType.TYPE_MESSAGE)
+
+    expectedFieldsAndTypesInOrder.zipWithIndex.foreach { case ((fieldName, protoType), index) =>
+      withClue(s"index $index") {
+        val field = descriptor.getField(index)
+        field.getNumber shouldBe (index + 1) // field numbering start at 1
+        field.getName shouldBe fieldName
+        field.getType shouldBe protoType
+      }
     }
   }
 

--- a/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ViewDescriptorFactorySpec.scala
+++ b/sdk/spring-sdk/src/test/scala/kalix/springsdk/impl/ViewDescriptorFactorySpec.scala
@@ -18,6 +18,7 @@ package kalix.springsdk.impl
 
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
+import com.google.protobuf.timestamp.Timestamp
 import kalix.JwtMethodOptions.JwtMethodMode
 import kalix.springsdk.testmodels.subscriptions.PubSubTestModels.EventStreamSubscriptionView
 import kalix.springsdk.testmodels.subscriptions.PubSubTestModels.SubscribeOnTypeToEventSourcedEvents
@@ -28,6 +29,7 @@ import kalix.springsdk.testmodels.view.ViewTestModels.MultiTableViewWithMultiple
 import kalix.springsdk.testmodels.view.ViewTestModels.MultiTableViewWithoutQuery
 import kalix.springsdk.testmodels.view.ViewTestModels.SubscribeToEventSourcedEvents
 import kalix.springsdk.testmodels.view.ViewTestModels.SubscribeToEventSourcedEventsWithMethodWithState
+import kalix.springsdk.testmodels.view.ViewTestModels.TimeTrackerView
 import kalix.springsdk.testmodels.view.ViewTestModels.TransformedUserView
 import kalix.springsdk.testmodels.view.ViewTestModels.TransformedUserViewUsingState
 import kalix.springsdk.testmodels.view.ViewTestModels.TransformedUserViewWithDeletes
@@ -198,6 +200,23 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
 
         val rule = findHttpRule(desc, "GetUser")
         rule.getPost shouldBe "/users/by-email"
+      }
+
+    }
+
+    "convert Interval fields to proto Timestamp" in {
+      assertDescriptor[TimeTrackerView] { desc =>
+
+        val timerStateMsg = desc.fileDescriptor.findMessageTypeByName("TimerState")
+        val createdTimeField = timerStateMsg.findFieldByName("createdTime")
+        createdTimeField.getMessageType shouldBe Timestamp.javaDescriptor
+
+        val timerEntry = desc.fileDescriptor.findMessageTypeByName("TimerEntry")
+        val startedField = timerEntry.findFieldByName("started")
+        startedField.getMessageType shouldBe Timestamp.javaDescriptor
+
+        val stoppedField = timerEntry.findFieldByName("stopped")
+        stoppedField.getMessageType shouldBe Timestamp.javaDescriptor
       }
     }
 


### PR DESCRIPTION
Quite hacky solution for issue with views for types containing `Instant`. I still need to confirm that this will work. The current tests is only patching the proto message to use proto Timestamp instead. 


References #1391