### PR TITLE
fix: KalixReactiveWebServer.start

### DIFF
--- a/sdk/spring-sdk/src/main/scala/kalix/spring/boot/KalixReactiveWebServerFactory.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/spring/boot/KalixReactiveWebServerFactory.scala
@@ -40,7 +40,6 @@ class KalixReactiveWebServerFactory(kalixApp: KalixSpringApplication) extends Re
     new WebServer {
       override def start(): Unit = {
         logger.info("Starting Kalix ReactiveWebServer...")
-        Await.ready(kalixApp.start(), 10.seconds)
         started = true
       }
 


### PR DESCRIPTION
We were waiting for the start, but the returned Future only completes when the application terminates or when if fails to bind.

We should review this more carefully. The right thing to do is to return a Future that completes when it starts, not when it terminates.
