### PR TITLE
chore: template mentioning spring-boot plugin

### DIFF
--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
@@ -26,7 +26,7 @@ To start the proxy, run the following command from this directory:
 docker-compose up
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
 
 ```shell
 mvn spring-boot:run

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
@@ -26,7 +26,7 @@ To start the proxy, run the following command from this directory:
 docker-compose up
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
 
 ```shell
 mvn spring-boot:run


### PR DESCRIPTION
`mvn exec:exec` will also work, but our docs and readmes refer to the `spring-boot:run` and that's part of the spring boot plugin.