### PR TITLE
chore: use JDK 17 for releasing maven plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1343,7 +1343,7 @@ jobs:
 
   publish-maven:
     docker:
-      - image: circleci/openjdk:11
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - restore_deps_cache


### PR DESCRIPTION
* otherwise publishM2 fails
* the maven pom has <maven.compiler.release>8 so it should still build for 8

Follow up of https://github.com/lightbend/kalix-jvm-sdk/pull/1430