### PR TITLE
fix(testkit): remove modification of proxy name

### DIFF
--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixProxyContainer.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixProxyContainer.java
@@ -41,7 +41,7 @@ public class KalixProxyContainer extends GenericContainer<KalixProxyContainer> {
   static {
     String customImage = System.getenv("KALIX_TESTKIT_PROXY_IMAGE");
     if (customImage == null) {
-      DEFAULT_PROXY_IMAGE_NAME = DockerImageName.parse(BuildInfo.proxyImage()).withTag(BuildInfo.proxyVersion().replace("-SNAPSHOT", ""));
+      DEFAULT_PROXY_IMAGE_NAME = DockerImageName.parse(BuildInfo.proxyImage()).withTag(BuildInfo.proxyVersion());
     } else {
       Logger logger = LoggerFactory.getLogger(KalixProxyContainer.class);
       DEFAULT_PROXY_IMAGE_NAME = DockerImageName.parse(customImage);

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/workflowentities/SpringWorkflowIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/workflowentities/SpringWorkflowIntegrationTest.java
@@ -301,8 +301,12 @@ public class SpringWorkflowIntegrationTest {
           assertThat(counterValue).isEqualTo(3);
         });
 
-    var state = getWorkflowState(path);
-    assertThat(state.finished()).isTrue();
+    await()
+        .atMost(10, TimeUnit.of(SECONDS))
+        .untilAsserted(() -> {
+          var state = getWorkflowState(path);
+          assertThat(state.finished()).isTrue();
+        });
   }
 
   @Test
@@ -329,8 +333,12 @@ public class SpringWorkflowIntegrationTest {
           assertThat(counterValue).isEqualTo(3);
         });
 
-    var state = getWorkflowState(path);
-    assertThat(state.finished()).isTrue();
+    await()
+        .atMost(10, TimeUnit.of(SECONDS))
+        .untilAsserted(() -> {
+          var state = getWorkflowState(path);
+          assertThat(state.finished()).isTrue();
+        });
   }
 
   @Test
@@ -357,8 +365,12 @@ public class SpringWorkflowIntegrationTest {
           assertThat(counterValue).isEqualTo(3);
         });
 
-    var state = getWorkflowState(path);
-    assertThat(state.finished()).isTrue();
+    await()
+        .atMost(10, TimeUnit.of(SECONDS))
+        .untilAsserted(() -> {
+          var state = getWorkflowState(path);
+          assertThat(state.finished()).isTrue();
+        });
   }
 
   @Test


### PR DESCRIPTION
This change was introduced in https://github.com/lightbend/kalix-jvm-sdk/pull/1516/files#diff-1cb4454ce26068222dcb8b5e3041baf55d5b3e4c9c68349c953dd4268e464922R44

But I'm not sure what it's meant to do, feels weird. Also, it's breaking ubi tests in proxy.

We could work around it if there's a good reason for it to stay though.