### PR TITLE
docs: updating READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Kalix Java SDK
+# Contributing to Kalix JVM SDKs
 
 FIXME contribution guidelines like in other LB projects
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,34 @@
-# Kalix Java and Scala SDK
+# Kalix JVM SDKs
 
-For more information see the documentation for [implementing Kalix services in Java or Scala](https://docs.kalix.io/java/index.html).
 
-## Parts of the Kalix Java/Scala SDK
+The Kalix JVM SDKs are used to develop Kalix services using Java or Scala. Two different development approaches are available as listed below: 
+- Java SDK (code-first)
+- Java Protobuf SDK (protocol-first)
+- Scala Protobuf SDK (protocol-first)
 
-* user-facing packages
-    * `kalix-java-sdk` and `kalix-scala-sdk` The Java/Scala API to build services in Kalix (backed by an implementation in Scala based on Akka gRPC).
+If you’re just looking to get started, we advise you to start with the Java SDK which is the only one supporting a code-first development approach at present. For more information see the documentation for [implementing Kalix services in Java](https://docs.kalix.io/java/index.html).
 
-      See [Developing with Java or Scala](https://docs.kalix.io/java/index.html).
 
-    * `kalix-java-sdk-testkit` and `kalix-scala-sdk-testkit` A library to implement integration tests for services with Junit 4 or 5, based on [TestContainers](https://www.testcontainers.org/). Also contains library parts of unit TestKit.
+## Java SDK
 
-    * [samples](samples/) Small example services to illustrate Kalix features. The code provides snippets for the documentation.
+* User-facing packages
+  * `kalix-spring-boot-starter`: The Java API to build services in Kalix with a code-first development approach using a Spring Boot Starter. See [Java SDK](https://docs.kalix.io/java/index.html).
+  * `kalix-spring-boot-starter-test`: A library to implement integration tests for services with Junit 4 or 5, based on [TestContainers](https://www.testcontainers.org/). Also contains library parts of unit TestKit.
+* [Samples](samples/): Small example services to illustrate Kalix features for this SDK are prefixed with `java-spring-`. The code also provides snippets for the documentation.
+* Developer tooling
+  * `maven-java` Maven tooling
+    * `kalix-spring-boot-archetype` Maven archetype to create a project.
 
-* developer tooling
+## Java/Scala Protobuf SDK
+
+* User-facing packages
+  * `kalix-java-sdk-protobuf` and `kalix-scala-sdk-protobuf`: The Java/Scala Protobuf API to build services in Kalix (backed by an implementation in Scala based on Akka gRPC). See [Java/Scala Protobuf SDK](https://docs.kalix.io/java-protobuf/index.html).
+
+  * `kalix-java-sdk-testkit` and `kalix-scala-sdk-testkit`: A library to implement integration tests for services with Junit 4 or 5, based on [TestContainers](https://www.testcontainers.org/). Also contains library parts of unit TestKit.
+
+* [Samples](samples/): Small example services to illustrate Kalix features are prefixed with `java-protobuf-` or `scala-protobuf-`. The code provides snippets for the documentation.
+
+* Developer tooling
    * `codegen/core`, `codegen/java-gen`, `codegen/scala-gen` Tooling to generate code from Protobuf with annotations.
    * `maven-java` Maven tooling
      * `kalix-maven-plugin` Maven plugin to trigger code generation.
@@ -23,11 +38,12 @@ For more information see the documentation for [implementing Kalix services in J
    * `sbt new` (gitter8) templates:
      * [lightbend/kalix-value-entity.g8](https://github.com/lightbend/kalix-value-entity.g8) 
 
-* `docs` The documentation feeding into [Developing with Java or Scala](https://docs.kalix.io/java/index.html).
+## Common parts
+* `docs` The documentation feeding into [Java SDK](https://docs.kalix.io/java/index.html) and [Java/Scala Protobuf SDK](https://docs.kalix.io/java/index.html).
 
 * `tck` The Technology Compatibility Kit which ensures the Java SDK adheres to the Kalix protocol.
 
 # License
 
-The Kalix Java SDK is Open Source and available under the [Apache 2 License](LICENSE).
+The Kalix JVM SDKs are Open Source and available under the [Apache 2 License](LICENSE).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Java SDK docs
+# JVM SDKs docs
 
 
 ## Building docs

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -10,7 +10,7 @@ While designing your service it is useful to read [designing services](https://d
 ]]#
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/index.html)
+and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/index.html)
 
 #[[
 ## Building
@@ -41,7 +41,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/${package}.MyServiceEntity/GetValue -d '{"entityId": "foo"}'

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
@@ -10,7 +10,7 @@ While designing your service it is useful to read [designing services](https://d
 ]]#
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/index.html)
+and in particular the [Java section](https://docs.kalix.io/java-protobuf/index.html)
 
 #[[
 ## Building
@@ -39,7 +39,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/${package}.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
@@ -9,7 +9,7 @@ To understand the Kalix concepts that are the basis for this example, see [Desig
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/)
+and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
 
 
 ## Building
@@ -49,7 +49,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 
 * Create a customer with:

--- a/samples/java-protobuf-customer-registry-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-quickstart/README.md
@@ -9,7 +9,7 @@ To understand the Kalix concepts that are the basis for this example, see [Desig
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/)
+and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
 
 
 ## Building
@@ -38,7 +38,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 
 * Create a customer with:

--- a/samples/java-protobuf-customer-registry-views-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-views-quickstart/README.md
@@ -9,7 +9,7 @@ To understand the Kalix concepts that are the basis for this example, see [Desig
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/)
+and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
 
 
 ## Building
@@ -38,7 +38,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 
 * Create a customer with:

--- a/samples/java-protobuf-eventsourced-counter/README.md
+++ b/samples/java-protobuf-eventsourced-counter/README.md
@@ -10,7 +10,7 @@ While designing your service it is useful to read [designing services](https://d
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/)
+and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
 
 
 ## Building
@@ -39,7 +39,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'        

--- a/samples/java-protobuf-fibonacci-action/README.md
+++ b/samples/java-protobuf-fibonacci-action/README.md
@@ -39,7 +39,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.fibonacci.Fibonacci/NextNumber -d '{"value": 5 }'

--- a/samples/java-protobuf-first-service/README.md
+++ b/samples/java-protobuf-first-service/README.md
@@ -10,7 +10,7 @@ While designing your service it is useful to read [designing services](https://d
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/)
+and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
 
 
 ## Building
@@ -39,7 +39,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/java-protobuf-reliable-timers/README.md
+++ b/samples/java-protobuf-reliable-timers/README.md
@@ -53,7 +53,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/PlaceOrder -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/java-protobuf-shopping-cart-quickstart/README.md
+++ b/samples/java-protobuf-shopping-cart-quickstart/README.md
@@ -9,7 +9,7 @@ To understand the Kalix concepts that are the basis for this example, see [Desig
 
 This project demonstrates the use of an Event Sourced Entity.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
-and in particular the [Java section](https://docs.kalix.io/java/)
+and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
 
 
 ## Building

--- a/samples/java-protobuf-valueentity-counter/README.md
+++ b/samples/java-protobuf-valueentity-counter/README.md
@@ -53,7 +53,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/java-protobuf-view-store/README.md
+++ b/samples/java-protobuf-view-store/README.md
@@ -31,7 +31,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 ### Exercising the services
 

--- a/samples/java-spring-fibonacci-action/README.md
+++ b/samples/java-spring-fibonacci-action/README.md
@@ -39,7 +39,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 
 ```shell 

--- a/samples/scala-protobuf-customer-registry-quickstart/README.md
+++ b/samples/scala-protobuf-customer-registry-quickstart/README.md
@@ -41,7 +41,7 @@ sbt run
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 
 * Create a customer with:

--- a/samples/scala-protobuf-eventsourced-counter/README.md
+++ b/samples/scala-protobuf-eventsourced-counter/README.md
@@ -31,7 +31,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-eventsourced-customer-registry/README.md
+++ b/samples/scala-protobuf-eventsourced-customer-registry/README.md
@@ -45,7 +45,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. 
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. 
 
 * Create a customer with:
   ```shell

--- a/samples/scala-protobuf-fibonacci-action/README.md
+++ b/samples/scala-protobuf-fibonacci-action/README.md
@@ -31,7 +31,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.fibonacci.Fibonacci/NextNumber -d '{"value": 5 }'

--- a/samples/scala-protobuf-first-service/README.md
+++ b/samples/scala-protobuf-first-service/README.md
@@ -35,7 +35,7 @@ To start the application locally, start it from your IDE or use:
 sbt run
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-reliable-timers/README.md
+++ b/samples/scala-protobuf-reliable-timers/README.md
@@ -30,7 +30,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/PlaceOrder -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
@@ -39,7 +39,7 @@ To start the application locally, start it from your IDE or use:
 sbt run
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 * Send an AddItem command:
 

--- a/samples/scala-protobuf-valueentity-counter/README.md
+++ b/samples/scala-protobuf-valueentity-counter/README.md
@@ -31,7 +31,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-valueentity-customer-registry/README.md
+++ b/samples/scala-protobuf-valueentity-customer-registry/README.md
@@ -31,7 +31,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 * Create a customer with:
   ```shell

--- a/samples/scala-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-valueentity-shopping-cart/README.md
@@ -39,7 +39,7 @@ To start the application locally, start it from your IDE or use:
 sbt run
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 * Send an AddItem command:
 

--- a/tck/README.md
+++ b/tck/README.md
@@ -1,4 +1,4 @@
-# Kalix TCK implementation for Java SDK
+# Kalix TCK implementation for Java Protobuf SDK
 
 Run the TCK (against the Kalix TCK docker image):
 


### PR DESCRIPTION
Closes https://github.com/lightbend/kalix-proxy/issues/1937

I'm not a huge fan of the current main README we have on this repo TBH. I don't think it provides much value currently.
I think a cleaner one more focused on the developer could be more useful.

Maybe I should open a separate issue for that discussion..