### PR TITLE
feat: missing handlers validation for ES Entities and Subscription wh…

### DIFF
--- a/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
+++ b/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
@@ -20,5 +20,14 @@ public class CounterJournalToTopicAction extends Action {
         ValueIncreased vi = new ValueIncreased(event.value() + 1);
         return effects().reply(vi); // <4>
     }
+    // end::class[]
+
+    @Subscribe.EventSourcedEntity(value = Counter.class)
+    @Publish.Topic("counter-events")
+    public Action.Effect<ValueIncreased> onValueMultiplied(ValueMultiplied event){
+        ValueIncreased vi = new ValueIncreased(event.value() + 1);
+        return effects().reply(vi);
+    }
+// tag::class[]
 }
 // end::class[]

--- a/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
+++ b/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
@@ -16,17 +16,15 @@ public class CounterJournalToTopicAction extends Action {
 
     @Subscribe.EventSourcedEntity(value = Counter.class) // <1>
     @Publish.Topic("counter-events") // <2>
-    public Action.Effect<ValueIncreased> onValueIncreased(ValueIncreased event){ // <3>
-        ValueIncreased vi = new ValueIncreased(event.value() + 1);
-        return effects().reply(vi); // <4>
+    public Action.Effect<CounterEvent> onValueIncreased(ValueIncreased event){ // <3>
+        return effects().reply(event); // <4>
     }
     // end::class[]
 
     @Subscribe.EventSourcedEntity(value = Counter.class)
     @Publish.Topic("counter-events")
-    public Action.Effect<ValueIncreased> onValueMultiplied(ValueMultiplied event){
-        ValueIncreased vi = new ValueIncreased(event.value() + 1);
-        return effects().reply(vi);
+    public Action.Effect<CounterEvent> onValueMultiplied(ValueMultiplied event){
+        return effects().reply(event);
     }
 // tag::class[]
 }

--- a/samples/java-spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartEntity.java
+++ b/samples/java-spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartEntity.java
@@ -105,6 +105,11 @@ public class ShoppingCartEntity extends EventSourcedEntity<ShoppingCart, Shoppin
   public ShoppingCart itemRemoved(ShoppingCartEvent.ItemRemoved itemRemoved) {
     return currentState().onItemRemoved(itemRemoved);
   }
+
+  @EventHandler
+  public ShoppingCart checkedOut(ShoppingCartEvent.CheckedOut checkedOut) {
+    return currentState().onCheckedOut();
+  }
 // tag::class[]
 
 }

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/ComponentDescriptorFactory.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/ComponentDescriptorFactory.scala
@@ -20,7 +20,6 @@ import java.lang.annotation.Annotation
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
-
 import scala.reflect.ClassTag
 import kalix.DirectDestination
 import kalix.DirectSource
@@ -41,6 +40,7 @@ import kalix.javasdk.annotations.EntityType
 import kalix.javasdk.annotations.JWT
 import kalix.javasdk.annotations.Table
 import kalix.javasdk.annotations.ViewId
+import kalix.javasdk.eventsourcedentity.EventSourcedEntity
 import kalix.javasdk.impl.reflection.CombinedSubscriptionServiceMethod
 import kalix.javasdk.impl.reflection.KalixMethod
 import kalix.javasdk.impl.reflection.NameGenerator
@@ -136,6 +136,11 @@ private[impl] object ComponentDescriptorFactory {
     val ann = javaMethod.getAnnotation(classOf[Subscribe.EventSourcedEntity])
     val entityClass = ann.value()
     entityClass.getAnnotation(classOf[EntityType]).value()
+  }
+
+  def findEventSourcedEntityClass(javaMethod: Method): Class[_ <: EventSourcedEntity[_, _]] = {
+    val ann = javaMethod.getAnnotation(classOf[Subscribe.EventSourcedEntity])
+    ann.value()
   }
 
   def findEventSourcedEntityType(clazz: Class[_]): String = {

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
@@ -189,7 +189,7 @@ object Validations {
               .map(_.getParameterTypes.last) //last because it could be a view update methods with 2 params
             val errors = eventType.getPermittedSubclasses
               .filterNot(effectMethodsInputParams.contains)
-              .map(clazz => s"Missing event handler for ${clazz.getName}")
+              .map(clazz => s"Missing event handler for '${clazz.getName}'")
             Validation(errors)
           } else {
             Valid

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
@@ -209,7 +209,8 @@ object Validations {
           val effectOutputInputParams: Seq[Class[_]] = methods.map(_.getParameterTypes.last)
           eventType.getPermittedSubclasses
             .filterNot(effectOutputInputParams.contains)
-            .map(clazz => s"Missing ${entityClass.getSimpleName} event handler for ${clazz.getName}")
+            .map(clazz =>
+              s"Component ${component.getSimpleName} missing event handler for ${clazz.getName} from ${entityClass.getSimpleName}")
             .toList
         } else {
           List.empty

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
@@ -215,7 +215,7 @@ object Validations {
   private def missingErrors(effectOutputInputParams: Seq[Class[_]], eventType: Class[_], component: Class[_]) = {
     eventType.getPermittedSubclasses
       .filterNot(effectOutputInputParams.contains)
-      .map(clazz => s"Component '${component.getSimpleName}' is missing event handler for '${clazz.getName}'")
+      .map(clazz => s"Component '${component.getSimpleName}' is missing an event handler for '${clazz.getName}'")
       .toList
   }
 

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
@@ -61,11 +61,6 @@ object Validations {
     final def isInvalid: Boolean = !isInvalid
     def ++(validation: Validation): Validation
 
-    /**
-     * add this validation when the current one is Valid
-     */
-    def combineWhenValid(validation: Validation): Validation
-
     def failIfInvalid: Validation
   }
 
@@ -74,8 +69,6 @@ object Validations {
     override def ++(validation: Validation): Validation = validation
 
     override def failIfInvalid: Validation = this
-
-    override def combineWhenValid(validation: Validation): Validation = validation
   }
 
   object Invalid {
@@ -94,14 +87,6 @@ object Validations {
 
     override def failIfInvalid: Validation =
       throw InvalidComponentException(messages.mkString(", "))
-
-    override def combineWhenValid(validation: Validation): Validation = {
-      if (isValid) {
-        validation
-      } else {
-        this
-      }
-    }
   }
 
   private def when(cond: Boolean)(block: => Validation): Validation =
@@ -120,8 +105,8 @@ object Validations {
   private def commonSubscriptionValidation(
       component: Class[_],
       updateMethodPredicate: Method => Boolean): Validation = {
-    eventSourcedEntitySubscriptionValidations(component)
-      .combineWhenValid(missingEventHandlerValidations(component, updateMethodPredicate)) ++
+    eventSourcedEntitySubscriptionValidations(component) ++
+    missingEventHandlerValidations(component, updateMethodPredicate) ++
     valueEntitySubscriptionValidations(component) ++
     topicSubscriptionValidations(component) ++
     publishStreamIdMustBeFilled(component) ++

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
@@ -68,7 +68,11 @@ object EventSourcedHandlersExtractor {
         val missingHandlerClasses = eventType.getPermittedSubclasses
           .filterNot(validHandlers.contains)
           .toList
-        List(HandlerValidationError(List.empty, s"missing event handler", missingHandlerClasses))
+        if (missingHandlerClasses.isEmpty) {
+          List.empty
+        } else {
+          List(HandlerValidationError(List.empty, s"missing event handler", missingHandlerClasses))
+        }
       } else {
         List.empty
       }

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
@@ -19,7 +19,6 @@ package kalix.javasdk.impl.eventsourcedentity
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
-
 import kalix.javasdk.annotations.EventHandler
 import kalix.javasdk.impl.MethodInvoker
 import kalix.javasdk.impl.JsonMessageCodec
@@ -32,13 +31,15 @@ object EventSourcedHandlersExtractor {
       .filter(_.getAnnotation(classOf[EventHandler]) != null)
       .toList
 
+    val genericTypeArguments = entityClass.getGenericSuperclass
+      .asInstanceOf[ParameterizedType]
+      .getActualTypeArguments
     // the type parameter from the entity defines the return type of each event handler
-    val returnType =
-      entityClass.getGenericSuperclass
-        .asInstanceOf[ParameterizedType]
-        .getActualTypeArguments
-        .head
-        .asInstanceOf[Class[_]]
+    val returnType = genericTypeArguments.head
+      .asInstanceOf[Class[_]]
+
+    val eventType = genericTypeArguments(1).asInstanceOf[Class[_]]
+
     val (invalidHandlers, validSignatureHandlers) = annotatedHandlers.partition((m: Method) =>
       m.getParameterCount != 1 || !Modifier.isPublic(m.getModifiers) || (returnType != m.getReturnType))
 
@@ -55,11 +56,22 @@ object EventSourcedHandlersExtractor {
           HandlerValidationError(
             invalidHandlers,
             "must be public, with exactly one parameter and return type '" + returnType.getTypeName + "'"))
+
     val errorsForDuplicates =
       for (elem <- duplicatedEventTypes)
         yield HandlerValidationError(
           elem._2,
           "cannot have duplicate event handlers for the same event type: '" + elem._1.getName + "'")
+
+    val missingEventHandler =
+      if (eventType.isSealed) {
+        val missingHandlerClasses = eventType.getPermittedSubclasses
+          .filterNot(validHandlers.contains)
+          .toList
+        List(HandlerValidationError(List.empty, s"missing event handler", missingHandlerClasses))
+      } else {
+        List.empty
+      }
 
     EventSourceEntityHandlers(
       handlers = validHandlers.map { case (classType, methods) =>
@@ -67,7 +79,7 @@ object EventSourcedHandlersExtractor {
           methods.head,
           ParameterExtractors.AnyBodyExtractor[AnyRef](classType))
       },
-      errors = errorsForSignatures ++ errorsForDuplicates.toList)
+      errors = errorsForSignatures ++ errorsForDuplicates.toList ++ missingEventHandler)
   }
 }
 
@@ -75,7 +87,11 @@ private[kalix] final case class EventSourceEntityHandlers private (
     handlers: Map[String, MethodInvoker],
     errors: List[HandlerValidationError])
 
-private[kalix] final case class HandlerValidationError(methods: List[Method], description: String) {
+private[kalix] final case class HandlerValidationError(
+    methods: List[Method],
+    description: String,
+    missingHandlersFor: List[Class[_]] = List.empty) {
   override def toString: String =
-    s"ValidationError(reason='$description', offendingMethods=${methods.map(_.getName)}"
+    s"ValidationError(reason='$description', offendingMethods=${methods.map(
+      _.getName)}, missingHandlersFor=${missingHandlersFor.map(_.getName)}"
 }

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
@@ -71,7 +71,7 @@ object EventSourcedHandlersExtractor {
         if (missingHandlerClasses.isEmpty) {
           List.empty
         } else {
-          List(HandlerValidationError(List.empty, s"missing event handler", missingHandlerClasses))
+          List(HandlerValidationError(List.empty, "missing event handler", missingHandlerClasses))
         }
       } else {
         List.empty

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EmployeeEvent.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EmployeeEvent.java
@@ -21,7 +21,7 @@ import kalix.javasdk.annotations.TypeName;
 public interface EmployeeEvent {
 
   @TypeName("created")
-  class EmployeeCreated implements EmployeeEvent {
+  final class EmployeeCreated implements EmployeeEvent {
 
     public final String firstName;
     public final String lastName;
@@ -35,7 +35,7 @@ public interface EmployeeEvent {
   }
 
   @TypeName("emailUpdated")
-  class EmployeeEmailUpdated implements EmployeeEvent {
+  final class EmployeeEmailUpdated implements EmployeeEvent {
 
     public final String email;
 

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
@@ -181,6 +181,24 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @EntityKey("id")
+  @EntityType("employee")
+  @RequestMapping("/employee/{id}")
+  public static class EmployeeEntityWithMissingHandler extends EventSourcedEntity<Employee, EmployeeEvent> {
+
+    @PostMapping
+    public Effect<String> createUser(@RequestBody CreateEmployee create) {
+      return effects()
+          .emitEvent(new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
+          .thenReply(__ -> "ok");
+    }
+
+    @EventHandler
+    public Employee onEvent(EmployeeEvent.EmployeeCreated created) {
+      return new Employee(created.firstName, created.lastName, created.email);
+    }
+  }
+
+  @EntityKey("id")
   @EntityType("counter")
   @Acl(allow = @Acl.Matcher(service = "test"))
   public static class EventSourcedEntityWithServiceLevelAcl extends EventSourcedEntity<Integer, Object> {

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/subscriptions/PubSubTestModels.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/subscriptions/PubSubTestModels.java
@@ -22,6 +22,7 @@ import kalix.javasdk.annotations.Publish;
 import kalix.javasdk.annotations.Subscribe;
 import kalix.spring.testmodels.Message;
 import kalix.spring.testmodels.Message2;
+import kalix.spring.testmodels.eventsourcedentity.EmployeeEvent.EmployeeCreated;
 import kalix.spring.testmodels.valueentity.Counter;
 import kalix.spring.testmodels.valueentity.CounterState;
 import kalix.javasdk.view.View;
@@ -121,6 +122,30 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     }
   }
 
+  @Subscribe.EventSourcedEntity(value = EmployeeEntity.class)
+  public static class MissingHandlersWhenSubscribeToEventSourcedEntityAction extends Action {
+
+    public Action.Effect<Integer> methodOne(Integer message) {
+      return effects().reply(message);
+    }
+
+    public Action.Effect<String> onEvent(EmployeeCreated message) {
+      return effects().reply(message.toString());
+    }
+  }
+
+  public static class MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction extends Action {
+
+    public Action.Effect<Integer> methodOne(Integer message) {
+      return effects().reply(message);
+    }
+
+    @Subscribe.EventSourcedEntity(value = EmployeeEntity.class)
+    public Action.Effect<String> onEvent(EmployeeCreated message) {
+      return effects().reply(message.toString());
+    }
+  }
+
   public static class SubscribeToTopicAction extends Action {
 
     @Subscribe.Topic(value = "topicXYZ", consumerGroup = "cg")
@@ -208,7 +233,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
   @Subscribe.EventSourcedEntity(value = EmployeeEntity.class, ignoreUnknown = true)
   public static class SubscribeOnTypeToEventSourcedEvents extends View<Employee> {
 
-      public UpdateEffect<Employee> onCreate(EmployeeEvent.EmployeeCreated evt) {
+      public UpdateEffect<Employee> onCreate(EmployeeCreated evt) {
         return effects()
             .updateState(new Employee(evt.firstName, evt.lastName, evt.email));
       }
@@ -230,7 +255,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     @Publish.Stream(id = "employee_events")
     public static class EventStreamPublishingAction extends Action {
 
-      public Effect<String> transform(EmployeeEvent.EmployeeCreated created) {
+      public Effect<String> transform(EmployeeCreated created) {
         return effects().reply(created.toString());
       }
 
@@ -243,7 +268,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     @Subscribe.Stream(service = "employee_service", id = "employee_events", ignoreUnknown = true)
     public static class EventStreamSubscriptionAction extends Action {
 
-      public Effect<String> transform(EmployeeEvent.EmployeeCreated created) {
+      public Effect<String> transform(EmployeeCreated created) {
         return effects().reply(created.toString());
       }
 
@@ -256,7 +281,7 @@ public class PubSubTestModels {//TODO shall we remove this class and move things
     @Subscribe.Stream(service = "employee_service", id = "employee_events")
     public static class EventStreamSubscriptionView extends View<Employee> {
 
-      public UpdateEffect<Employee> onCreate(EmployeeEvent.EmployeeCreated evt) {
+      public UpdateEffect<Employee> onCreate(EmployeeCreated evt) {
         return effects()
             .updateState(new Employee(evt.firstName, evt.lastName, evt.email));
       }

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/view/ViewTestModels.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/view/ViewTestModels.java
@@ -391,8 +391,23 @@ public class ViewTestModels {
   public static class SubscribeToEventSourcedEventsWithMethodWithState extends View<Employee> {
 
     @Subscribe.EventSourcedEntity(EventSourcedEntitiesTestModels.EmployeeEntity.class)
-    public UpdateEffect<Employee> onEvent(Employee employee, EmployeeEvent evt) {
-      EmployeeEvent.EmployeeCreated created = (EmployeeEvent.EmployeeCreated) evt;
+    public UpdateEffect<Employee> onEvent(Employee employee, EmployeeEvent.EmployeeCreated created) {
+      return effects()
+          .updateState(new Employee(created.firstName, created.lastName, created.email));
+    }
+
+    @Query("SELECT * FROM employees_view WHERE email = :email")
+    @PostMapping("/employees/by-email/{email}")
+    public Employee getEmployeeByEmail(@PathVariable String email) {
+      return null;
+    }
+  }
+
+  @Table(value = "employees_view")
+  @Subscribe.EventSourcedEntity(value = EventSourcedEntitiesTestModels.EmployeeEntity.class, ignoreUnknown = false)
+  public static class TypeLevelSubscribeToEventSourcedEventsWithState extends View<Employee> {
+
+    public UpdateEffect<Employee> onEvent(Employee employee, EmployeeEvent.EmployeeCreated created) {
       return effects()
           .updateState(new Employee(created.firstName, created.lastName, created.email));
     }

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
@@ -18,7 +18,7 @@ package kalix.javasdk.impl
 
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import com.google.protobuf.empty.Empty
-import com.google.protobuf.{ Any => JavaPbAny }
+import com.google.protobuf.{Any => JavaPbAny}
 import kalix.JwtMethodOptions.JwtMethodMode
 import kalix.spring.testmodels.action.ActionsTestModels.DeleteWithOneParam
 import kalix.spring.testmodels.action.ActionsTestModels.GetClassLevel
@@ -58,6 +58,7 @@ import kalix.spring.testmodels.subscriptions.PubSubTestModels.SubscribeToTopicAc
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.SubscribeToTwoTopicsAction
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.SubscribeToValueEntityAction
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.SubscribeToValueEntityWithDeletesAction
+import org.scalatest.Ignore
 import org.scalatest.wordspec.AnyWordSpec
 
 class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuite {
@@ -419,14 +420,16 @@ class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSu
       }.getMessage should include("You cannot use @Subscribe.EventSourcedEntity annotation in both methods and class.")
     }
 
-    "validates if there are missing event handlers for event sourced Entity Subscription at type level" in {
+    //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
+    "validates if there are missing event handlers for event sourced Entity Subscription at type level" ignore {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedEntityAction]).failIfInvalid
       }.getMessage should include(
         "Missing event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
     }
 
-    "validates if there are missing event handlers for event sourced Entity Subscription at method level" in {
+    //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
+    "validates if there are missing event handlers for event sourced Entity Subscription at method level" ignore {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction]).failIfInvalid
       }.getMessage should include(

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
@@ -425,7 +425,7 @@ class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSu
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedEntityAction]).failIfInvalid
       }.getMessage should include(
-        "Missing event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
+        "Component `MissingHandlersWhenSubscribeToEventSourcedEntityAction` is missing event handler for `kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated`")
     }
 
     //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
@@ -433,7 +433,7 @@ class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSu
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction]).failIfInvalid
       }.getMessage should include(
-        "Missing EmployeeEntity event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
+        "Component `MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction` is missing event handler for `kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated`")
     }
 
     "validates it is forbidden Topic Subscription at annotation type level and method level at the same time" in {

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
@@ -425,7 +425,7 @@ class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSu
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedEntityAction]).failIfInvalid
       }.getMessage should include(
-        "Component `MissingHandlersWhenSubscribeToEventSourcedEntityAction` is missing event handler for `kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated`")
+        "Component 'MissingHandlersWhenSubscribeToEventSourcedEntityAction' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
     }
 
     //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
@@ -433,7 +433,7 @@ class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSu
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction]).failIfInvalid
       }.getMessage should include(
-        "Component `MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction` is missing event handler for `kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated`")
+        "Component 'MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
     }
 
     "validates it is forbidden Topic Subscription at annotation type level and method level at the same time" in {

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
@@ -18,7 +18,7 @@ package kalix.javasdk.impl
 
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import com.google.protobuf.empty.Empty
-import com.google.protobuf.{Any => JavaPbAny}
+import com.google.protobuf.{ Any => JavaPbAny }
 import kalix.JwtMethodOptions.JwtMethodMode
 import kalix.spring.testmodels.action.ActionsTestModels.DeleteWithOneParam
 import kalix.spring.testmodels.action.ActionsTestModels.GetClassLevel

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
@@ -46,6 +46,8 @@ import kalix.spring.testmodels.subscriptions.PubSubTestModels.EventStreamPublish
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.EventStreamSubscriptionAction
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.InvalidSubscribeToEventSourcedEntityAction
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.InvalidSubscribeToTopicAction
+import kalix.spring.testmodels.subscriptions.PubSubTestModels.MissingHandlersWhenSubscribeToEventSourcedEntityAction
+import kalix.spring.testmodels.subscriptions.PubSubTestModels.MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.PublishToTopicAction
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.RestAnnotatedSubscribeToEventSourcedEntityAction
 import kalix.spring.testmodels.subscriptions.PubSubTestModels.RestAnnotatedSubscribeToValueEntityAction
@@ -415,6 +417,20 @@ class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSu
       intercept[InvalidComponentException] {
         Validations.validate(classOf[InvalidSubscribeToEventSourcedEntityAction]).failIfInvalid
       }.getMessage should include("You cannot use @Subscribe.EventSourcedEntity annotation in both methods and class.")
+    }
+
+    "validates if there are missing event handlers for event sourced Entity Subscription at type level" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedEntityAction]).failIfInvalid
+      }.getMessage should include(
+        "Missing event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
+    }
+
+    "validates if there are missing event handlers for event sourced Entity Subscription at method level" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction]).failIfInvalid
+      }.getMessage should include(
+        "Missing EmployeeEntity event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
     }
 
     "validates it is forbidden Topic Subscription at annotation type level and method level at the same time" in {

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
@@ -537,7 +537,7 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
       intercept[InvalidComponentException] {
         Validations.validate(classOf[SubscribeToEventSourcedEventsWithMethodWithState]).failIfInvalid
       }.getMessage should include(
-        "Missing EmployeeEntity event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
+        "Component 'SubscribeToEventSourcedEventsWithMethodWithState' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
     }
 
     //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
@@ -545,7 +545,7 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
       intercept[InvalidComponentException] {
         Validations.validate(classOf[TypeLevelSubscribeToEventSourcedEventsWithState]).failIfInvalid
       }.getMessage should include(
-        "Missing event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
+        "Component 'TypeLevelSubscribeToEventSourcedEventsWithState' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
     }
   }
 

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
@@ -532,14 +532,16 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
       }
     }
 
-    "validate missing handlers for method level subscription" in {
+    //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
+    "validate missing handlers for method level subscription" ignore {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[SubscribeToEventSourcedEventsWithMethodWithState]).failIfInvalid
       }.getMessage should include(
         "Missing EmployeeEntity event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
     }
 
-    "validate missing handlers for type level subscription" in {
+    //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
+    "validate missing handlers for type level subscription" ignore {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[TypeLevelSubscribeToEventSourcedEventsWithState]).failIfInvalid
       }.getMessage should include(

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
@@ -35,6 +35,7 @@ import kalix.spring.testmodels.view.ViewTestModels.TransformedUserViewUsingState
 import kalix.spring.testmodels.view.ViewTestModels.TransformedUserViewWithDeletes
 import kalix.spring.testmodels.view.ViewTestModels.TransformedUserViewWithJWT
 import kalix.spring.testmodels.view.ViewTestModels.TransformedViewWithoutSubscriptionOnMethodLevel
+import kalix.spring.testmodels.view.ViewTestModels.TypeLevelSubscribeToEventSourcedEventsWithState
 import kalix.spring.testmodels.view.ViewTestModels.UserByEmailWithCollectionReturn
 import kalix.spring.testmodels.view.ViewTestModels.UserByEmailWithGet
 import kalix.spring.testmodels.view.ViewTestModels.UserByEmailWithPost
@@ -529,6 +530,20 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
         methodOptions.getView.getJsonSchema.getOutput shouldBe "Employee"
 
       }
+    }
+
+    "validate missing handlers for method level subscription" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[SubscribeToEventSourcedEventsWithMethodWithState]).failIfInvalid
+      }.getMessage should include(
+        "Missing EmployeeEntity event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
+    }
+
+    "validate missing handlers for type level subscription" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[TypeLevelSubscribeToEventSourcedEventsWithState]).failIfInvalid
+      }.getMessage should include(
+        "Missing event handler for kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated")
     }
   }
 

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/eventsourceentity/EventSourcedHandlersExtractorSpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/eventsourceentity/EventSourcedHandlersExtractorSpec.scala
@@ -56,7 +56,8 @@ class EventSourcedHandlersExtractorSpec extends AnyWordSpec with Matchers {
       offendingMethods shouldBe List("receivedIntegerEvent", "receivedIntegerEventAndString")
     }
 
-    "report error on missing event handler for sealed event interface" in {
+    //TODO remove ignore after updating to Scala 2.13.11 (https://github.com/scala/scala/pull/10105)
+    "report error on missing event handler for sealed event interface" ignore {
       val result = EventSourcedHandlersExtractor.handlersFrom(classOf[EmployeeEntityWithMissingHandler], messageCodec)
       result.handlers.size shouldBe 1
       result.errors.size shouldBe 1


### PR DESCRIPTION
References #1517 

Currently, tests are failing from sbt because I can't use Mixed compilation mode with Java sealed interface, Scala update is required: https://github.com/scala/scala/pull/10105 The solution works or my machine, I could even run tests with IntelliJ, so I can comment out new tests, merge, and wait for Scala release. Or I could wait with the merge for Scala release.