### PR TITLE
fix: junit5 dependency

### DIFF
--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -290,13 +290,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -359,13 +359,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -293,13 +293,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -293,13 +293,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -291,13 +291,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -291,7 +291,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -297,13 +297,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -294,13 +294,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -291,13 +291,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -293,13 +293,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -291,13 +291,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -291,13 +291,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -294,13 +294,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -296,13 +296,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -291,13 +291,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -296,13 +296,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -294,13 +294,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The spring-boot parent brings in another version of junit5 and the mixing versions is causing 

```java
java.lang.NoClassDefFoundError: org/junit/jupiter/api/io/CleanupMode
        at org.junit.jupiter.engine.JupiterTestEngine.discover(JupiterTestEngine.java:66)
        at org.junit.platform.launcher.core.DefaultLauncher.discoverEngineRoot(DefaultLauncher.java:168)
        at org.junit.platform.launcher.core.DefaultLauncher.discoverRoot(DefaultLauncher.java:155)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: java.lang.ClassNotFoundException: org.junit.jupiter.api.io.CleanupMode
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java
```

Instead, we can just rely on the bom provided by spring-boot-parent