### PR TITLE
feat!: typed events in eventsourced entity

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntitySourceGenerator.scala
@@ -81,7 +81,7 @@ object EventSourcedEntitySourceGenerator {
        | * An event sourced entity handler that is the glue between the Protobuf service <code>${service.messageType.name}</code>
        | * and the command and event handler methods in the <code>${entity.messageType.name}</code> class.
        | */
-       |public class ${className}Router extends EventSourcedEntityRouter<$stateType, ${entity.messageType.name}> {
+       |public class ${className}Router extends EventSourcedEntityRouter<$stateType, Object, ${entity.messageType.name}> {
        |
        |  public ${className}Router(${entity.messageType.name} entity) {
        |    super(entity);
@@ -146,7 +146,7 @@ object EventSourcedEntitySourceGenerator {
        | *
        | * Should be used with the <code>register</code> method in {@link kalix.javasdk.Kalix}.
        | */
-       |public class ${className}Provider implements EventSourcedEntityProvider<${entity.state.messageType.fullName}, $className> {
+       |public class ${className}Provider implements EventSourcedEntityProvider<${entity.state.messageType.fullName}, Object, $className> {
        |
        |  private final Function<EventSourcedEntityContext, $className> entityFactory;
        |  private final EventSourcedEntityOptions options;
@@ -301,7 +301,7 @@ object EventSourcedEntitySourceGenerator {
        |
        |$managedComment
        |
-       |public abstract class Abstract${className} extends EventSourcedEntity<${qualifiedType(entity.state.messageType)}> {
+       |public abstract class Abstract${className} extends EventSourcedEntity<${qualifiedType(entity.state.messageType)}, Object> {
        |
        |  protected final Components components() {
        |    return new ComponentsImpl(commandContext());

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/EventSourcedEntityTestKitGenerator.scala
@@ -72,7 +72,7 @@ object EventSourcedEntityTestKitGenerator {
           |/**
           | * TestKit for unit testing $entityClassName
           | */
-          |public final class ${testkitClassName} extends EventSourcedEntityEffectsRunner<$stateClassName> {
+          |public final class ${testkitClassName} extends EventSourcedEntityEffectsRunner<$stateClassName, Object> {
           |
           |  /**
           |   * Create a testkit instance of $entityClassName

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/AbstractCounter.java
@@ -12,7 +12,7 @@ import org.example.state.OuterCounterState;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractCounter extends EventSourcedEntity<OuterCounterState.CounterState> {
+public abstract class AbstractCounter extends EventSourcedEntity<OuterCounterState.CounterState, Object> {
 
   protected final Components components() {
     return new ComponentsImpl(commandContext());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterProvider.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  *
  * Should be used with the <code>register</code> method in {@link kalix.javasdk.Kalix}.
  */
-public class CounterProvider implements EventSourcedEntityProvider<OuterCounterState.CounterState, Counter> {
+public class CounterProvider implements EventSourcedEntityProvider<OuterCounterState.CounterState, Object, Counter> {
 
   private final Function<EventSourcedEntityContext, Counter> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterRouter.java
@@ -16,7 +16,7 @@ import org.example.state.OuterCounterState;
  * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
  * and the command and event handler methods in the <code>Counter</code> class.
  */
-public class CounterRouter extends EventSourcedEntityRouter<OuterCounterState.CounterState, Counter> {
+public class CounterRouter extends EventSourcedEntityRouter<OuterCounterState.CounterState, Object, Counter> {
 
   public CounterRouter(Counter entity) {
     super(entity);

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 /**
  * TestKit for unit testing Counter
  */
-public final class CounterTestKit extends EventSourcedEntityEffectsRunner<OuterCounterState.CounterState> {
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<OuterCounterState.CounterState, Object> {
 
   /**
    * Create a testkit instance of Counter

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/AbstractCounter.java
@@ -9,7 +9,7 @@ import org.example.ComponentsImpl;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState> {
+public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState, Object> {
 
   protected final Components components() {
     return new ComponentsImpl(commandContext());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterProvider.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
  *
  * Should be used with the <code>register</code> method in {@link kalix.javasdk.Kalix}.
  */
-public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Counter> {
+public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Object, Counter> {
 
   private final Function<EventSourcedEntityContext, Counter> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterRouter.java
@@ -13,7 +13,7 @@ import kalix.javasdk.impl.eventsourcedentity.EventSourcedEntityRouter;
  * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
  * and the command and event handler methods in the <code>Counter</code> class.
  */
-public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Counter> {
+public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Object, Counter> {
 
   public CounterRouter(Counter entity) {
     super(entity);

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-managed/org/example/eventsourcedentity/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-managed/org/example/eventsourcedentity/CounterTestKit.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 /**
  * TestKit for unit testing Counter
  */
-public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState> {
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState, Object> {
 
   /**
    * Create a testkit instance of Counter

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
@@ -10,7 +10,7 @@ import org.example.eventsourcedentity.CounterApi;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState> {
+public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState, Object> {
 
   protected final Components components() {
     return new ComponentsImpl(commandContext());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
  *
  * Should be used with the <code>register</code> method in {@link kalix.javasdk.Kalix}.
  */
-public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Counter> {
+public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Object, Counter> {
 
   private final Function<EventSourcedEntityContext, Counter> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
@@ -14,7 +14,7 @@ import org.example.eventsourcedentity.CounterApi;
  * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
  * and the command and event handler methods in the <code>Counter</code> class.
  */
-public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Counter> {
+public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Object, Counter> {
 
   public CounterRouter(Counter entity) {
     super(entity);

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style-with-java-package/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 /**
  * TestKit for unit testing Counter
  */
-public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState> {
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState, Object> {
 
   /**
    * Create a testkit instance of Counter

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
@@ -10,7 +10,7 @@ import org.example.eventsourcedentity.CounterApi;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState> {
+public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState, Object> {
 
   protected final Components components() {
     return new ComponentsImpl(commandContext());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
  *
  * Should be used with the <code>register</code> method in {@link kalix.javasdk.Kalix}.
  */
-public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Counter> {
+public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Object, Counter> {
 
   private final Function<EventSourcedEntityContext, Counter> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
@@ -14,7 +14,7 @@ import org.example.eventsourcedentity.CounterApi;
  * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
  * and the command and event handler methods in the <code>Counter</code> class.
  */
-public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Counter> {
+public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Object, Counter> {
 
   public CounterRouter(Counter entity) {
     super(entity);

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 /**
  * TestKit for unit testing Counter
  */
-public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState> {
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState, Object> {
 
   /**
    * Create a testkit instance of Counter

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
@@ -12,7 +12,7 @@ import org.example.eventsourcedentity.state.OuterCounterState;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractCounter extends EventSourcedEntity<OuterCounterState.CounterState> {
+public abstract class AbstractCounter extends EventSourcedEntity<OuterCounterState.CounterState, Object> {
 
   protected final Components components() {
     return new ComponentsImpl(commandContext());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  *
  * Should be used with the <code>register</code> method in {@link kalix.javasdk.Kalix}.
  */
-public class CounterProvider implements EventSourcedEntityProvider<OuterCounterState.CounterState, Counter> {
+public class CounterProvider implements EventSourcedEntityProvider<OuterCounterState.CounterState, Object, Counter> {
 
   private final Function<EventSourcedEntityContext, Counter> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
@@ -16,7 +16,7 @@ import org.example.eventsourcedentity.state.OuterCounterState;
  * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
  * and the command and event handler methods in the <code>Counter</code> class.
  */
-public class CounterRouter extends EventSourcedEntityRouter<OuterCounterState.CounterState, Counter> {
+public class CounterRouter extends EventSourcedEntityRouter<OuterCounterState.CounterState, Object, Counter> {
 
   public CounterRouter(Counter entity) {
     super(entity);

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 /**
  * TestKit for unit testing Counter
  */
-public final class CounterTestKit extends EventSourcedEntityEffectsRunner<OuterCounterState.CounterState> {
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<OuterCounterState.CounterState, Object> {
 
   /**
    * Create a testkit instance of Counter

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/AbstractCounterServiceEntity.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/AbstractCounterServiceEntity.java
@@ -10,7 +10,7 @@ import org.example.eventsourcedentity.domain.CounterDomain;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractCounterServiceEntity extends EventSourcedEntity<CounterDomain.CounterState> {
+public abstract class AbstractCounterServiceEntity extends EventSourcedEntity<CounterDomain.CounterState, Object> {
 
   protected final Components components() {
     return new ComponentsImpl(commandContext());

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityProvider.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
  *
  * Should be used with the <code>register</code> method in {@link kalix.javasdk.Kalix}.
  */
-public class CounterServiceEntityProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, CounterServiceEntity> {
+public class CounterServiceEntityProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Object, CounterServiceEntity> {
 
   private final Function<EventSourcedEntityContext, CounterServiceEntity> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityRouter.java
@@ -14,7 +14,7 @@ import org.example.eventsourcedentity.domain.CounterDomain;
  * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
  * and the command and event handler methods in the <code>CounterServiceEntity</code> class.
  */
-public class CounterServiceEntityRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, CounterServiceEntity> {
+public class CounterServiceEntityRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Object, CounterServiceEntity> {
 
   public CounterServiceEntityRouter(CounterServiceEntity entity) {
     super(entity);

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-managed/org/example/eventsourcedentity/CounterServiceEntityTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-managed/org/example/eventsourcedentity/CounterServiceEntityTestKit.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 /**
  * TestKit for unit testing CounterServiceEntity
  */
-public final class CounterServiceEntityTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState> {
+public final class CounterServiceEntityTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState, Object> {
 
   /**
    * Create a testkit instance of CounterServiceEntity

--- a/samples/spring-eventsourced-counter/src/main/java/com/example/Counter.java
+++ b/samples/spring-eventsourced-counter/src/main/java/com/example/Counter.java
@@ -27,13 +27,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.List;
+
 import static com.example.CounterEvent.ValueIncreased;
 import static com.example.CounterEvent.ValueMultiplied;
 
 @EntityKey("id")
 @EntityType("counter")
 @RequestMapping("/counter/{id}")
-public class Counter extends EventSourcedEntity<Integer> {
+public class Counter extends EventSourcedEntity<Integer, CounterEvent> {
 
     private Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/samples/spring-eventsourced-counter/src/test/java/com/example/CounterTest.java
+++ b/samples/spring-eventsourced-counter/src/test/java/com/example/CounterTest.java
@@ -13,8 +13,8 @@ public class CounterTest {
 
   @Test
   public void testIncrease() {
-    EventSourcedTestKit<Integer, Counter> testKit = EventSourcedTestKit.of(Counter::new);
-    EventSourcedResult<String> result = testKit.call(e -> e.increase(10));
+    EventSourcedTestKit<Integer, CounterEvent, Counter> testKit = EventSourcedTestKit.of(Counter::new);
+    EventSourcedResult<String, CounterEvent> result = testKit.call(e -> e.increase(10));
 
     assertTrue(result.isReply());
     assertEquals("10", result.getReply());
@@ -25,11 +25,11 @@ public class CounterTest {
 
   @Test
   public void testMultiply() {
-    EventSourcedTestKit<Integer, Counter> testKit = EventSourcedTestKit.of(Counter::new);
+    EventSourcedTestKit<Integer, CounterEvent, Counter> testKit = EventSourcedTestKit.of(Counter::new);
     // set initial value to 2
     testKit.call(e -> e.increase(2));
 
-    EventSourcedResult<String> result = testKit.call(e -> e.multiply(10));
+    EventSourcedResult<String, CounterEvent> result = testKit.call(e -> e.multiply(10));
     assertTrue(result.isReply());
     assertEquals("20", result.getReply());
     assertEquals(1, result.getAllEvents().size());

--- a/samples/spring-eventsourced-counter/src/test/java/com/example/CounterTest.java
+++ b/samples/spring-eventsourced-counter/src/test/java/com/example/CounterTest.java
@@ -14,7 +14,7 @@ public class CounterTest {
   @Test
   public void testIncrease() {
     EventSourcedTestKit<Integer, CounterEvent, Counter> testKit = EventSourcedTestKit.of(Counter::new);
-    EventSourcedResult<String, CounterEvent> result = testKit.call(e -> e.increase(10));
+    EventSourcedResult<String> result = testKit.call(e -> e.increase(10));
 
     assertTrue(result.isReply());
     assertEquals("10", result.getReply());
@@ -29,7 +29,7 @@ public class CounterTest {
     // set initial value to 2
     testKit.call(e -> e.increase(2));
 
-    EventSourcedResult<String, CounterEvent> result = testKit.call(e -> e.multiply(10));
+    EventSourcedResult<String> result = testKit.call(e -> e.multiply(10));
     assertTrue(result.isReply());
     assertEquals("20", result.getReply());
     assertEquals(1, result.getAllEvents().size());

--- a/samples/spring-eventsourced-customer-registry/src/main/java/customer/api/CustomerEntity.java
+++ b/samples/spring-eventsourced-customer-registry/src/main/java/customer/api/CustomerEntity.java
@@ -2,6 +2,7 @@ package customer.api;
 
 import customer.domain.Address;
 import customer.domain.Customer;
+import customer.domain.CustomerEvent;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import kalix.springsdk.annotations.EntityKey;
@@ -14,7 +15,7 @@ import static customer.domain.CustomerEvent.*;
 @EntityKey("id")
 @EntityType("customer")
 @RequestMapping("/customer/{id}")
-public class CustomerEntity extends EventSourcedEntity<Customer> {
+public class CustomerEntity extends EventSourcedEntity<Customer, CustomerEvent> {
 
   @GetMapping
   public Effect<Customer> getCustomer() {

--- a/samples/spring-eventsourced-customer-registry/src/test/java/customer/api/CustomerEntityTest.java
+++ b/samples/spring-eventsourced-customer-registry/src/test/java/customer/api/CustomerEntityTest.java
@@ -2,6 +2,7 @@ package customer.api;
 
 import customer.domain.Address;
 import customer.domain.Customer;
+import customer.domain.CustomerEvent;
 import kalix.javasdk.testkit.EventSourcedResult;
 import kalix.springsdk.testkit.EventSourcedTestKit;
 import org.junit.jupiter.api.Test;
@@ -18,15 +19,15 @@ public class CustomerEntityTest {
   @Test
   public void testCustomerNameChange() {
 
-    EventSourcedTestKit<Customer, CustomerEntity> testKit = EventSourcedTestKit.of(CustomerEntity::new);
+    EventSourcedTestKit<Customer, CustomerEvent, CustomerEntity> testKit = EventSourcedTestKit.of(CustomerEntity::new);
     {
-      EventSourcedResult<String> result = testKit.call(e -> e.create(customer));
+      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.create(customer));
       assertEquals("OK", result.getReply());
       result.getNextEventOfType(CustomerCreated.class);
     }
 
     {
-      EventSourcedResult<String> result = testKit.call(e -> e.changeName("FooBar"));
+      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.changeName("FooBar"));
       assertEquals("OK", result.getReply());
       assertEquals("FooBar", testKit.getState().name());
       result.getNextEventOfType(NameChanged.class);
@@ -37,16 +38,16 @@ public class CustomerEntityTest {
   @Test
   public void testCustomerAddressChange() {
 
-    EventSourcedTestKit<Customer, CustomerEntity> testKit = EventSourcedTestKit.of(CustomerEntity::new);
+    EventSourcedTestKit<Customer, CustomerEvent, CustomerEntity> testKit = EventSourcedTestKit.of(CustomerEntity::new);
     {
-      EventSourcedResult<String> result = testKit.call(e -> e.create(customer));
+      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.create(customer));
       assertEquals("OK", result.getReply());
       result.getNextEventOfType(CustomerCreated.class);
     }
 
     {
       Address newAddress = new Address("Sesame Street", "Sesame City");
-      EventSourcedResult<String> result = testKit.call(e -> e.changeAddress(newAddress));
+      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.changeAddress(newAddress));
       assertEquals("OK", result.getReply());
       assertEquals("Sesame Street", testKit.getState().address().street());
       assertEquals("Sesame City", testKit.getState().address().city());

--- a/samples/spring-eventsourced-customer-registry/src/test/java/customer/api/CustomerEntityTest.java
+++ b/samples/spring-eventsourced-customer-registry/src/test/java/customer/api/CustomerEntityTest.java
@@ -21,13 +21,13 @@ public class CustomerEntityTest {
 
     EventSourcedTestKit<Customer, CustomerEvent, CustomerEntity> testKit = EventSourcedTestKit.of(CustomerEntity::new);
     {
-      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.create(customer));
+      EventSourcedResult<String> result = testKit.call(e -> e.create(customer));
       assertEquals("OK", result.getReply());
       result.getNextEventOfType(CustomerCreated.class);
     }
 
     {
-      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.changeName("FooBar"));
+      EventSourcedResult<String> result = testKit.call(e -> e.changeName("FooBar"));
       assertEquals("OK", result.getReply());
       assertEquals("FooBar", testKit.getState().name());
       result.getNextEventOfType(NameChanged.class);
@@ -40,14 +40,14 @@ public class CustomerEntityTest {
 
     EventSourcedTestKit<Customer, CustomerEvent, CustomerEntity> testKit = EventSourcedTestKit.of(CustomerEntity::new);
     {
-      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.create(customer));
+      EventSourcedResult<String> result = testKit.call(e -> e.create(customer));
       assertEquals("OK", result.getReply());
       result.getNextEventOfType(CustomerCreated.class);
     }
 
     {
       Address newAddress = new Address("Sesame Street", "Sesame City");
-      EventSourcedResult<String, CustomerEvent> result = testKit.call(e -> e.changeAddress(newAddress));
+      EventSourcedResult<String> result = testKit.call(e -> e.changeAddress(newAddress));
       assertEquals("OK", result.getReply());
       assertEquals("Sesame Street", testKit.getState().address().street());
       assertEquals("Sesame City", testKit.getState().address().city());

--- a/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartEntity.java
+++ b/samples/spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartEntity.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 @EntityKey("cartId") // <2>
 @EntityType("shopping-cart") // <3>
 @RequestMapping("/cart/{cartId}") // <4>
-public class ShoppingCartEntity extends EventSourcedEntity<ShoppingCart> { // <1>
+public class ShoppingCartEntity extends EventSourcedEntity<ShoppingCart, ShoppingCartEvent> { // <1>
   // end::class[]
 
 // tag::getCart[]

--- a/samples/spring-view-store/src/main/java/store/customer/api/CustomerEntity.java
+++ b/samples/spring-view-store/src/main/java/store/customer/api/CustomerEntity.java
@@ -7,13 +7,14 @@ import kalix.springsdk.annotations.EntityKey;
 import kalix.springsdk.annotations.EntityType;
 import kalix.springsdk.annotations.EventHandler;
 import org.springframework.web.bind.annotation.*;
+import store.customer.domain.CustomerEvent;
 
 import static store.customer.domain.CustomerEvent.*;
 
 @EntityType("customer")
 @EntityKey("id")
 @RequestMapping("/customer/{id}")
-public class CustomerEntity extends EventSourcedEntity<Customer> {
+public class CustomerEntity extends EventSourcedEntity<Customer, CustomerEvent> {
 
   @GetMapping
   public Effect<Customer> get() {

--- a/samples/spring-view-store/src/main/java/store/product/api/ProductEntity.java
+++ b/samples/spring-view-store/src/main/java/store/product/api/ProductEntity.java
@@ -7,13 +7,14 @@ import kalix.springsdk.annotations.EntityKey;
 import kalix.springsdk.annotations.EntityType;
 import kalix.springsdk.annotations.EventHandler;
 import org.springframework.web.bind.annotation.*;
+import store.product.domain.ProductEvent;
 
 import static store.product.domain.ProductEvent.*;
 
 @EntityType("product")
 @EntityKey("id")
 @RequestMapping("/product/{id}")
-public class ProductEntity extends EventSourcedEntity<Product> {
+public class ProductEntity extends EventSourcedEntity<Product, ProductEvent> {
 
   @GetMapping
   public Effect<Product> get() {

--- a/samples/spring-view-store/src/test/java/store/customer/api/CustomerEntityTest.java
+++ b/samples/spring-view-store/src/test/java/store/customer/api/CustomerEntityTest.java
@@ -5,6 +5,7 @@ import store.customer.domain.Customer;
 import kalix.javasdk.testkit.EventSourcedResult;
 import kalix.springsdk.testkit.EventSourcedTestKit;
 import org.junit.jupiter.api.Test;
+import store.customer.domain.CustomerEvent;
 
 import static store.customer.domain.CustomerEvent.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,7 +15,7 @@ public class CustomerEntityTest {
   @Test
   public void testCustomerNameChange() {
 
-    EventSourcedTestKit<Customer, CustomerEntity> testKit =
+    EventSourcedTestKit<Customer, CustomerEvent, CustomerEntity> testKit =
         EventSourcedTestKit.of(CustomerEntity::new);
 
     {
@@ -39,7 +40,7 @@ public class CustomerEntityTest {
   @Test
   public void testCustomerAddressChange() {
 
-    EventSourcedTestKit<Customer, CustomerEntity> testKit =
+    EventSourcedTestKit<Customer, CustomerEvent, CustomerEntity> testKit =
         EventSourcedTestKit.of(CustomerEntity::new);
 
     {

--- a/samples/spring-view-store/src/test/java/store/product/api/ProductEntityTest.java
+++ b/samples/spring-view-store/src/test/java/store/product/api/ProductEntityTest.java
@@ -14,7 +14,7 @@ public class ProductEntityTest {
   @Test
   public void testProductNameChange() {
 
-    EventSourcedTestKit<Product, ProductEntity> testKit =
+    EventSourcedTestKit<Product, ProductEvent, ProductEntity> testKit =
         EventSourcedTestKit.of(ProductEntity::new);
 
     {
@@ -38,7 +38,7 @@ public class ProductEntityTest {
   @Test
   public void testProductPriceChange() {
 
-    EventSourcedTestKit<Product, ProductEntity> testKit =
+    EventSourcedTestKit<Product, ProductEvent, ProductEntity> testKit =
         EventSourcedTestKit.of(ProductEntity::new);
 
     {

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedResult.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedResult.java
@@ -27,9 +27,8 @@ import java.util.List;
  * <p>Not for user extension, returned by the testkit.
  *
  * @param <R> The type of reply that is expected from invoking a command handler
- * @param <E> The parent type of events produced by the ES entity
  */
-public interface EventSourcedResult<R, E> {
+public interface EventSourcedResult<R> {
 
   /** @return true if the call had an effect with a reply, false if not */
   boolean isReply();
@@ -69,7 +68,7 @@ public interface EventSourcedResult<R, E> {
   boolean didEmitEvents();
 
   /** @return All the events that were emitted by handling this command. */
-  List<E> getAllEvents();
+  List<Object> getAllEvents();
 
   /**
    * Look at the next event and verify that it is of type E or fail if not or if there is no next

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedResult.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedResult.java
@@ -27,8 +27,9 @@ import java.util.List;
  * <p>Not for user extension, returned by the testkit.
  *
  * @param <R> The type of reply that is expected from invoking a command handler
+ * @param <E> The parent type of events produced by the ES entity
  */
-public interface EventSourcedResult<R> {
+public interface EventSourcedResult<R, E> {
 
   /** @return true if the call had an effect with a reply, false if not */
   boolean isReply();
@@ -68,7 +69,7 @@ public interface EventSourcedResult<R> {
   boolean didEmitEvents();
 
   /** @return All the events that were emitted by handling this command. */
-  List<Object> getAllEvents();
+  List<E> getAllEvents();
 
   /**
    * Look at the next event and verify that it is of type E or fail if not or if there is no next
@@ -77,7 +78,7 @@ public interface EventSourcedResult<R> {
    *
    * @return The next event if it is of type E, for additional assertions.
    */
-  <E> E getNextEventOfType(Class<E> expectedClass);
+  <T> T getNextEventOfType(Class<T> expectedClass);
 
   /** @return The list of side effects */
   List<DeferredCallDetails<?, ?>> getSideEffects();

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedResult.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedResult.java
@@ -77,7 +77,7 @@ public interface EventSourcedResult<R> {
    *
    * @return The next event if it is of type E, for additional assertions.
    */
-  <T> T getNextEventOfType(Class<T> expectedClass);
+  <E> E getNextEventOfType(Class<E> expectedClass);
 
   /** @return The list of side effects */
   List<DeferredCallDetails<?, ?>> getSideEffects();

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/impl/EventSourcedEntityEffectsRunner.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/impl/EventSourcedEntityEffectsRunner.java
@@ -31,7 +31,7 @@ public abstract class EventSourcedEntityEffectsRunner<S, E> {
 
   private EventSourcedEntity<S, E> entity;
   private S _state;
-  private List<E> events = new ArrayList();
+  private List<Object> events = new ArrayList();
 
   public EventSourcedEntityEffectsRunner(EventSourcedEntity<S, E> entity) {
     this.entity = entity;
@@ -47,7 +47,7 @@ public abstract class EventSourcedEntityEffectsRunner<S, E> {
   }
 
   /** @return All events emitted by command handlers of this entity up to now */
-  public List<E> getAllEvents() {
+  public List<Object> getAllEvents() {
     return events;
   }
 
@@ -58,7 +58,7 @@ public abstract class EventSourcedEntityEffectsRunner<S, E> {
    *
    * @return the result of the side effects
    */
-  protected <R> EventSourcedResult<R, E> interpretEffects(
+  protected <R> EventSourcedResult<R> interpretEffects(
       Supplier<EventSourcedEntity.Effect<R>> effect, Metadata metadata) {
     var commandContext = new TestKitEventSourcedEntityCommandContext(metadata);
     EventSourcedEntity.Effect<R> effectExecuted;
@@ -79,7 +79,7 @@ public abstract class EventSourcedEntityEffectsRunner<S, E> {
     } finally {
       entity._internalSetEventContext(Optional.empty());
     }
-    EventSourcedResult<R, E> result;
+    EventSourcedResult<R> result;
     try {
       entity._internalSetCommandContext(Optional.of(commandContext));
       var secondaryEffect = EventSourcedResultImpl.secondaryEffectOf(effectExecuted, _state);

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/impl/EventSourcedEntityEffectsRunner.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/impl/EventSourcedEntityEffectsRunner.java
@@ -31,7 +31,7 @@ public abstract class EventSourcedEntityEffectsRunner<S, E> {
 
   private EventSourcedEntity<S, E> entity;
   private S _state;
-  private List<Object> events = new ArrayList();
+  private List<E> events = new ArrayList();
 
   public EventSourcedEntityEffectsRunner(EventSourcedEntity<S, E> entity) {
     this.entity = entity;
@@ -47,7 +47,7 @@ public abstract class EventSourcedEntityEffectsRunner<S, E> {
   }
 
   /** @return All events emitted by command handlers of this entity up to now */
-  public List<Object> getAllEvents() {
+  public List<E> getAllEvents() {
     return events;
   }
 

--- a/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/impl/EventSourcedEntityEffectsRunner.java
+++ b/sdk/java-sdk-testkit/src/main/java/kalix/javasdk/testkit/impl/EventSourcedEntityEffectsRunner.java
@@ -27,19 +27,19 @@ import java.util.function.Supplier;
 import scala.jdk.javaapi.CollectionConverters;
 
 /** Extended by generated code, not meant for user extension */
-public abstract class EventSourcedEntityEffectsRunner<S> {
+public abstract class EventSourcedEntityEffectsRunner<S, E> {
 
-  private EventSourcedEntity<S> entity;
+  private EventSourcedEntity<S, E> entity;
   private S _state;
-  private List<Object> events = new ArrayList();
+  private List<E> events = new ArrayList();
 
-  public EventSourcedEntityEffectsRunner(EventSourcedEntity<S> entity) {
+  public EventSourcedEntityEffectsRunner(EventSourcedEntity<S, E> entity) {
     this.entity = entity;
     this._state = entity.emptyState();
   }
 
   /** @return The current state of the entity after applying the event */
-  protected abstract S handleEvent(S state, Object event);
+  protected abstract S handleEvent(S state, E event);
 
   /** @return The current state of the entity */
   public S getState() {
@@ -47,7 +47,7 @@ public abstract class EventSourcedEntityEffectsRunner<S> {
   }
 
   /** @return All events emitted by command handlers of this entity up to now */
-  public List<Object> getAllEvents() {
+  public List<E> getAllEvents() {
     return events;
   }
 
@@ -58,7 +58,7 @@ public abstract class EventSourcedEntityEffectsRunner<S> {
    *
    * @return the result of the side effects
    */
-  protected <R> EventSourcedResult<R> interpretEffects(
+  protected <R> EventSourcedResult<R, E> interpretEffects(
       Supplier<EventSourcedEntity.Effect<R>> effect, Metadata metadata) {
     var commandContext = new TestKitEventSourcedEntityCommandContext(metadata);
     EventSourcedEntity.Effect<R> effectExecuted;
@@ -73,17 +73,17 @@ public abstract class EventSourcedEntityEffectsRunner<S> {
     try {
       entity._internalSetEventContext(Optional.of(new TestKitEventSourcedEntityEventContext()));
       for (Object event : EventSourcedResultImpl.eventsOf(effectExecuted)) {
-        this._state = handleEvent(this._state, event);
+        this._state = handleEvent(this._state, (E) event);
         entity._internalSetCurrentState(this._state);
       }
     } finally {
       entity._internalSetEventContext(Optional.empty());
     }
-    EventSourcedResult<R> result;
+    EventSourcedResult<R, E> result;
     try {
       entity._internalSetCommandContext(Optional.of(commandContext));
       var secondaryEffect = EventSourcedResultImpl.secondaryEffectOf(effectExecuted, _state);
-      result = new EventSourcedResultImpl<R, S>(effectExecuted, _state, secondaryEffect);
+      result = new EventSourcedResultImpl<>(effectExecuted, _state, secondaryEffect);
     } finally {
       entity._internalSetCommandContext(Optional.empty());
     }

--- a/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventSourcedResultImpl.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventSourcedResultImpl.scala
@@ -45,8 +45,8 @@ private[kalix] object EventSourcedResultImpl {
     effect match {
       case ei: EventSourcedEntityEffectImpl[_, E @unchecked] =>
         ei.primaryEffect match {
-          case ee: EmitEvents[E]       => ee.event.toList.asJava
-          case _: NoPrimaryEffect.type => Collections.emptyList()
+          case ee: EmitEvents[E @unchecked] => ee.event.toList.asJava
+          case _: NoPrimaryEffect.type      => Collections.emptyList()
         }
     }
   }
@@ -77,7 +77,7 @@ private[kalix] final class EventSourcedResultImpl[R, S, E](
     effect: EventSourcedEntityEffectImpl[S, E],
     state: S,
     secondaryEffect: SecondaryEffectImpl)
-    extends EventSourcedResult[R, E] {
+    extends EventSourcedResult[R] {
   import EventSourcedResultImpl._
 
   def this(effect: EventSourcedEntity.Effect[R], state: S, secondaryEffect: SecondaryEffectImpl) =
@@ -93,7 +93,7 @@ private[kalix] final class EventSourcedResultImpl[R, S, E](
   }
 
   /** All emitted events. */
-  override def getAllEvents: java.util.List[E] = eventsOf(effect)
+  override def getAllEvents: java.util.List[Any] = eventsOf(effect)
 
   override def isReply: Boolean = secondaryEffect.isInstanceOf[MessageReplyImpl[_]]
 

--- a/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventSourcedResultImpl.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventSourcedResultImpl.scala
@@ -41,11 +41,11 @@ import scala.jdk.CollectionConverters._
  * INTERNAL API
  */
 private[kalix] object EventSourcedResultImpl {
-  def eventsOf(effect: EventSourcedEntity.Effect[_]): JList[Any] = {
+  def eventsOf[E](effect: EventSourcedEntity.Effect[_]): JList[E] = {
     effect match {
-      case ei: EventSourcedEntityEffectImpl[_] =>
+      case ei: EventSourcedEntityEffectImpl[_, E @unchecked] =>
         ei.primaryEffect match {
-          case ee: EmitEvents          => ee.event.toList.asJava
+          case ee: EmitEvents[E]       => ee.event.toList.asJava
           case _: NoPrimaryEffect.type => Collections.emptyList()
         }
     }
@@ -53,7 +53,7 @@ private[kalix] object EventSourcedResultImpl {
 
   def secondaryEffectOf[S](effect: EventSourcedEntity.Effect[_], state: S): SecondaryEffectImpl = {
     effect match {
-      case ei: EventSourcedEntityEffectImpl[S @unchecked] =>
+      case ei: EventSourcedEntityEffectImpl[S @unchecked, _] =>
         ei.secondaryEffect(state)
     }
   }
@@ -73,15 +73,15 @@ private[kalix] object EventSourcedResultImpl {
 /**
  * INTERNAL API
  */
-private[kalix] final class EventSourcedResultImpl[R, S](
-    effect: EventSourcedEntityEffectImpl[S],
+private[kalix] final class EventSourcedResultImpl[R, S, E](
+    effect: EventSourcedEntityEffectImpl[S, E],
     state: S,
     secondaryEffect: SecondaryEffectImpl)
-    extends EventSourcedResult[R] {
+    extends EventSourcedResult[R, E] {
   import EventSourcedResultImpl._
 
   def this(effect: EventSourcedEntity.Effect[R], state: S, secondaryEffect: SecondaryEffectImpl) =
-    this(effect.asInstanceOf[EventSourcedEntityEffectImpl[S]], state, secondaryEffect)
+    this(effect.asInstanceOf[EventSourcedEntityEffectImpl[S, E]], state, secondaryEffect)
 
   private lazy val eventsIterator = getAllEvents().iterator
 
@@ -93,7 +93,7 @@ private[kalix] final class EventSourcedResultImpl[R, S](
   }
 
   /** All emitted events. */
-  override def getAllEvents(): java.util.List[Any] = eventsOf(effect)
+  override def getAllEvents: java.util.List[E] = eventsOf(effect)
 
   override def isReply: Boolean = secondaryEffect.isInstanceOf[MessageReplyImpl[_]]
 
@@ -126,11 +126,11 @@ private[kalix] final class EventSourcedResultImpl[R, S](
 
   override def didEmitEvents(): Boolean = !getAllEvents().isEmpty
 
-  override def getNextEventOfType[E](expectedClass: Class[E]): E =
+  override def getNextEventOfType[T](expectedClass: Class[T]): T =
     if (!eventsIterator.hasNext) throw new NoSuchElementException("No more events found")
     else {
       @SuppressWarnings(Array("unchecked")) val next = eventsIterator.next
-      if (expectedClass.isInstance(next)) next.asInstanceOf[E]
+      if (expectedClass.isInstance(next)) next.asInstanceOf[T]
       else
         throw new NoSuchElementException(
           "expected event type [" + expectedClass.getName + "] but found [" + next.getClass.getName + "]")

--- a/sdk/java-sdk-testkit/src/test/scala/kalix/javasdk/testkit/impl/EventSourcedResultSpec.scala
+++ b/sdk/java-sdk-testkit/src/test/scala/kalix/javasdk/testkit/impl/EventSourcedResultSpec.scala
@@ -31,8 +31,8 @@ class EventSourcedResultSpec extends AnyWordSpec with Matchers {
 
   "Event Sourced Entity Results" must {
     "extract side effects" in {
-      val replyWithSideEffectResult = new EventSourcedResultImpl[String, String](
-        new EventSourcedEntityEffectImpl().reply("not actually used here"),
+      val replyWithSideEffectResult = new EventSourcedResultImpl[String, String, Object](
+        new EventSourcedEntityEffectImpl[String, Object]().reply("not actually used here"),
         "state",
         MessageReplyImpl(
           "reply", // pretend it was evaluated, in practice done by the generated testkit
@@ -46,8 +46,8 @@ class EventSourcedResultSpec extends AnyWordSpec with Matchers {
     }
 
     "extract forward details" in {
-      val forwardResult = new EventSourcedResultImpl[String, String](
-        new EventSourcedEntityEffectImpl().reply("not actually used here"),
+      val forwardResult = new EventSourcedResultImpl[String, String, Object](
+        new EventSourcedEntityEffectImpl[String, Object]().reply("not actually used here"),
         "state",
         ForwardReplyImpl(
           deferredCall =

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/Kalix.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/Kalix.java
@@ -479,8 +479,8 @@ public final class Kalix {
    *
    * @return This stateful service builder.
    */
-  public <S, E extends EventSourcedEntity<S>> Kalix register(
-    EventSourcedEntityProvider<S, E> provider) {
+  public <S, E, ES extends EventSourcedEntity<S, E>> Kalix register(
+      EventSourcedEntityProvider<S, E, ES> provider) {
     return provider
       .alternativeCodec()
       .map(

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -30,8 +30,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-/** @param <S> The type of the state for this entity. */
-public abstract class EventSourcedEntity<S> {
+/**
+ * @param <S> The type of the state for this entity.
+ * @param <E> The parent type of the event hierarchy for this entity.
+ */
+public abstract class EventSourcedEntity<S, E> {
 
   private Optional<CommandContext> commandContext = Optional.empty();
   private Optional<EventContext> eventContext = Optional.empty();
@@ -108,8 +111,8 @@ public abstract class EventSourcedEntity<S> {
       throw new IllegalStateException("Current state is only available when handling a command.");
   }
 
-  protected final Effect.Builder<S> effects() {
-    return new EventSourcedEntityEffectImpl<S>();
+  protected final Effect.Builder<S, E> effects() {
+    return new EventSourcedEntityEffectImpl<S, E>();
   }
 
   /**
@@ -125,11 +128,11 @@ public abstract class EventSourcedEntity<S> {
      *
      * @param <S> The type of the state for this entity.
      */
-    interface Builder<S> {
+    interface Builder<S, E> {
 
-      OnSuccessBuilder<S> emitEvent(Object event);
+      OnSuccessBuilder<S> emitEvent(E event);
 
-      OnSuccessBuilder<S> emitEvents(List<?> event);
+      OnSuccessBuilder<S> emitEvents(List<? extends E> event);
 
       /**
        * Create a message reply.

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntityProvider.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/eventsourcedentity/EventSourcedEntityProvider.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  * generated for the specific entities defined in Protobuf, for example <code>CustomerEntityProvider
  * </code>.
  */
-public interface EventSourcedEntityProvider<S, E extends EventSourcedEntity<S>> {
+public interface EventSourcedEntityProvider<S, E, ES extends EventSourcedEntity<S, E>> {
 
   EventSourcedEntityOptions options();
 
@@ -37,7 +37,7 @@ public interface EventSourcedEntityProvider<S, E extends EventSourcedEntity<S>> 
 
   String entityType();
 
-  EventSourcedEntityRouter<S, E> newRouter(EventSourcedEntityContext context);
+  EventSourcedEntityRouter<S, E, ES> newRouter(EventSourcedEntityContext context);
 
   Descriptors.FileDescriptor[] additionalDescriptors();
 

--- a/sdk/java-sdk/src/main/java/kalix/javasdk/impl/EventSourcedEntityFactory.java
+++ b/sdk/java-sdk/src/main/java/kalix/javasdk/impl/EventSourcedEntityFactory.java
@@ -32,5 +32,5 @@ public interface EventSourcedEntityFactory {
    * @param context The context.
    * @return The handler for the given context.
    */
-  EventSourcedEntityRouter<?, ?> create(EventSourcedEntityContext context);
+  EventSourcedEntityRouter<?, ?, ?> create(EventSourcedEntityContext context);
 }

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -146,7 +146,7 @@ final class EventSourcedEntitiesImpl(
       services.getOrElse(init.serviceName, throw ProtocolException(init, s"Service not found: ${init.serviceName}"))
     val router = service.factory
       .create(new EventSourcedEntityContextImpl(init.entityId))
-      .asInstanceOf[EventSourcedEntityRouter[Any, EventSourcedEntity[Any]]]
+      .asInstanceOf[EventSourcedEntityRouter[Any, Any, EventSourcedEntity[Any, Any]]]
     val thisEntityId = init.entityId
 
     val startingSequenceNumber = (for {

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntityRouter.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntityRouter.scala
@@ -17,7 +17,6 @@
 package kalix.javasdk.impl.eventsourcedentity
 
 import java.util.Optional
-
 import kalix.javasdk.eventsourcedentity.CommandContext
 import kalix.javasdk.eventsourcedentity.EventContext
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity
@@ -25,6 +24,7 @@ import kalix.javasdk.impl.EntityExceptions
 import kalix.javasdk.impl.effect.SecondaryEffectImpl
 import kalix.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.EmitEvents
 import kalix.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.NoPrimaryEffect
+import org.checkerframework.checker.units.qual.K
 
 object EventSourcedEntityRouter {
   final case class CommandResult(
@@ -45,7 +45,7 @@ object EventSourcedEntityRouter {
  *
  * The concrete <code>EventSourcedEntityRouter</code> is generated for the specific entities defined in Protobuf.
  */
-abstract class EventSourcedEntityRouter[S, E <: EventSourcedEntity[S]](protected val entity: E) {
+abstract class EventSourcedEntityRouter[S, E, ES <: EventSourcedEntity[S, E]](protected val entity: ES) {
   import EventSourcedEntityRouter._
 
   private var state: Option[S] = None
@@ -70,7 +70,7 @@ abstract class EventSourcedEntityRouter[S, E <: EventSourcedEntity[S]](protected
 
   /** INTERNAL API */
   // "public" api against the impl/testkit
-  final def _internalHandleEvent(event: Object, context: EventContext): Unit = {
+  final def _internalHandleEvent(event: E, context: EventContext): Unit = {
     entity._internalSetEventContext(Optional.of(context))
     try {
       val newState = handleEvent(_stateOrEmpty(), event)
@@ -94,7 +94,7 @@ abstract class EventSourcedEntityRouter[S, E <: EventSourcedEntity[S]](protected
     val commandEffect =
       try {
         entity._internalSetCommandContext(Optional.of(context))
-        handleCommand(commandName, _stateOrEmpty(), command, context).asInstanceOf[EventSourcedEntityEffectImpl[Any]]
+        handleCommand(commandName, _stateOrEmpty(), command, context).asInstanceOf[EventSourcedEntityEffectImpl[Any, E]]
       } catch {
         case CommandHandlerNotFound(name) =>
           throw new EntityExceptions.EntityException(
@@ -112,7 +112,7 @@ abstract class EventSourcedEntityRouter[S, E <: EventSourcedEntity[S]](protected
         events.foreach { event =>
           try {
             entity._internalSetEventContext(Optional.of(eventContextFactory(currentSequence)))
-            val newState = handleEvent(_stateOrEmpty(), event)
+            val newState = handleEvent(_stateOrEmpty(), event.asInstanceOf[E])
             if (newState == null)
               throw new IllegalArgumentException("Event handler must not return null as the updated state.")
             setState(newState)
@@ -161,7 +161,7 @@ abstract class EventSourcedEntityRouter[S, E <: EventSourcedEntity[S]](protected
     }
   }
 
-  def handleEvent(state: S, event: Any): S
+  def handleEvent(state: S, event: E): S
 
   def handleCommand(commandName: String, state: S, command: Any, context: CommandContext): EventSourcedEntity.Effect[_]
 

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntityRouter.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntityRouter.scala
@@ -24,7 +24,6 @@ import kalix.javasdk.impl.EntityExceptions
 import kalix.javasdk.impl.effect.SecondaryEffectImpl
 import kalix.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.EmitEvents
 import kalix.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.NoPrimaryEffect
-import org.checkerframework.checker.units.qual.K
 
 object EventSourcedEntityRouter {
   final case class CommandResult(

--- a/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/ResolvedEventSourcedEntityFactory.scala
+++ b/sdk/java-sdk/src/main/scala/kalix/javasdk/impl/eventsourcedentity/ResolvedEventSourcedEntityFactory.scala
@@ -27,7 +27,7 @@ class ResolvedEventSourcedEntityFactory(
     extends EventSourcedEntityFactory
     with ResolvedEntityFactory {
 
-  override def create(context: EventSourcedEntityContext): EventSourcedEntityRouter[_, _] =
+  override def create(context: EventSourcedEntityContext): EventSourcedEntityRouter[_, _, _] =
     delegate.create(context)
 
 }

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/AbstractCartEntity.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/AbstractCartEntity.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Empty;
  * Generated entity baseclass, extended by user entity impl, helps getting the impl in sync with
  * protobuf def
  */
-public abstract class AbstractCartEntity extends EventSourcedEntity<ShoppingCartDomain.Cart> {
+public abstract class AbstractCartEntity extends EventSourcedEntity<ShoppingCartDomain.Cart, Object> {
 
   public abstract Effect<Empty> addItem(
       ShoppingCartDomain.Cart currentState, ShoppingCartApi.AddLineItem command);

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntityProvider.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntityProvider.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 
 /** An event sourced entity provider */
 public class CartEntityProvider
-    implements EventSourcedEntityProvider<ShoppingCartDomain.Cart, CartEntity> {
+    implements EventSourcedEntityProvider<ShoppingCartDomain.Cart, Object, CartEntity> {
 
   private final Function<EventSourcedEntityContext, CartEntity> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntityRouter.java
+++ b/sdk/java-sdk/src/test/java/kalix/javasdk/eventsourcedentity/CartEntityRouter.java
@@ -21,7 +21,7 @@ import com.example.shoppingcart.ShoppingCartApi;
 import com.example.shoppingcart.domain.ShoppingCartDomain;
 
 /** Generated, does the routing from command name to concrete method */
-final class CartEntityRouter extends EventSourcedEntityRouter<ShoppingCartDomain.Cart, CartEntity> {
+final class CartEntityRouter extends EventSourcedEntityRouter<ShoppingCartDomain.Cart, Object, CartEntity> {
 
   public CartEntityRouter(CartEntity entity) {
     super(entity);

--- a/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/eventsourcedentity/TestEventSourced.scala
+++ b/sdk/java-sdk/src/test/scala/kalix/javasdk/impl/eventsourcedentity/TestEventSourced.scala
@@ -24,11 +24,11 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityProvider
 
 object TestEventSourced {
-  def service(entityProvider: EventSourcedEntityProvider[_, _]): TestEventSourcedService =
+  def service(entityProvider: EventSourcedEntityProvider[_, _, _]): TestEventSourcedService =
     new TestEventSourcedService(entityProvider)
 }
 
-class TestEventSourcedService(entityProvider: EventSourcedEntityProvider[_, _]) {
+class TestEventSourcedService(entityProvider: EventSourcedEntityProvider[_, _, _]) {
   val port: Int = SocketUtil.temporaryLocalPort()
 
   val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""

--- a/sdk/scala-sdk-testkit/src/main/scala/kalix/scalasdk/testkit/impl/EventSourcedResultImpl.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/kalix/scalasdk/testkit/impl/EventSourcedResultImpl.scala
@@ -104,7 +104,7 @@ object EventSourcedResultImpl {
     effect match {
       case ei: EventSourcedEntityEffectImpl[_, _] =>
         ei.javasdkEffect.primaryEffect match {
-          case ee: EmitEvents          => ee.event.toList
+          case ee: EmitEvents[_]       => ee.event.toList
           case _: NoPrimaryEffect.type => Nil
         }
     }

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/eventsourcedentity/EventSourcedEntityAdapters.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/eventsourcedentity/EventSourcedEntityAdapters.scala
@@ -43,7 +43,7 @@ import scala.jdk.CollectionConverters.SetHasAsScala
 import scala.jdk.OptionConverters._
 
 private[scalasdk] final class JavaEventSourcedEntityAdapter[S](scalaSdkEventSourcedEntity: EventSourcedEntity[S])
-    extends JavaSdkEventSourcedEntity[S] {
+    extends JavaSdkEventSourcedEntity[S, Any] {
 
   override def emptyState(): S = scalaSdkEventSourcedEntity.emptyState
 
@@ -55,16 +55,16 @@ private[scalasdk] final class JavaEventSourcedEntityAdapter[S](scalaSdkEventSour
 
 }
 
-private[scalasdk] final class JavaEventSourcedEntityProviderAdapter[S, E <: EventSourcedEntity[S]](
-    scalaSdkProvider: EventSourcedEntityProvider[S, E])
-    extends JavaSdkEventSourcedEntityProvider[S, JavaSdkEventSourcedEntity[S]] {
+private[scalasdk] final class JavaEventSourcedEntityProviderAdapter[S, ES <: EventSourcedEntity[S]](
+    scalaSdkProvider: EventSourcedEntityProvider[S, ES])
+    extends JavaSdkEventSourcedEntityProvider[S, Any, JavaSdkEventSourcedEntity[S, Any]] {
 
   def additionalDescriptors(): Array[Descriptors.FileDescriptor] = scalaSdkProvider.additionalDescriptors.toArray
 
   def entityType(): String = scalaSdkProvider.entityType
 
-  def newRouter(
-      context: JavaSdkEventSourcedEntityContext): JavaSdkEventSourcedEntityRouter[S, JavaSdkEventSourcedEntity[S]] = {
+  def newRouter(context: JavaSdkEventSourcedEntityContext)
+      : JavaSdkEventSourcedEntityRouter[S, Any, JavaSdkEventSourcedEntity[S, Any]] = {
     val scaladslRouter = scalaSdkProvider
       .newRouter(new ScalaEventSourcedEntityContextAdapter(context))
       .asInstanceOf[EventSourcedEntityRouter[S, EventSourcedEntity[S]]]
@@ -102,9 +102,9 @@ private[scalasdk] final class JavaEventSourcedEntityOptionsAdapter(
 }
 
 private[scalasdk] final class JavaEventSourcedEntityRouterAdapter[S](
-    javaSdkEventSourcedEntity: JavaSdkEventSourcedEntity[S],
+    javaSdkEventSourcedEntity: JavaSdkEventSourcedEntity[S, Any],
     scalaSdkRouter: EventSourcedEntityRouter[S, EventSourcedEntity[S]])
-    extends JavaSdkEventSourcedEntityRouter[S, JavaSdkEventSourcedEntity[S]](javaSdkEventSourcedEntity) {
+    extends JavaSdkEventSourcedEntityRouter[S, Any, JavaSdkEventSourcedEntity[S, Any]](javaSdkEventSourcedEntity) {
 
   override def handleEvent(state: S, event: Any): S = {
     scalaSdkRouter.handleEvent(state, event)

--- a/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/kalix/scalasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
@@ -27,11 +27,11 @@ import io.grpc.Status
 
 private[scalasdk] object EventSourcedEntityEffectImpl {
   def apply[R, S](): EventSourcedEntityEffectImpl[R, S] = EventSourcedEntityEffectImpl(
-    new javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl[S]())
+    new javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl[S, Any]())
 }
 
 private[scalasdk] final case class EventSourcedEntityEffectImpl[R, S](
-    javasdkEffect: javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl[S])
+    javasdkEffect: javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl[S, Any])
     extends EventSourcedEntity.Effect.Builder[S]
     with EventSourcedEntity.Effect.OnSuccessBuilder[S]
     with EventSourcedEntity.Effect[R] {

--- a/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/EventSourcedTestKit.java
+++ b/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/EventSourcedTestKit.java
@@ -104,7 +104,7 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
    * @return a EventSourcedResult
    * @param <R> The type of reply that is expected from invoking a command handler
    */
-  public <R> EventSourcedResult<R, E> call(Function<ES, EventSourcedEntity.Effect<R>> func) {
+  public <R> EventSourcedResult<R> call(Function<ES, EventSourcedEntity.Effect<R>> func) {
     return interpretEffects(() -> func.apply(entity), Metadata.EMPTY);
   }
 

--- a/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/EventSourcedTestKit.java
+++ b/sdk/spring-sdk-testkit/src/main/java/kalix/springsdk/testkit/EventSourcedTestKit.java
@@ -41,15 +41,15 @@ import java.util.function.Supplier;
  *
  * <p>Use the {@code call} methods to interact with the testkit.
  */
-public class EventSourcedTestKit<S, E extends EventSourcedEntity<S>>
-    extends EventSourcedEntityEffectsRunner<S> {
+public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
+    extends EventSourcedEntityEffectsRunner<S, E> {
 
-  private final E entity;
+  private final ES entity;
   private final EventSourceEntityHandlers eventHandlers;
 
   private final SpringSdkMessageCodec messageCodec;
 
-  private EventSourcedTestKit(E entity) {
+  private EventSourcedTestKit(ES entity) {
     super(entity);
     this.entity = entity;
     this.messageCodec = new SpringSdkMessageCodec();
@@ -61,8 +61,8 @@ public class EventSourcedTestKit<S, E extends EventSourcedEntity<S>>
    *
    * <p>A default test entity id will be automatically provided.
    */
-  public static <S, E extends EventSourcedEntity<S>> EventSourcedTestKit<S, E> of(
-      Supplier<E> entityFactory) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> of(
+      Supplier<ES> entityFactory) {
     return of("testkit-entity-id", entityFactory);
   }
 
@@ -71,8 +71,8 @@ public class EventSourcedTestKit<S, E extends EventSourcedEntity<S>>
    *
    * <p>A default test entity id will be automatically provided.
    */
-  public static <S, E extends EventSourcedEntity<S>> EventSourcedTestKit<S, E> of(
-      Function<EventSourcedEntityContext, E> entityFactory) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> of(
+      Function<EventSourcedEntityContext, ES> entityFactory) {
     return of("testkit-entity-id", entityFactory);
   }
 
@@ -80,8 +80,8 @@ public class EventSourcedTestKit<S, E extends EventSourcedEntity<S>>
    * Creates a new testkit instance from a user defined entity id and an EventSourcedEntity
    * Supplier.
    */
-  public static <S, E extends EventSourcedEntity<S>> EventSourcedTestKit<S, E> of(
-      String entityId, Supplier<E> entityFactory) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> of(
+      String entityId, Supplier<ES> entityFactory) {
     return of(entityId, ctx -> entityFactory.get());
   }
 
@@ -89,8 +89,8 @@ public class EventSourcedTestKit<S, E extends EventSourcedEntity<S>>
    * Creates a new testkit instance from a user defined entity id and a function
    * EventSourcedEntityContext to EventSourcedEntity.
    */
-  public static <S, E extends EventSourcedEntity<S>> EventSourcedTestKit<S, E> of(
-      String entityId, Function<EventSourcedEntityContext, E> entityFactory) {
+  public static <S, E, ES extends EventSourcedEntity<S, E>> EventSourcedTestKit<S, E, ES> of(
+      String entityId, Function<EventSourcedEntityContext, ES> entityFactory) {
     EventSourcedEntityContext context = new TestKitEventSourcedEntityContext(entityId);
     return new EventSourcedTestKit<>(entityFactory.apply(context));
   }
@@ -104,12 +104,12 @@ public class EventSourcedTestKit<S, E extends EventSourcedEntity<S>>
    * @return a EventSourcedResult
    * @param <R> The type of reply that is expected from invoking a command handler
    */
-  public <R> EventSourcedResult<R> call(Function<E, EventSourcedEntity.Effect<R>> func) {
+  public <R> EventSourcedResult<R, E> call(Function<ES, EventSourcedEntity.Effect<R>> func) {
     return interpretEffects(() -> func.apply(entity), Metadata.EMPTY);
   }
 
   @Override
-  protected final S handleEvent(S state, Object event) {
+  protected final S handleEvent(S state, E event) {
     try {
       Method method = eventHandlers.handlers().apply(messageCodec.typeUrlFor(event.getClass())).method();
       return (S) method.invoke(entity, event);

--- a/sdk/spring-sdk-testkit/src/test/java/springsdk/testmodels/eventsourced/CounterEventSourcedEntity.java
+++ b/sdk/spring-sdk-testkit/src/test/java/springsdk/testmodels/eventsourced/CounterEventSourcedEntity.java
@@ -21,7 +21,7 @@ import kalix.springsdk.annotations.EventHandler;
 
 import java.util.List;
 
-public class CounterEventSourcedEntity extends EventSourcedEntity<Integer> {
+public class CounterEventSourcedEntity extends EventSourcedEntity<Integer, Increased> {
 
   public Effect<String> increaseBy(Integer value) {
     if (value <= 0) return effects().error("Can't increase with a negative value");

--- a/sdk/spring-sdk-testkit/src/test/java/springsdk/testmodels/eventsourced/CounterEventSourcedEntityTest.java
+++ b/sdk/spring-sdk-testkit/src/test/java/springsdk/testmodels/eventsourced/CounterEventSourcedEntityTest.java
@@ -27,7 +27,7 @@ public class CounterEventSourcedEntityTest {
 
   @Test
   public void testIncrease() {
-    EventSourcedTestKit<Integer, CounterEventSourcedEntity> testKit =
+    EventSourcedTestKit<Integer, Increased, CounterEventSourcedEntity> testKit =
         EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
     EventSourcedResult<String> result = testKit.call(entity -> entity.increaseBy(10));
     assertTrue(result.isReply());
@@ -38,7 +38,7 @@ public class CounterEventSourcedEntityTest {
 
   @Test
   public void testDoubleIncrease() {
-    EventSourcedTestKit<Integer, CounterEventSourcedEntity> testKit =
+    EventSourcedTestKit<Integer, Increased, CounterEventSourcedEntity> testKit =
         EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
     EventSourcedResult<String> result = testKit.call(entity -> entity.doubleIncreaseBy(10));
     assertTrue(result.isReply());
@@ -49,7 +49,7 @@ public class CounterEventSourcedEntityTest {
 
   @Test
   public void testIncreaseWithNegativeValue() {
-    EventSourcedTestKit<Integer, CounterEventSourcedEntity> testKit =
+    EventSourcedTestKit<Integer, Increased, CounterEventSourcedEntity> testKit =
         EventSourcedTestKit.of(ctx -> new CounterEventSourcedEntity());
     EventSourcedResult<String> result = testKit.call(entity -> entity.increaseBy(-10));
     assertTrue(result.isError());

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/eventsourcedentities/counter/CounterEntity.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/eventsourcedentities/counter/CounterEntity.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @EntityKey("id")
 @EntityType("counter")
 @RequestMapping("/counter/{id}")
-public class CounterEntity extends EventSourcedEntity<Counter> {
+public class CounterEntity extends EventSourcedEntity<Counter, CounterEvent> {
 
   private Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/sdk/spring-sdk/src/it/java/com/example/wiring/eventsourcedentities/headers/ForwardHeadersESEntity.java
+++ b/sdk/spring-sdk/src/it/java/com/example/wiring/eventsourcedentities/headers/ForwardHeadersESEntity.java
@@ -30,7 +30,7 @@ import static com.example.wiring.actions.headers.ForwardHeadersAction.SOME_HEADE
 @EntityType("forward-headers-es")
 @RequestMapping("/forward-headers-es/{id}")
 @ForwardHeaders(SOME_HEADER)
-public class ForwardHeadersESEntity extends EventSourcedEntity<String> {
+public class ForwardHeadersESEntity extends EventSourcedEntity<String, Object> {
 
   @PutMapping()
   public Effect<Message> createUser() {

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Subscribe.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/annotations/Subscribe.java
@@ -77,7 +77,7 @@ public @interface Subscribe {
      * Assign the class type of the entity one intends to subscribe to, which must extend {@link
      * kalix.javasdk.eventsourcedentity.EventSourcedEntity EventSourcedEntity}.
      */
-    Class<? extends kalix.javasdk.eventsourcedentity.EventSourcedEntity<?>> value();
+    Class<? extends kalix.javasdk.eventsourcedentity.EventSourcedEntity<?, ?>> value();
 
     /**
      * This option is only available for classes. Using it in a method has no effect.

--- a/sdk/spring-sdk/src/main/java/kalix/springsdk/eventsourced/ReflectiveEventSourcedEntityProvider.java
+++ b/sdk/spring-sdk/src/main/java/kalix/springsdk/eventsourced/ReflectiveEventSourcedEntityProvider.java
@@ -34,11 +34,11 @@ import kalix.springsdk.impl.eventsourcedentity.ReflectiveEventSourcedEntityRoute
 import java.util.Optional;
 import java.util.function.Function;
 
-public class ReflectiveEventSourcedEntityProvider<S, E extends EventSourcedEntity<S>>
-    implements EventSourcedEntityProvider<S, E> {
+public class ReflectiveEventSourcedEntityProvider<S, E, ES extends EventSourcedEntity<S, E>>
+    implements EventSourcedEntityProvider<S, E, ES> {
 
   private final String entityType;
-  private final Function<EventSourcedEntityContext, E> factory;
+  private final Function<EventSourcedEntityContext, ES> factory;
   private final EventSourcedEntityOptions options;
   private final Descriptors.FileDescriptor fileDescriptor;
   private final Descriptors.ServiceDescriptor serviceDescriptor;
@@ -48,18 +48,18 @@ public class ReflectiveEventSourcedEntityProvider<S, E extends EventSourcedEntit
 
   private final EventSourceEntityHandlers eventHandlers;
 
-  public static <S, E extends EventSourcedEntity<S>> ReflectiveEventSourcedEntityProvider<S, E> of(
-      Class<E> cls,
+  public static <S, E, ES extends EventSourcedEntity<S, E>> ReflectiveEventSourcedEntityProvider<S, E, ES> of(
+      Class<ES> cls,
       SpringSdkMessageCodec messageCodec,
-      Function<EventSourcedEntityContext, E> factory) {
+      Function<EventSourcedEntityContext, ES> factory) {
     return new ReflectiveEventSourcedEntityProvider<>(
         cls, messageCodec, factory, EventSourcedEntityOptions.defaults());
   }
 
   public ReflectiveEventSourcedEntityProvider(
-      Class<E> entityClass,
+      Class<ES> entityClass,
       SpringSdkMessageCodec messageCodec,
-      Function<EventSourcedEntityContext, E> factory,
+      Function<EventSourcedEntityContext, ES> factory,
       EventSourcedEntityOptions options) {
 
     EntityType annotation = entityClass.getAnnotation(EntityType.class);
@@ -101,8 +101,8 @@ public class ReflectiveEventSourcedEntityProvider<S, E extends EventSourcedEntit
   }
 
   @Override
-  public EventSourcedEntityRouter<S, E> newRouter(EventSourcedEntityContext context) {
-    E entity = factory.apply(context);
+  public EventSourcedEntityRouter<S, E, ES> newRouter(EventSourcedEntityContext context) {
+    ES entity = factory.apply(context);
     return new ReflectiveEventSourcedEntityRouter<>(
         entity, componentDescriptor.commandHandlers(), eventHandlers.handlers(), messageCodec);
   }

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixSpringApplication.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixSpringApplication.scala
@@ -86,7 +86,7 @@ object KalixSpringApplication {
 
   val kalixComponents: Seq[Class[_]] =
     classOf[Action] ::
-    classOf[EventSourcedEntity[_]] ::
+    classOf[EventSourcedEntity[_, _]] ::
     classOf[WorkflowEntity[_]] ::
     classOf[ValueEntity[_]] ::
     classOf[ReplicatedEntity[_]] ::
@@ -299,9 +299,9 @@ case class KalixSpringApplication(applicationContext: ApplicationContext, config
         kalixClient.registerComponent(action.serviceDescriptor())
       }
 
-      if (classOf[EventSourcedEntity[_]].isAssignableFrom(clz)) {
+      if (classOf[EventSourcedEntity[_, _]].isAssignableFrom(clz)) {
         logger.info(s"Registering EventSourcedEntity provider for [${clz.getName}]")
-        val esEntity = eventSourcedEntityProvider(clz.asInstanceOf[Class[EventSourcedEntity[Nothing]]])
+        val esEntity = eventSourcedEntityProvider(clz.asInstanceOf[Class[EventSourcedEntity[Nothing, Nothing]]])
         kalix.register(esEntity)
         kalixClient.registerComponent(esEntity.serviceDescriptor())
       }
@@ -395,8 +395,8 @@ case class KalixSpringApplication(applicationContext: ApplicationContext, config
     }
   }
 
-  private def eventSourcedEntityProvider[S, E <: EventSourcedEntity[S]](
-      clz: Class[E]): EventSourcedEntityProvider[S, E] =
+  private def eventSourcedEntityProvider[S, E, ES <: EventSourcedEntity[S, E]](
+      clz: Class[ES]): EventSourcedEntityProvider[S, E, ES] =
     ReflectiveEventSourcedEntityProvider.of(
       clz,
       messageCodec,

--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/eventsourcedentity/ReflectiveEventSourcedEntityRouter.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/eventsourcedentity/ReflectiveEventSourcedEntityRouter.scala
@@ -28,12 +28,12 @@ import kalix.springsdk.impl.{ CommandHandler, InvocationContext }
 
 import java.lang.reflect.ParameterizedType
 
-class ReflectiveEventSourcedEntityRouter[S, E <: EventSourcedEntity[S]](
-    override protected val entity: E,
+class ReflectiveEventSourcedEntityRouter[S, E, ES <: EventSourcedEntity[S, E]](
+    override protected val entity: ES,
     commandHandlers: Map[String, CommandHandler],
     eventHandlerMethods: Map[String, MethodInvoker],
     messageCodec: SpringSdkMessageCodec)
-    extends EventSourcedEntityRouter[S, E](entity) {
+    extends EventSourcedEntityRouter[S, E, ES](entity) {
 
   private def commandHandlerLookup(commandName: String) =
     commandHandlers.getOrElse(
@@ -45,7 +45,7 @@ class ReflectiveEventSourcedEntityRouter[S, E <: EventSourcedEntity[S]](
       eventName,
       throw new HandlerNotFoundException("event", eventName, commandHandlers.keySet))
 
-  override def handleEvent(state: S, event: Any): S = {
+  override def handleEvent(state: S, event: E): S = {
 
     _extractAndSetCurrentState(state)
 

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/badwiring/eventsourced/IllDefinedEventSourcedEntity.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/badwiring/eventsourced/IllDefinedEventSourcedEntity.java
@@ -24,4 +24,4 @@ import org.springframework.stereotype.Component;
 @EntityKey("id")
 @EntityType("test")
 @Component
-public class IllDefinedEventSourcedEntity extends EventSourcedEntity<String> {}
+public class IllDefinedEventSourcedEntity extends EventSourcedEntity<String, Object> {}

--- a/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
+++ b/sdk/spring-sdk/src/test/java/kalix/springsdk/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
@@ -25,7 +25,7 @@ public class EventSourcedEntitiesTestModels {
   @EntityKey("id")
   @EntityType("employee")
   @RequestMapping("/employee/{id}")
-  public static class EmployeeEntity extends EventSourcedEntity<Employee> {
+  public static class EmployeeEntity extends EventSourcedEntity<Employee, EmployeeEvent> {
 
     @PostMapping
     public Effect<String> createUser(@RequestBody CreateEmployee create) {
@@ -44,7 +44,7 @@ public class EventSourcedEntitiesTestModels {
   @EntityKey("id")
   @EntityType("counter")
   @RequestMapping("/eventsourced/{id}")
-  public static class CounterEventSourcedEntity extends EventSourcedEntity<Integer> {
+  public static class CounterEventSourcedEntity extends EventSourcedEntity<Integer, Object> {
 
     @GetMapping("/int/{number}")
     public Integer getInteger(@PathVariable Integer number) {
@@ -77,7 +77,7 @@ public class EventSourcedEntitiesTestModels {
 
 
   @EntityType("counter")
-  public static class CounterEventSourcedEntityWithEntityKeyOnMethod extends EventSourcedEntity<Integer> {
+  public static class CounterEventSourcedEntityWithEntityKeyOnMethod extends EventSourcedEntity<Integer, Object> {
     @EntityKey("id")
     @GetMapping("/eventsourced/{id}/int/{number}")
     public Integer getInteger(@PathVariable Integer number) {
@@ -87,7 +87,7 @@ public class EventSourcedEntitiesTestModels {
 
   @EntityKey("id")
   @EntityType("counter")
-  public static class CounterEventSourcedEntityWithEntityKeyMethodOverride extends EventSourcedEntity<Integer> {
+  public static class CounterEventSourcedEntityWithEntityKeyMethodOverride extends EventSourcedEntity<Integer, Object> {
 
     @EntityKey("counter_id")
     @GetMapping("/eventsourced/{counter_id}/int/{number}")
@@ -97,7 +97,7 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @EntityType("counter")
-  public static class CounterEventSourcedEntityWithEntityKeyGenerator extends EventSourcedEntity<Integer> {
+  public static class CounterEventSourcedEntityWithEntityKeyGenerator extends EventSourcedEntity<Integer, Object> {
     @GenerateEntityKey
     @PutMapping("/eventsourced/int/{number}")
     public Integer getInteger(@PathVariable Integer number) {
@@ -106,7 +106,7 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @EntityType("counter")
-  public static class IllDefinedEntityWithEntityKeyGeneratorAndEntityKey extends EventSourcedEntity<Integer> {
+  public static class IllDefinedEntityWithEntityKeyGeneratorAndEntityKey extends EventSourcedEntity<Integer, Object> {
     @GenerateEntityKey
     @EntityKey("id")
     @GetMapping("/eventsourced/{id}/int/{number}")
@@ -116,7 +116,7 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @EntityType("counter")
-  public static class IllDefinedEntityWithoutEntityKeyGeneratorNorEntityKey extends EventSourcedEntity<Integer> {
+  public static class IllDefinedEntityWithoutEntityKeyGeneratorNorEntityKey extends EventSourcedEntity<Integer, Object> {
     @GetMapping("/eventsourced/{id}/int/{number}")
     public Integer getInteger(@PathVariable Integer number) {
       return number;
@@ -126,7 +126,7 @@ public class EventSourcedEntitiesTestModels {
   @EntityKey("id")
   @EntityType("counter")
   @RequestMapping("/eventsourced/{id}")
-  public static class CounterEventSourcedEntityWithJWT extends EventSourcedEntity<Integer> {
+  public static class CounterEventSourcedEntityWithJWT extends EventSourcedEntity<Integer, Object> {
 
     @GetMapping("/int/{number}")
     @JWT(
@@ -147,7 +147,7 @@ public class EventSourcedEntitiesTestModels {
 
   @EntityKey("id")
   @EntityType("counter")
-  public static class ErrorDuplicatedEventsEntity extends EventSourcedEntity<Integer> {
+  public static class ErrorDuplicatedEventsEntity extends EventSourcedEntity<Integer, Object> {
 
     @EventHandler
     public Integer receiveStringEvent(String event) {
@@ -167,7 +167,7 @@ public class EventSourcedEntitiesTestModels {
 
   @EntityKey("id")
   @EntityType("counter")
-  public static class ErrorWrongSignaturesEntity extends EventSourcedEntity<Integer> {
+  public static class ErrorWrongSignaturesEntity extends EventSourcedEntity<Integer, Object> {
 
     @EventHandler
     public String receivedIntegerEvent(Integer event) {
@@ -183,7 +183,7 @@ public class EventSourcedEntitiesTestModels {
   @EntityKey("id")
   @EntityType("counter")
   @Acl(allow = @Acl.Matcher(service = "test"))
-  public static class EventSourcedEntityWithServiceLevelAcl extends EventSourcedEntity<Integer> {
+  public static class EventSourcedEntityWithServiceLevelAcl extends EventSourcedEntity<Integer, Object> {
 
   }
 
@@ -191,7 +191,7 @@ public class EventSourcedEntitiesTestModels {
   @EntityKey("id")
   @EntityType("counter")
   @RequestMapping("/employee/{id}")
-  public static class EventSourcedEntityWithMethodLevelAcl extends EventSourcedEntity<Integer> {
+  public static class EventSourcedEntityWithMethodLevelAcl extends EventSourcedEntity<Integer, Object> {
     @PostMapping
     @Acl(allow = @Acl.Matcher(service = "test"))
     public Effect<String> createUser(@RequestBody CreateEmployee create) {

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityOne.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityOne.java
@@ -20,7 +20,7 @@ import kalix.javasdk.eventsourcedentity.*;
 import kalix.tck.model.eventing.LocalPersistenceEventing;
 import com.google.protobuf.Empty;
 
-public class EventSourcedEntityOne extends EventSourcedEntity<String> {
+public class EventSourcedEntityOne extends EventSourcedEntity<String, Object> {
 
   public EventSourcedEntityOne(EventSourcedEntityContext context) {}
 

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityOneProvider.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityOneProvider.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 /** An event sourced entity provider */
 public class EventSourcedEntityOneProvider
-    implements EventSourcedEntityProvider<String, EventSourcedEntityOne> {
+    implements EventSourcedEntityProvider<String, Object, EventSourcedEntityOne> {
 
   private final Function<EventSourcedEntityContext, EventSourcedEntityOne> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityOneRouter.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityOneRouter.java
@@ -23,7 +23,7 @@ import kalix.tck.model.eventing.LocalPersistenceEventing;
 
 /** An event sourced entity handler */
 public class EventSourcedEntityOneRouter
-    extends EventSourcedEntityRouter<String, EventSourcedEntityOne> {
+    extends EventSourcedEntityRouter<String, Object, EventSourcedEntityOne> {
 
   public EventSourcedEntityOneRouter(EventSourcedEntityOne entity) {
     super(entity);

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityTwo.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityTwo.java
@@ -21,7 +21,7 @@ import kalix.javasdk.eventsourcedentity.*;
 import kalix.tck.model.eventing.LocalPersistenceEventing;
 import com.google.protobuf.Empty;
 
-public class EventSourcedEntityTwo extends EventSourcedEntity<String> {
+public class EventSourcedEntityTwo extends EventSourcedEntity<String, Object> {
 
   public EventSourcedEntityTwo(EventSourcedEntityContext context) {}
 

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityTwoProvider.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityTwoProvider.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 /** An event sourced entity provider */
 public class EventSourcedEntityTwoProvider
-    implements EventSourcedEntityProvider<String, EventSourcedEntityTwo> {
+    implements EventSourcedEntityProvider<String, Object, EventSourcedEntityTwo> {
 
   private final Function<EventSourcedEntityContext, EventSourcedEntityTwo> entityFactory;
   private final EventSourcedEntityOptions options;

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityTwoRouter.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/EventSourcedEntityTwoRouter.java
@@ -25,7 +25,7 @@ import com.google.protobuf.Any;
 
 /** An event sourced entity handler */
 public class EventSourcedEntityTwoRouter
-    extends EventSourcedEntityRouter<String, EventSourcedEntityTwo> {
+    extends EventSourcedEntityRouter<String, Object, EventSourcedEntityTwo> {
 
   public EventSourcedEntityTwoRouter(EventSourcedEntityTwo entity) {
     super(entity);


### PR DESCRIPTION
References #1323 

~Opening for visibility and early feedback.~

Task breakdown:
- [x] update ES entity signature and had a new type param
- [x] update testkits
  - [x] Ended-up not typing testkit ESResult, otherwise it's a breaking change for the grpc sdks. Note: the only drawback here is the getAllEvents returning a `List<Object>` instead of `List<E>`. Still, there is the `getNextEventOfType` which is typed anyway.
- [x] update spring ES samples to new format
- [x] update codegen for grpc sdks