### PR TITLE
ci: fix labeler tag names

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,14 +3,14 @@
 kalix-proxy:
   - '**/*'
 
-java-protobuf-sdk:
+java-sdk-protobuf:
   - sdk/java-sdk/**/*
   - sdk/java-sdk-testkit/**/*
   - maven-java/**/*
   - codegen/java-gen/**/*
   - samples/java-protobuf-*/**/*
 
-scala-protobuf-sdk:
+scala-sdk-protobuf:
   - sdk/scala-sdk/**/*
   - sdk/scala-sdk-testkit/**/*
   - sbt-plugin/**/*


### PR DESCRIPTION
I had only one job... Follow up of https://github.com/lightbend/kalix-jvm-sdk/pull/1504