### PR TITLE
chore: fix logger format in spring samples and archetypes

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -181,6 +181,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
+            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
             <argument>${D}{mainClass}</argument>
           </arguments>
           <environmentVariables>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Non json config for Kalix user dev modes, note that for actual deploy
+     the default sample JSON logging output must be used or else production
+     does not work -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="WARN"/>
+
+    <!-- Silence some details from Akka, should not be important to user/SDK dev mode -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/resources/logback.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/resources/logback.xml
@@ -31,7 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-<!--        <appender-ref ref="STDOUT"/>-->
         <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -181,6 +181,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
+            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
             <argument>${D}{mainClass}</argument>
           </arguments>
           <environmentVariables>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Non json config for Kalix user dev modes, note that for actual deploy
+     the default sample JSON logging output must be used or else production
+     does not work -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="WARN"/>
+
+    <!-- Silence some details from Akka, should not be important to user/SDK dev mode -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/resources/logback.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/resources/logback.xml
@@ -31,7 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-<!--        <appender-ref ref="STDOUT"/>-->
         <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -146,6 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -223,6 +224,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Non json config for Kalix user dev modes, note that for actual deploy
+     the default sample JSON logging output must be used or else production
+     does not work -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="WARN"/>
+
+    <!-- Silence some details from Akka, should not be important to user/SDK dev mode -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/logback.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -186,6 +186,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -263,6 +264,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/src/main/resources/logback-dev-mode.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Non json config for Kalix user dev modes, note that for actual deploy
+     the default sample JSON logging output must be used or else production
+     does not work -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="WARN"/>
+
+    <!-- Silence some details from Akka, should not be important to user/SDK dev mode -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/src/main/resources/logback.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-customer-registry-quickstart/pom.xml
+++ b/samples/spring-customer-registry-quickstart/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -207,6 +207,11 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
 
       <plugin>

--- a/samples/spring-customer-registry-quickstart/src/main/resources/logback.xml
+++ b/samples/spring-customer-registry-quickstart/src/main/resources/logback.xml
@@ -26,12 +26,11 @@
     </appender>
 
     <logger name="akka" level="INFO"/>
-    <logger name="kalix" level="DEBUG"/>
+    <logger name="kalix" level="INFO"/>
     <logger name="akka.http" level="INFO"/>
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-<!--        <appender-ref ref="STDOUT"/>-->
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/spring-customer-registry-views-quickstart/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -207,6 +207,11 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
 
       <plugin>

--- a/samples/spring-customer-registry-views-quickstart/src/main/resources/logback.xml
+++ b/samples/spring-customer-registry-views-quickstart/src/main/resources/logback.xml
@@ -26,12 +26,11 @@
     </appender>
 
     <logger name="akka" level="INFO"/>
-    <logger name="kalix" level="DEBUG"/>
+    <logger name="kalix" level="INFO"/>
     <logger name="akka.http" level="INFO"/>
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-<!--        <appender-ref ref="STDOUT"/>-->
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-doc-snippets/pom.xml
+++ b/samples/spring-doc-snippets/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -224,6 +224,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-doc-snippets/src/main/resources/logback.xml
+++ b/samples/spring-doc-snippets/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-eventsourced-counter/pom.xml
+++ b/samples/spring-eventsourced-counter/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -224,6 +224,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-eventsourced-counter/src/main/resources/logback.xml
+++ b/samples/spring-eventsourced-counter/src/main/resources/logback.xml
@@ -26,11 +26,11 @@
     </appender>
 
     <logger name="akka" level="INFO"/>
-    <logger name="kalix" level="DEBUG"/>
+    <logger name="kalix" level="INFO"/>
     <logger name="akka.http" level="INFO"/>
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -151,7 +151,7 @@
             <argument>-Dkalix.user-function-port=8081</argument>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -230,6 +230,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-eventsourced-customer-registry-subscriber/src/main/resources/logback.xml
+++ b/samples/spring-eventsourced-customer-registry-subscriber/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-eventsourced-customer-registry/pom.xml
+++ b/samples/spring-eventsourced-customer-registry/pom.xml
@@ -147,7 +147,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -208,6 +208,11 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
 
       <plugin>

--- a/samples/spring-eventsourced-customer-registry/src/main/resources/logback.xml
+++ b/samples/spring-eventsourced-customer-registry/src/main/resources/logback.xml
@@ -31,7 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-<!--        <appender-ref ref="STDOUT"/>-->
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/spring-eventsourced-shopping-cart/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -224,6 +224,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-eventsourced-shopping-cart/src/main/resources/logback.xml
+++ b/samples/spring-eventsourced-shopping-cart/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-fibonacci-action/pom.xml
+++ b/samples/spring-fibonacci-action/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -207,6 +207,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+       <configuration>
+          <systemPropertyVariables>
+              <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+          </systemPropertyVariables>
+        </configuration>
      </plugin>
 
       <plugin>

--- a/samples/spring-fibonacci-action/src/main/resources/logback.xml
+++ b/samples/spring-fibonacci-action/src/main/resources/logback.xml
@@ -31,7 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-<!--        <appender-ref ref="STDOUT"/>-->
         <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-reliable-timers/pom.xml
+++ b/samples/spring-reliable-timers/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -224,6 +224,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-reliable-timers/src/main/resources/logback.xml
+++ b/samples/spring-reliable-timers/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-valueentity-counter/pom.xml
+++ b/samples/spring-valueentity-counter/pom.xml
@@ -150,7 +150,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -229,6 +229,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-valueentity-counter/src/main/resources/logback.xml
+++ b/samples/spring-valueentity-counter/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-valueentity-customer-registry/pom.xml
+++ b/samples/spring-valueentity-customer-registry/pom.xml
@@ -146,7 +146,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -224,6 +224,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-valueentity-customer-registry/src/main/resources/logback.xml
+++ b/samples/spring-valueentity-customer-registry/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-valueentity-shopping-cart/pom.xml
+++ b/samples/spring-valueentity-shopping-cart/pom.xml
@@ -150,7 +150,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -229,6 +229,11 @@
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <version>3.0.2</version>
+        <configuration>
+            <systemPropertyVariables>
+                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+            </systemPropertyVariables>
+          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/samples/spring-valueentity-shopping-cart/src/main/resources/logback.xml
+++ b/samples/spring-valueentity-shopping-cart/src/main/resources/logback.xml
@@ -31,6 +31,6 @@
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>

--- a/samples/spring-view-store/pom.xml
+++ b/samples/spring-view-store/pom.xml
@@ -147,7 +147,7 @@
           <arguments>
             <argument>-classpath</argument>
             <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
+            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
             <argument>${mainClass}</argument>
           </arguments>
           <environmentVariables>
@@ -208,6 +208,11 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>3.0.2</version>
+        <configuration>
+          <systemPropertyVariables>
+              <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/samples/spring-view-store/src/main/resources/logback.xml
+++ b/samples/spring-view-store/src/main/resources/logback.xml
@@ -26,12 +26,11 @@
     </appender>
 
     <logger name="akka" level="INFO"/>
-    <logger name="kalix" level="DEBUG"/>
+    <logger name="kalix" level="INFO"/>
     <logger name="akka.http" level="INFO"/>
     <logger name="io.grpc" level="INFO"/>
 
     <root level="INFO">
-<!--        <appender-ref ref="STDOUT"/>-->
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Follow up of https://github.com/lightbend/kalix-jvm-sdk/pull/1449

Spring requires different settings when configuring logback through maven. 

PR updating the archetypes as well.