### PR TITLE
fix: fix uberjar - use spring-boot-starter-parent

### DIFF
--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
   <version>${version}</version>
@@ -66,9 +71,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -2,6 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
+
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
   <version>${version}</version>
@@ -106,9 +113,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   val JUnitInterfaceVersion = "0.11"
   val JUnitJupiterVersion = "5.7.1"
   val SpringFrameworkVersion = "6.0.4"
-  val SpringBootVersion = "3.0.2"
+  val SpringBootVersion = "3.0.4"
 
   val CommonsIoVersion = "2.11.0"
   val MunitVersion = "0.7.29"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,6 +29,7 @@ object Dependencies {
   val JUnitInterfaceVersion = "0.11"
   val JUnitJupiterVersion = "5.7.1"
   val SpringFrameworkVersion = "6.0.4"
+  // make sure to sync spring-boot-starter-parent version in samples and archetype to this version
   val SpringBootVersion = "3.0.4"
 
   val CommonsIoVersion = "2.11.0"

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-customer-registry</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-customer-registry-views</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-doc-snippets</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-eventsourced-counter</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>customer</groupId>
   <artifactId>java-spring-eventsourced-customer-registry-subscriber</artifactId>
@@ -70,9 +76,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-eventsourced-customer-registry</artifactId>
@@ -67,9 +73,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-eventsourced-shopping-cart</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-fibonacci-action</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-reliable-timers</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>shopping.cart</groupId>
   <artifactId>java-spring-shopping-cart-quickstart</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-transfer-workflow</artifactId>
@@ -67,9 +73,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-valueentity-counter</artifactId>
@@ -70,9 +76,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-valueentity-customer-registry</artifactId>
@@ -66,9 +72,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>java-spring-valueentity-shoppingcart</artifactId>
@@ -70,9 +76,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent> 
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
 
   <groupId>com.example</groupId>
   <artifactId>spring-view-store</artifactId>
@@ -67,9 +73,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>


### PR DESCRIPTION
This fix the uberjar layout. Alan hit that bug today and reported to me during a call.

It turns out that since we moved to the spring-boot-starter, the application won't start correctly when run directly from the java command, eg: `java -jar ...`. Which is how the docker image will bootstrap the application. 

The best solution I found is to rely on `spring-boot-starter-parent`. This dependency includes a few configurations to the build. Also, a shading config that builds a uberjar in the way the `starter` expects it to be.
