### PR TITLE
chore: Update nexus-staging-maven-plugin for JDK 17, #1435

### DIFF
--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -58,7 +58,7 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.7</version>
+          <version>1.6.13</version>
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>


### PR DESCRIPTION
I was able to reproduce the "Unable to make field private final..." error locally. Seems fixed in later nexus-staging-maven-plugin version.

Fixes #1435