### PR TITLE
chore: zip customer-registry-views quickstart

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -88,12 +88,13 @@ examples:
 	rsync -a --exclude-from=.examplesignore ../samples/java-spring-* "${java_managed_examples}/"
 
 bundles:
+	bin/bundle.sh --zip "${java_managed_attachments}/java-spring-customer-registry-quickstart.zip" ../samples/java-spring-customer-registry-quickstart
+	bin/bundle.sh --zip "${java_managed_attachments}/java-spring-customer-registry-views-quickstart.zip" ../samples/java-spring-customer-registry-views-quickstart
 	bin/bundle.sh --zip "${java_pb_managed_attachments}/java-protobuf-customer-registry-quickstart.zip" ../samples/java-protobuf-customer-registry-quickstart
 	bin/bundle.sh --zip "${java_pb_managed_attachments}/java-protobuf-customer-registry-views-quickstart.zip" ../samples/java-protobuf-customer-registry-views-quickstart
 	bin/bundle.sh --zip "${java_pb_managed_attachments}/java-protobuf-customer-registry-kafka-quickstart.zip" ../samples/java-protobuf-customer-registry-kafka-quickstart
 	bin/bundle.sh --zip "${java_pb_managed_attachments}/java-protobuf-shopping-cart-quickstart.zip" ../samples/java-protobuf-shopping-cart-quickstart
 	bin/bundle.sh --zip "${java_pb_managed_attachments}/scala-protobuf-customer-registry-quickstart.zip" ../samples/scala-protobuf-customer-registry-quickstart
-	bin/bundle.sh --zip "${java_managed_attachments}/java-spring-customer-registry-quickstart.zip" ../samples/java-spring-customer-registry-quickstart
 
 dev: clean managed validate-xrefs dev-html
 

--- a/samples/java-spring-customer-registry-views-quickstart/.bundleignore
+++ b/samples/java-spring-customer-registry-views-quickstart/.bundleignore
@@ -1,0 +1,3 @@
+target
+.*
+dependency-reduced-pom.xml


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
References https://github.com/lightbend/kalix-jvm-sdk/issues/1343

This only creates the zip so we can download it using `kalix quickstart`. We will need to add a page for it and update https://docs.kalix.io/quickstart/index.html 