### PR TITLE
docs(sample): add integration test example for s2s eventing

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -131,7 +131,7 @@ jobs:
           - { sample: java-protobuf-eventsourced-shopping-cart, it: true }
 
           - { sample: java-spring-eventsourced-customer-registry, it: true }
-          - { sample: java-spring-eventsourced-customer-registry-subscriber, it: false }
+          - { sample: java-spring-eventsourced-customer-registry-subscriber, pre_cmd: 'docker-compose -f ../java-spring-eventsourced-customer-registry/docker-compose.yml up -d; (cd ../java-spring-eventsourced-customer-registry/; mvn spring-boot:run &);sleep 10;', it: true }
           - { sample: java-spring-eventsourced-shopping-cart, it: true }
 
           - { sample: java-protobuf-valueentity-counter, it: true }

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -131,7 +131,9 @@ jobs:
           - { sample: java-protobuf-eventsourced-shopping-cart, it: true }
 
           - { sample: java-spring-eventsourced-customer-registry, it: true }
-          - { sample: java-spring-eventsourced-customer-registry-subscriber, pre_cmd: 'docker-compose -f ../java-spring-eventsourced-customer-registry/docker-compose.yml up -d; (cd ../java-spring-eventsourced-customer-registry/; mvn spring-boot:run &);sleep 10;', it: true }
+          # FIXME would be good to enable integration tests but currently failing to resolve host.docker.internal
+          # pre_cmd: 'docker-compose -f ../java-spring-eventsourced-customer-registry/docker-compose.yml up -d; (cd ../java-spring-eventsourced-customer-registry/; mvn spring-boot:run &);sleep 10;'
+          - { sample: java-spring-eventsourced-customer-registry-subscriber, it: false }
           - { sample: java-spring-eventsourced-shopping-cart, it: true }
 
           - { sample: java-protobuf-valueentity-counter, it: true }

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -305,6 +305,11 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-    
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -1,0 +1,95 @@
+package customer.api;
+
+
+import customer.Main;
+import customer.views.Customer;
+import kalix.spring.testkit.KalixIntegrationTestKitSupport;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.*;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Main.class)
+@Import(TestkitConfig.class)
+public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
+
+
+
+  @Autowired
+  private WebClient webClient;
+
+  private Duration timeout = Duration.of(5, SECONDS);
+
+  private void assertSourceServiceIsUp(WebClient sourceServiceWebClient) {
+    try {
+      var code =
+          sourceServiceWebClient.get()
+              .retrieve()
+              .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                  Mono.empty()
+              )
+              .toBodilessEntity()
+              .block(timeout);;
+      Assertions.assertEquals(HttpStatus.NOT_FOUND, code.getStatusCode()); // NOT_FOUND is a sign that the source service is there
+    } catch (WebClientRequestException ex) {
+      Assertions.fail("This test requires an external kalix service to be running on localhost:9000 but was not able to reach it.");
+    }
+  }
+
+  /**
+   * This test relies on a source Kalix service to which it subscribes. Such service should be running on :9000
+   */
+  @Test
+  public void create() {
+    WebClient sourceServiceWebClient = WebClient.builder().baseUrl("http://localhost:9000")
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build();
+
+    assertSourceServiceIsUp(sourceServiceWebClient);
+
+    String id = UUID.randomUUID().toString();
+    Customer customer = new Customer("Johanna", "foo@example.com", "Johanna");
+
+    ResponseEntity<String> response =
+        sourceServiceWebClient.post()
+            .uri("/customer/" + id + "/create")
+            .bodyValue(customer)
+            .retrieve()
+            .toEntity(String.class)
+            .block(timeout);
+
+    Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    // the view is eventually updated
+    await()
+        .ignoreExceptions()
+        .atMost(20, TimeUnit.SECONDS)
+        .until(() ->
+                webClient.get()
+                    .uri("/customers/by_name/Johanna")
+                    .retrieve()
+                    .bodyToFlux(Customer.class)
+                    .blockFirst()
+                    .name(),
+            new IsEqual("Johanna")
+        );
+  }
+
+}

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/TestkitConfig.java
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/TestkitConfig.java
@@ -1,0 +1,13 @@
+package customer.api;
+
+import kalix.javasdk.testkit.KalixTestKit;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestkitConfig {
+  @Bean
+  public KalixTestKit.Settings settings() {
+    return KalixTestKit.Settings.DEFAULT.withAclEnabled();
+  }
+}

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/resources/logback-test.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="INFO"/>
+    <logger name="akka.http" level="INFO"/>
+    <logger name="kalix" level="INFO"/>
+    <logger name="com.github.dockerjava" level="INFO"/>
+    <logger name="io.grpc.netty" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/src/main/java/customer/views/CustomersByNameView.java
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/src/main/java/customer/views/CustomersByNameView.java
@@ -5,6 +5,8 @@ import kalix.javasdk.annotations.Acl;
 import kalix.javasdk.annotations.Query;
 import kalix.javasdk.annotations.Subscribe;
 import kalix.javasdk.annotations.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import reactor.core.publisher.Flux;
@@ -25,9 +27,11 @@ import reactor.core.publisher.Flux;
     id = "customer_events" // <3>
 )
 public class CustomersByNameView extends View<Customer> {
+  private static final Logger logger = LoggerFactory.getLogger(CustomersByNameView.class);
 
   public UpdateEffect<Customer> onEvent( // <4>
       CustomerPublicEvent.Created created) {
+    logger.info("Received: {}", created);
     var id = updateContext().eventSubject().get();
     return effects().updateState(
         new Customer(id, created.email(), created.name()));
@@ -35,6 +39,7 @@ public class CustomersByNameView extends View<Customer> {
 
   public UpdateEffect<Customer> onEvent(
       CustomerPublicEvent.NameChanged nameChanged) {
+    logger.info("Received: {}", nameChanged);
     var updated = viewState().withName(nameChanged.newName());
     return effects().updateState(updated);
   }

--- a/samples/java-spring-eventsourced-customer-registry/src/main/java/customer/api/CustomerEntity.java
+++ b/samples/java-spring-eventsourced-customer-registry/src/main/java/customer/api/CustomerEntity.java
@@ -4,10 +4,11 @@ import customer.domain.Address;
 import customer.domain.Customer;
 import customer.domain.CustomerEvent;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
-import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import kalix.javasdk.annotations.EntityKey;
 import kalix.javasdk.annotations.EntityType;
 import kalix.javasdk.annotations.EventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
 import static customer.domain.CustomerEvent.*;
@@ -16,6 +17,7 @@ import static customer.domain.CustomerEvent.*;
 @EntityType("customer")
 @RequestMapping("/customer/{id}")
 public class CustomerEntity extends EventSourcedEntity<Customer, CustomerEvent> {
+  private static final Logger logger = LoggerFactory.getLogger(CustomerEntity.class);
 
   @GetMapping
   public Effect<Customer> getCustomer() {
@@ -24,6 +26,7 @@ public class CustomerEntity extends EventSourcedEntity<Customer, CustomerEvent> 
 
   @PostMapping("/create")
   public Effect<String> create(@RequestBody Customer customer) {
+    logger.info("Creating {}", customer);
     return effects()
         .emitEvent(new CustomerCreated(customer.email(), customer.name(), customer.address()))
         .thenReply(__ -> "OK");

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -250,7 +250,9 @@ public class KalixTestKit {
       proxyContainer.addEnv("SERVICE_NAME", settings.serviceName);
       proxyContainer.addEnv("ACL_ENABLED", Boolean.toString(settings.aclEnabled));
       proxyContainer.addEnv("VIEW_FEATURES_ALL", Boolean.toString(settings.advancedViews));
+      proxyContainer.addEnv("JAVA_TOOL_OPTIONS", "-Dlogback.configurationFile=logback-dev-mode.xml");
       settings.workflowTickInterval.ifPresent(tickInterval -> proxyContainer.addEnv("WORKFLOW_TICK_INTERVAL", tickInterval.toMillis() + ".millis"));
+
       proxyContainer.start();
 
       proxyPort = proxyContainer.getProxyPort();


### PR DESCRIPTION
This PR:
- adds an example for an integration test with s2s eventing for future reference
- this was mainly an exercise for me to understand what was possible at the moment and how
- Logs from the testcontainer proxy will now come formatted in plain text and not JSON

~I think it's useful to run in CI anyway because it also validates the s2s logic.~ Commented out this part because I don't want to spend much more time on this and it needs more work. Might revisit later.