### PR TITLE
fix: check if file exists before using it

### DIFF
--- a/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
+++ b/maven-java/kalix-maven-plugin/src/main/scala/kalix/RunMojo.scala
@@ -189,13 +189,18 @@ class RunMojo extends AbstractMojo {
         element(name("classpath")),
         element(name("argument"), "-Dkalix.user-function-port=" + userFunctionPort))
 
-    val loggingArgs: Seq[Element] =
-      if (logConfig.trim.nonEmpty) {
-        log.info("Using logging configuration: " + logConfig)
+    val loggingArgs: Seq[Element] = {
+      val logConfigFile = new File(logConfig.trim)
+      if (logConfigFile.exists) {
+        log.info(s"Using logging configuration file: '$logConfigFile' ")
         // when using SpringBoot, logback config is passed using logging.config
         element(name("argument"), "-Dlogging.config=" + logConfig) ::
         element(name("argument"), "-Dlogback.configurationFile=" + logConfig) :: Nil
-      } else List.empty
+      } else {
+        log.warn(s"Dev mode logging configuration file '$logConfig' not found")
+        List.empty
+      }
+    }
 
     val allArgs =
       mainArgs ++ loggingArgs :+


### PR DESCRIPTION
By default we will pass `src/main/resources/logback-dev-mode.xml` to the application, but we need to check if the file really exists. 

Old projects won't have `logback-dev-mode.xml` file and will get an error message from logback. 