### PR TITLE
chore: use version as release name

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 # Config for https://github.com/release-drafter/release-drafter
-name-template: 'Kalix Java and Scala SDKs $NEXT_PATCH_VERSION'
+name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: 'Java SDK'


### PR DESCRIPTION
Same change as in JS SDK https://github.com/lightbend/kalix-javascript-sdk/pull/472

I think it's more useful to show the latest version right on the main page (same we have for akka).

<img width="430" alt="Screenshot 2023-03-23 at 10 38 22" src="https://user-images.githubusercontent.com/1105359/227180671-cf85257b-12c8-4e9a-adf9-9823628fb061.png">

VS 

<img width="418" alt="Screenshot 2023-03-23 at 10 50 00" src="https://user-images.githubusercontent.com/1105359/227180883-4e0d501e-3050-4b60-94eb-dbe8bb426e02.png">
