### PR TITLE
feat!: default to FQCN when typename is not present

### DIFF
--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -40,7 +40,7 @@ include::example$java-spring-eventsourced-shopping-cart/src/main/java/com/exampl
 <1> The 3 types of event all derive from the same type `ShoppingCartEvent`.
 <2> Includes the logical type name using `@TypeName` annotation.
 
-IMPORTANT: The use of logical names for subtypes is essential for maintainability purposes. Since that information is persisted, failing to do so might lead to the use of a FQCN preventing the application from correctly deserialize the events in case of a package change.
+IMPORTANT: The use of logical names for subtypes is essential for maintainability purposes. Since that information is persisted, failing to do so might lead to the use of a FQCN preventing the application from correctly deserialize the events in case of a package change. Our recommendation is to use logical names (i.e. `@TypeName`) that are unique per Kalix service.
 
 include::partial$entity-keys.adoc[]
 

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/JsonMessageCodec.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/JsonMessageCodec.scala
@@ -18,13 +18,15 @@ package kalix.javasdk.impl
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
-
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => JavaPbAny }
 import kalix.javasdk.JsonSupport
 import kalix.javasdk.annotations.TypeName
+import org.slf4j.LoggerFactory
 
 private[kalix] class JsonMessageCodec extends MessageCodec {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   private val cache: ConcurrentMap[Class[_], String] = new ConcurrentHashMap()
   private[kalix] val reversedCache: ConcurrentMap[String, Class[_]] = new ConcurrentHashMap()
@@ -56,7 +58,7 @@ private[kalix] class JsonMessageCodec extends MessageCodec {
   private[kalix] def lookupTypeHint(clz: Class[_]): String = {
     val typeName = Option(clz.getAnnotation(classOf[TypeName]))
       .collect { case ann if ann.value().trim.nonEmpty => ann.value() }
-      .getOrElse(clz.getSimpleName) //TODO getName to minimize collision chance, is it backward compatible
+      .getOrElse(clz.getName)
     cache.computeIfAbsent(clz, _ => typeName)
     //TODO verify if this could be replaced by sth smarter/safer
     reversedCache.compute(

--- a/sdk/java-sdk-spring/src/main/scala/kalix/spring/impl/KalixSpringApplication.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/spring/impl/KalixSpringApplication.scala
@@ -248,7 +248,6 @@ case class KalixSpringApplication(applicationContext: ApplicationContext, config
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
   private val messageCodec = new JsonMessageCodec
-
   private val kalixClient = new RestKalixClientImpl(messageCodec)
 
   private val kalixBeanFactory = new DefaultListableBeanFactory(applicationContext)
@@ -416,7 +415,7 @@ case class KalixSpringApplication(applicationContext: ApplicationContext, config
         kalixBeanFactory.getBean(clz)
       })
 
-  private def workflowProvider[S, E <: WorkflowEntity[S]](clz: Class[E]): WorkflowEntityProvider[S, E] =
+  private def workflowProvider[S, E <: WorkflowEntity[S]](clz: Class[E]): WorkflowEntityProvider[S, E] = {
     ReflectiveWorkflowEntityProvider.of(
       clz,
       messageCodec,
@@ -453,6 +452,7 @@ case class KalixSpringApplication(applicationContext: ApplicationContext, config
 
         workflowEntity
       })
+  }
 
   private def valueEntityProvider[S, E <: ValueEntity[S]](clz: Class[E]): ValueEntityProvider[S, E] =
     ReflectiveValueEntityProvider.of(

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/JsonMessageCodecSpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/JsonMessageCodecSpec.scala
@@ -73,7 +73,7 @@ class JsonMessageCodecSpec extends AnyWordSpec with Matchers {
 
     "default to FQCN for typeUrl (java)" in {
       val encoded = messageCodec.encodeJava(SimpleClass("abc", 10))
-      encoded.getTypeUrl shouldBe jsonTypeUrlWith("SimpleClass")
+      encoded.getTypeUrl shouldBe jsonTypeUrlWith("kalix.javasdk.impl.JsonMessageCodecSpec$SimpleClass")
     }
 
     "not re-encode (wrap) to JavaPbAny" in {
@@ -92,7 +92,7 @@ class JsonMessageCodecSpec extends AnyWordSpec with Matchers {
 
     "default to FQCN for typeUrl (scala)" in {
       val encoded = messageCodec.encodeScala(SimpleClass("abc", 10))
-      encoded.typeUrl shouldBe jsonTypeUrlWith("SimpleClass")
+      encoded.typeUrl shouldBe jsonTypeUrlWith("kalix.javasdk.impl.JsonMessageCodecSpec$SimpleClass")
     }
 
     "not re-encode (wrap) to ScalaPbAny" in {
@@ -153,22 +153,26 @@ class JsonMessageCodecSpec extends AnyWordSpec with Matchers {
       import JsonMessageCodecSpec.AnnotatedWithEmptyTypeName.Elephant
       import JsonMessageCodecSpec.AnnotatedWithEmptyTypeName.Lion
 
-      "default to FQCN  if TypeName is has empty string (java)" in {
+      "default to FQCN  if TypeName has empty string (java)" in {
 
         val encodedLion = messageCodec.encodeJava(Lion("Simba"))
-        encodedLion.getTypeUrl shouldBe jsonTypeUrlWith("Lion")
+        encodedLion.getTypeUrl shouldBe jsonTypeUrlWith(
+          "kalix.javasdk.impl.JsonMessageCodecSpec$AnnotatedWithEmptyTypeName$Lion")
 
         val encodedElephant = messageCodec.encodeJava(Elephant("Dumbo", 1))
-        encodedElephant.getTypeUrl shouldBe jsonTypeUrlWith("Elephant")
+        encodedElephant.getTypeUrl shouldBe jsonTypeUrlWith(
+          "kalix.javasdk.impl.JsonMessageCodecSpec$AnnotatedWithEmptyTypeName$Elephant")
       }
 
-      "default to FQCN  if TypeName is has empty string" in {
+      "default to FQCN  if TypeName has empty string" in {
 
         val encodedLion = messageCodec.encodeScala(Lion("Simba"))
-        encodedLion.typeUrl shouldBe jsonTypeUrlWith("Lion")
+        encodedLion.typeUrl shouldBe jsonTypeUrlWith(
+          "kalix.javasdk.impl.JsonMessageCodecSpec$AnnotatedWithEmptyTypeName$Lion")
 
         val encodedElephant = messageCodec.encodeScala(Elephant("Dumbo", 1))
-        encodedElephant.typeUrl shouldBe jsonTypeUrlWith("Elephant")
+        encodedElephant.typeUrl shouldBe jsonTypeUrlWith(
+          "kalix.javasdk.impl.JsonMessageCodecSpec$AnnotatedWithEmptyTypeName$Elephant")
       }
     }
 


### PR DESCRIPTION
References https://github.com/lightbend/kalix-jvm-sdk/issues/1556

This MR:
- changes the default back to FQCN when no TypeName is provided (which also decreases chances of collision within the same service)
  - this is a breaking change for Java SDK (code-first)
- update docs to advise that TypeName should ideally be unique.