### PR TITLE
ci: fix publish docs on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1407,7 +1407,7 @@ jobs:
       # deploy key for pushing docs to branch
       - add_ssh_keys:
           fingerprints:
-            - "fd:fd:d3:9d:88:2c:df:5c:5d:b9:c0:2f:43:c6:b8:82"
+            - "92:20:53:ff:db:d1:3f:f3:79:85:53:b5:9e:4b:b4:b4"
       - run:
           name: Publish docs
           command: make -C docs deploy

--- a/docs/bin/deploy.sh
+++ b/docs/bin/deploy.sh
@@ -84,6 +84,10 @@ function __deploy_checkout {
     info "Cloning $repo repository ..."
     git clone --origin upstream $repo_url "$dir"
   fi
+  if [ $? -ne 0 ]; then
+    error "Failed to clone/fetch repository"
+    exit 1
+  fi
   local local_branch_exists=$(git -C "$dir" rev-parse --verify $branch &> /dev/null; echo $?)
   local remote_branch_exists=$(git -C "$dir" ls-remote --exit-code --heads $repo_url $branch &> /dev/null; echo $?)
   if [ $local_branch_exists -ne 0 ] && [ $remote_branch_exists -ne 0 ] ; then


### PR DESCRIPTION
Closes #1447 

After much digging, ended up refreshing a specific SSH key.. tried it by connecting with ssh and it gets rid of the permission denied but I think it needs the new fingerprint to test all the way.

Added a check so it fails when failing to checkout.