### PR TITLE
fix: use await after restarting an entity

### DIFF
--- a/sdk/spring-sdk/src/it/java/com/example/wiring/EventSourcedEntityIntegrationTest.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/EventSourcedEntityIntegrationTest.java
@@ -110,7 +110,12 @@ public class EventSourcedEntityIntegrationTest {
     restartCounterEntity(counterId);
 
     // current state is based on snapshot and should be the same as previously
-    Assertions.assertEquals(10, getCounter(counterId));
+    await()
+      .ignoreExceptions()
+      .atMost(20, TimeUnit.of(SECONDS))
+      .until(
+        () -> getCounter(counterId),
+        new IsEqual(10));
   }
 
   private Integer increaseCounter(String name, int value) {


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
References https://github.com/lightbend/kalix-jvm-sdk/issues/1439