### PR TITLE
fix: retry container port until is available

### DIFF
--- a/devtools/src/main/scala/kalix/devtools/impl/KalixProxyContainer.scala
+++ b/devtools/src/main/scala/kalix/devtools/impl/KalixProxyContainer.scala
@@ -74,7 +74,6 @@ class KalixProxyContainer private (image: DockerImageName, config: KalixProxyCon
   // FIXME: users must also indicate a folder to mount as volume
   if (config.brokerConfigFile.nonEmpty)
     withEnv("BROKER_CONFIG_FILE", config.brokerConfigFile)
-
   // JVM are that should be passed to the proxy container on start-up
   val containerArgs =
     Seq("-Dconfig.resource=dev-mode.conf", "-Dlogback.configurationFile=logback-dev-mode.xml")

--- a/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
+++ b/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
@@ -165,7 +165,7 @@ class RunMojo extends AbstractMojo {
 
       // shutdown hook to stop the container as soon as possible
       // Note: this is not guaranteed to be called, but it's better than nothing
-      // also, the main reason it's wrapped in a Future is ensure that it runs
+      // also, the main reason it's wrapped in a Future is to ensure that it runs
       // on a thread that shares the same classloader
       sys.addShutdownHook(Future(container.stop()))
 

--- a/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
+++ b/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
@@ -1,5 +1,6 @@
 package kalix
 
+import java.net.BindException
 import java.net.ServerSocket
 
 import scala.annotation.tailrec
@@ -109,7 +110,7 @@ class RunMojo extends AbstractMojo {
       try {
         new ServerSocket(proxyPort).close()
         false
-      } catch { case _: Throwable => true }
+      } catch { case _: BindException => true }
 
     if (isInUse) {
       if (count == 20)

--- a/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
+++ b/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
@@ -1,6 +1,10 @@
 package kalix
 
+import java.net.ServerSocket
+
+import scala.annotation.tailrec
 import scala.concurrent.Future
+import scala.concurrent.blocking
 
 import kalix.devtools.BuildInfo
 import kalix.devtools.impl.KalixProxyContainer
@@ -100,11 +104,32 @@ class RunMojo extends AbstractMojo {
     startUserFunction()
   }
 
+  @tailrec
+  private def checkPortAvailability(proxyPort: Int, count: Int = 0): Unit = {
+    def isInUse =
+      try {
+        new ServerSocket(proxyPort).close()
+        false
+      } catch { case _: Throwable => true }
+
+    if (isInUse) {
+      if (count == 20)
+        throw new RuntimeException(
+          s"Port '$proxyPort' is still in use after 20 seconds. Please make sure that no other service is running on port '$proxyPort'.")
+
+      if (count == 0 || count % 5 == 0)
+        log.info(s"Port '$proxyPort' is in use. Waiting for port to become available.")
+
+      Thread.sleep(1000)
+      checkPortAvailability(proxyPort, count + 1)
+    }
+  }
+
   private def startKalixProxy(): Unit = {
-    // TODO: when restarting, it's possible that testcontainers haven't yet freed the port from previous run
-    // therefore we need to check if the port is free and it not, add some artificial delay. And we should keep trying
-    // and notifying the user that we are waiting for the port.
+
     if (runProxy) {
+
+      checkPortAvailability(proxyPort)
 
       def renderString(value: String) = if (value.trim.isEmpty) "<not defined>" else value
 
@@ -137,6 +162,12 @@ class RunMojo extends AbstractMojo {
       val container = KalixProxyContainer(config)
       import scala.concurrent.ExecutionContext.Implicits.global
       Future(container.start())
+
+      // shutdown hook to stop the container as soon as possible
+      // Note: this is not guaranteed to be called, but it's better than nothing
+      // also, the main reason it's wrapped in a Future is ensure that it runs
+      // on a thread that shares the same classloader
+      sys.addShutdownHook(Future(container.stop()))
 
     } else {
       log.info("Kalix Proxy won't start (ie: runProxy = false).")

--- a/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
+++ b/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
@@ -4,7 +4,6 @@ import java.net.ServerSocket
 
 import scala.annotation.tailrec
 import scala.concurrent.Future
-import scala.concurrent.blocking
 
 import kalix.devtools.BuildInfo
 import kalix.devtools.impl.KalixProxyContainer


### PR DESCRIPTION
This is still not perfect, but good enough for now.

Removal of container takes too long. I think we should look for a better solution. Like tiny http proxy running on port 9000 and forwarding traffic to kalix-proxy running on random port. Then when restarting, the proxy running on 9000 will free the port immediately while testcontainers would start a new kalix-proxy on another port. 