### PR TITLE
chore: add redirects from spring to java

### DIFF
--- a/docs/src/modules/java/pages/access-control.adoc
+++ b/docs/src/modules/java/pages/access-control.adoc
@@ -1,4 +1,5 @@
 = Using ACLs
+:page-aliases: spring:access-control.adoc
 
 This section describes the practical aspects of configuring Access Control Lists (ACLs) with the Java SDK, if you are not sure what ACLs are or how they work, see https://docs.kalix.io/security/acls.html[Understanding ACLs] first.
 

--- a/docs/src/modules/java/pages/actions-as-controller.adoc
+++ b/docs/src/modules/java/pages/actions-as-controller.adoc
@@ -1,4 +1,5 @@
 = Actions as Controllers
+:page-aliases: spring:actions-as-controller.adoc
 
 Actions can be used to implement link:https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller[MVC Controllers] by
 acting as the external interface of a service, receiving requests, operating over the requests values and forwarding the call

--- a/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
@@ -1,4 +1,5 @@
 = Publishing and Subscribing with Actions
+:page-aliases: spring:actions-publishing-subscribing.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/java/pages/actions.adoc
+++ b/docs/src/modules/java/pages/actions.adoc
@@ -1,4 +1,5 @@
 = Implementing Actions
+:page-aliases: spring:actions.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$actions.adoc[]

--- a/docs/src/modules/java/pages/call-another-service.adoc
+++ b/docs/src/modules/java/pages/call-another-service.adoc
@@ -1,4 +1,5 @@
 = Calling other services
+:page-aliases: spring:call-another-service.adoc
 
 
 == Kalix services

--- a/docs/src/modules/java/pages/development-process.adoc
+++ b/docs/src/modules/java/pages/development-process.adoc
@@ -1,4 +1,5 @@
 = Process overview
+:page-aliases: spring:development-process.adoc
 include::ROOT:partial$include.adoc[]
 
 The main steps in developing a service include:

--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -1,5 +1,5 @@
 = Implementing Event Sourced Entities
-:page-aliases: spring:eventsourced.adoc
+:page-aliases: spring:eventsourced.adoc, spring:event-sourced-entities.adoc
 :sample-url: https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples/java-spring-eventsourced-shopping-cart
 
 include::ROOT:partial$include.adoc[]

--- a/docs/src/modules/java/pages/failures-and-errors.adoc
+++ b/docs/src/modules/java/pages/failures-and-errors.adoc
@@ -1,4 +1,5 @@
 = Failures and errors
+:page-aliases: spring:failures-and-errors.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]

--- a/docs/src/modules/java/pages/getting-started.adoc
+++ b/docs/src/modules/java/pages/getting-started.adoc
@@ -1,6 +1,5 @@
 = Getting started
-:page-aliases: spring:kickstart.adoc
-:page-aliases: spring:quickstart-java-maven.adoc
+:page-aliases: spring:kickstart.adoc, spring:quickstart-java-maven.adoc, spring:getting-started.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]

--- a/docs/src/modules/java/pages/index.adoc
+++ b/docs/src/modules/java/pages/index.adoc
@@ -1,4 +1,5 @@
 = Java SDK
+:page-aliases: spring:index.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]

--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-spring.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-spring.adoc
@@ -1,4 +1,5 @@
 = Quickstart: Customer Registry with Java
+:page-aliases: spring:quickstart/cr-value-entity-spring.adoc
 
 include::ROOT:partial$include.adoc[]
 include::java:partial$attributes.adoc[]

--- a/docs/src/modules/java/pages/serialization.adoc
+++ b/docs/src/modules/java/pages/serialization.adoc
@@ -1,4 +1,5 @@
 = Handling Serialization
+:page-aliases: spring:serialization.adoc
 
 You do not need to create serializers for the messages, events, or the state of Kalix components but you need to make them serializable. The same is true with Kalix endpoints. Kalix exposes the inputs and outputs of endpoints as JSON and you need to make them serializable. You have two ways to do this. 
 

--- a/docs/src/modules/java/pages/service-to-service.adoc
+++ b/docs/src/modules/java/pages/service-to-service.adoc
@@ -1,4 +1,5 @@
 = Service to Service Eventing
+:page-aliases: spring:service-to-service.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/java/pages/side-effects.adoc
+++ b/docs/src/modules/java/pages/side-effects.adoc
@@ -1,4 +1,5 @@
 = Running Side Effects
+:page-aliases: spring:side-effects.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/java/pages/spring-boot-integration.adoc
+++ b/docs/src/modules/java/pages/spring-boot-integration.adoc
@@ -1,4 +1,5 @@
 = Spring Boot Integration
+:page-aliases: spring:spring-boot-integration.adoc
 
 The Kalix Java SDK provides a familiar developer experience for Java developers that are used to Spring. Its `Main`
 class is annotated with `@SpringBootApplication` and starts exactly the same way as a common Spring Boot application, namely

--- a/docs/src/modules/java/pages/timers.adoc
+++ b/docs/src/modules/java/pages/timers.adoc
@@ -1,4 +1,5 @@
 = Timers
+:page-aliases: spring:timers.adoc
 
 include::java-protobuf:partial$timers-intro.adoc[]
 

--- a/docs/src/modules/java/pages/using-jwts.adoc
+++ b/docs/src/modules/java/pages/using-jwts.adoc
@@ -1,4 +1,5 @@
 = Using JWTs
+:page-aliases: spring:using-jwts.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/java/pages/value-entity.adoc
+++ b/docs/src/modules/java/pages/value-entity.adoc
@@ -1,4 +1,5 @@
 = Implementing Value Entities
+:page-aliases: spring:value-entity.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -1,4 +1,5 @@
 = Implementing Views
+:page-aliases: spring:views.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/docs/src/modules/java/pages/workflow-entities.adoc
+++ b/docs/src/modules/java/pages/workflow-entities.adoc
@@ -1,5 +1,5 @@
 = Implementing Workflow Entities
-:page-aliases: spring:workflow.adoc
+:page-aliases: spring:workflow.adoc, spring:workflow-entities.adoc
 :sample-url: https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples/java-spring-transfer-workflow
 
 include::ROOT:partial$include.adoc[]


### PR DESCRIPTION
Closes https://github.com/lightbend/kalix-proxy/issues/1980

Any page that was previously under `spring/` will now be under `java/`.