### PR TITLE
fix: use the same spring context environment for KalixComponentProvider

### DIFF
--- a/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixSpringApplication.scala
+++ b/sdk/spring-sdk/src/main/scala/kalix/springsdk/impl/KalixSpringApplication.scala
@@ -266,6 +266,7 @@ case class KalixSpringApplication(applicationContext: ApplicationContext, config
     .withDefaultAclFileDescriptor(AclDescriptorFactory.defaultAclFileDescriptor(mainClass).toJava)
 
   private val provider = new KalixComponentProvider(cglibEnhanceMainClass.getClass)
+  provider.setEnvironment(applicationContext.getEnvironment) //use the same environment to get access to properties
 
   // load all Kalix components found in the classpath
   val classBeanMap =


### PR DESCRIPTION
with this change we can disable components with existing Spring annotation:
```@ConditionalOnProperty```