### PR TITLE
chore: replacing junit 4 @RunWith annotation with junit 5 @ExtendWith

### DIFF
--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/it/java/__packageInPathFormat__/IntegrationTest.java
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/it/java/__packageInPathFormat__/IntegrationTest.java
@@ -5,10 +5,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 
@@ -21,7 +21,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/it/java/__packageInPathFormat__/IntegrationTest.java
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/src/it/java/__packageInPathFormat__/IntegrationTest.java
@@ -5,10 +5,8 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 
@@ -21,7 +19,6 @@ import org.springframework.web.reactive.function.client.WebClient;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-protobuf-valueentity-counter-spring-client/src/test/java/com/example/client/spring/rest/CounterControllerTest.java
+++ b/samples/java-protobuf-valueentity-counter-spring-client/src/test/java/com/example/client/spring/rest/CounterControllerTest.java
@@ -5,18 +5,15 @@ import com.example.client.spring.rest.model.ValueRequest;
 import com.example.client.spring.rest.service.CounterService;
 import com.example.client.spring.rest.service.GrpcClientService;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(SpringExtension.class)
 @WebFluxTest(CounterController.class)
 public class CounterControllerTest {
 

--- a/samples/java-spring-customer-registry-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-customer-registry-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -8,12 +8,12 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-customer-registry-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-customer-registry-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -8,12 +8,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -24,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-customer-registry-views-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-customer-registry-views-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -9,12 +9,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -25,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-customer-registry-views-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-customer-registry-views-quickstart/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -9,12 +9,12 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -4,10 +4,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -15,7 +15,7 @@ import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 // tag::class[]
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import(TestkitConfig.class)  // <1>
 public class CounterIntegrationTest extends KalixIntegrationTestKitSupport {

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -4,18 +4,15 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 // tag::class[]
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import(TestkitConfig.class)  // <1>
 public class CounterIntegrationTest extends KalixIntegrationTestKitSupport {

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -7,12 +7,12 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.*;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
@@ -25,7 +25,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import(TestkitConfig.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -7,12 +7,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.*;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
@@ -25,7 +23,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import(TestkitConfig.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {

--- a/samples/java-spring-eventsourced-customer-registry/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-eventsourced-customer-registry/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -9,12 +9,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -26,7 +24,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-eventsourced-customer-registry/src/it/java/customer/api/CustomerIntegrationTest.java
+++ b/samples/java-spring-eventsourced-customer-registry/src/it/java/customer/api/CustomerIntegrationTest.java
@@ -9,12 +9,12 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -25,7 +25,8 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
-@RunWith(SpringRunner.class)
+
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
+++ b/samples/java-spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
@@ -7,12 +7,12 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -29,7 +29,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
+++ b/samples/java-spring-eventsourced-shopping-cart/src/it/java/com/example/IntegrationTest.java
@@ -7,12 +7,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -29,7 +27,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-fibonacci-action/src/it/java/com/example/fibonacci/FibonacciActionIntegrationTest.java
+++ b/samples/java-spring-fibonacci-action/src/it/java/com/example/fibonacci/FibonacciActionIntegrationTest.java
@@ -5,12 +5,12 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -20,7 +20,7 @@ import java.time.temporal.ChronoUnit;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class FibonacciActionIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-fibonacci-action/src/it/java/com/example/fibonacci/FibonacciActionIntegrationTest.java
+++ b/samples/java-spring-fibonacci-action/src/it/java/com/example/fibonacci/FibonacciActionIntegrationTest.java
@@ -5,12 +5,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -20,7 +18,6 @@ import java.time.temporal.ChronoUnit;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class FibonacciActionIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-reliable-timers/src/it/java/com/example/OrderActionIntegrationTest.java
+++ b/samples/java-spring-reliable-timers/src/it/java/com/example/OrderActionIntegrationTest.java
@@ -7,10 +7,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class OrderActionIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-reliable-timers/src/it/java/com/example/OrderActionIntegrationTest.java
+++ b/samples/java-spring-reliable-timers/src/it/java/com/example/OrderActionIntegrationTest.java
@@ -7,10 +7,8 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -20,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class OrderActionIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-shopping-cart-quickstart/src/it/java/shoppingcart/cart/IntegrationTest.java
+++ b/samples/java-spring-shopping-cart-quickstart/src/it/java/shoppingcart/cart/IntegrationTest.java
@@ -3,12 +3,12 @@ package shoppingcart.cart;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import shoppingcart.Main;
 import shoppingcart.domain.ShoppingCart;
@@ -28,7 +28,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-shopping-cart-quickstart/src/it/java/shoppingcart/cart/IntegrationTest.java
+++ b/samples/java-spring-shopping-cart-quickstart/src/it/java/shoppingcart/cart/IntegrationTest.java
@@ -3,12 +3,10 @@ package shoppingcart.cart;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import shoppingcart.Main;
 import shoppingcart.domain.ShoppingCart;
@@ -28,7 +26,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-transfer-workflow-compensation/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
+++ b/samples/java-spring-transfer-workflow-compensation/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
@@ -5,12 +5,10 @@ import com.example.transfer.TransferState.Transfer;
 import com.example.wallet.WalletEntity.Balance;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -24,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class TransferWorkflowIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-transfer-workflow-compensation/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
+++ b/samples/java-spring-transfer-workflow-compensation/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
@@ -5,12 +5,12 @@ import com.example.transfer.TransferState.Transfer;
 import com.example.wallet.WalletEntity.Balance;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class TransferWorkflowIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-transfer-workflow/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
+++ b/samples/java-spring-transfer-workflow/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
@@ -5,12 +5,10 @@ import com.example.transfer.TransferState.Transfer;
 import com.example.wallet.WalletEntity.Balance;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -22,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class TransferWorkflowIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-transfer-workflow/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
+++ b/samples/java-spring-transfer-workflow/src/it/java/com/example/transfer/TransferWorkflowIntegrationTest.java
@@ -5,12 +5,12 @@ import com.example.transfer.TransferState.Transfer;
 import com.example.wallet.WalletEntity.Balance;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class TransferWorkflowIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-valueentity-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-valueentity-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -4,10 +4,10 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -26,7 +26,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  */
 
 // tag::sample-it[]
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CounterIntegrationTest extends KalixIntegrationTestKitSupport { // <1>
 

--- a/samples/java-spring-valueentity-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-valueentity-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -4,10 +4,8 @@ import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -26,7 +24,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  */
 
 // tag::sample-it[]
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CounterIntegrationTest extends KalixIntegrationTestKitSupport { // <1>
 

--- a/samples/java-spring-valueentity-customer-registry/src/it/java/customer/CustomerIntegrationTest.java
+++ b/samples/java-spring-valueentity-customer-registry/src/it/java/customer/CustomerIntegrationTest.java
@@ -6,12 +6,10 @@ import customer.domain.Customer;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -24,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-valueentity-customer-registry/src/it/java/customer/CustomerIntegrationTest.java
+++ b/samples/java-spring-valueentity-customer-registry/src/it/java/customer/CustomerIntegrationTest.java
@@ -6,12 +6,12 @@ import customer.domain.Customer;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class CustomerIntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-valueentity-shopping-cart/src/it/java/com/example/IntegrationTest.java
+++ b/samples/java-spring-valueentity-shopping-cart/src/it/java/com/example/IntegrationTest.java
@@ -6,10 +6,8 @@ import com.example.domain.ShoppingCart;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -29,7 +27,6 @@ import static org.junit.Assert.assertEquals;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-valueentity-shopping-cart/src/it/java/com/example/IntegrationTest.java
+++ b/samples/java-spring-valueentity-shopping-cart/src/it/java/com/example/IntegrationTest.java
@@ -6,10 +6,10 @@ import com.example.domain.ShoppingCart;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
  * Since this is an integration tests, it interacts with the application using a WebClient
  * (already configured and provided automatically through injection).
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 public class IntegrationTest extends KalixIntegrationTestKitSupport {
 

--- a/samples/java-spring-view-store/src/it/java/store/view/StoreViewIntegrationTest.java
+++ b/samples/java-spring-view-store/src/it/java/store/view/StoreViewIntegrationTest.java
@@ -1,14 +1,14 @@
 package store.view;
 
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import store.Main;
 import store.customer.domain.Address;
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Import(TestKitConfig.class)
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @DirtiesContext // fresh testkit and proxy for each integration test
 public abstract class StoreViewIntegrationTest extends KalixIntegrationTestKitSupport {

--- a/samples/java-spring-view-store/src/it/java/store/view/StoreViewIntegrationTest.java
+++ b/samples/java-spring-view-store/src/it/java/store/view/StoreViewIntegrationTest.java
@@ -1,14 +1,12 @@
 package store.view;
 
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import store.Main;
 import store.customer.domain.Address;
@@ -24,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Import(TestKitConfig.class)
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @DirtiesContext // fresh testkit and proxy for each integration test
 public abstract class StoreViewIntegrationTest extends KalixIntegrationTestKitSupport {

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/EventSourcedEntityIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/EventSourcedEntityIntegrationTest.java
@@ -21,12 +21,10 @@ import kalix.spring.KalixConfigurationTest;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -36,7 +34,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import(KalixConfigurationTest.class)
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
@@ -33,14 +33,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -53,7 +51,6 @@ import java.util.stream.Collectors;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import({KalixConfigurationTest.class, TestkitConfig.class})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/ValueEntityIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/ValueEntityIntegrationTest.java
@@ -21,12 +21,10 @@ import com.example.wiring.valueentities.user.User;
 import kalix.spring.KalixConfigurationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
@@ -34,7 +32,6 @@ import java.time.Duration;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import(KalixConfigurationTest.class)
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/XComponentCallsIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/XComponentCallsIntegrationTest.java
@@ -22,12 +22,10 @@ import com.example.wiring.valueentities.user.User;
 import kalix.spring.KalixConfigurationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -35,7 +33,6 @@ import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import(KalixConfigurationTest.class)
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/workflowentities/SpringWorkflowIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/workflowentities/SpringWorkflowIntegrationTest.java
@@ -20,7 +20,6 @@ import com.example.wiring.TestkitConfig;
 import com.example.wiring.actions.echo.Message;
 import kalix.spring.KalixConfigurationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -28,7 +27,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -40,7 +38,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Main.class)
 @Import({KalixConfigurationTest.class, TestkitConfig.class})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")


### PR DESCRIPTION
from spring docs:
```
If you are using JUnit 4, do not forget to also add @RunWith(SpringRunner.class) to your test, otherwise the annotations will be ignored. If you are using JUnit 5, there is no need to add the equivalent @ExtendWith(SpringExtension.class) as @SpringBootTest and the other @…​Test annotations are already annotated with it.
```