### PR TITLE
docs: documentent how to use kalix:run

### DIFF
--- a/docs/src/modules/java-protobuf/pages/quickstart-template.adoc
+++ b/docs/src/modules/java-protobuf/pages/quickstart-template.adoc
@@ -262,14 +262,7 @@ TIP: For more details see xref:developing:development-process-proto.adoc#_packag
 
 == Run locally
 
-You can run your service locally for manual testing via HTTP or gRPC requests. To run your application locally, you need to initiate the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-
-To start the proxy, run the following command from the project directory:
-
-[source,bash]
-----
-docker compose up
-----
+You can run your service locally for manual testing via HTTP or gRPC requests. 
 
 Start the application locally with the following command:
 
@@ -278,7 +271,27 @@ Java::
 +
 [source,bash]
 ----
-mvn compile exec:exec
+mvn kalix:runAll
+----
+
+Scala::
++
+[source,bash]
+----
+sbt runAll
+----
+
+This command will start your Kalix application and a Kalix Proxy using the included `docker-compose.yml` file.
+
+If you prefer, you can also start docker-compose directly by running `docker-compose up` in one terminal and in another terminal start your Kalix Application with:
+
+
+[.tabset]
+Java::
++
+[source,bash]
+----
+mvn kalix:run
 ----
 
 Scala::

--- a/docs/src/modules/java-protobuf/pages/quickstart-template.adoc
+++ b/docs/src/modules/java-protobuf/pages/quickstart-template.adoc
@@ -264,7 +264,7 @@ TIP: For more details see xref:developing:development-process-proto.adoc#_packag
 
 You can run your service locally for manual testing via HTTP or gRPC requests. 
 
-Start the application locally with the following command:
+To start your service locally, run:
 
 [.tabset]
 Java::
@@ -281,9 +281,9 @@ Scala::
 sbt runAll
 ----
 
-This command will start your Kalix application and a Kalix Proxy using the included `docker-compose.yml` file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in `docker-compose.yml` file.
 
-If you prefer, you can also start docker-compose directly by running `docker-compose up` in one terminal and in another terminal start your Kalix Application with:
+If you prefer, you can also start docker-compose directly by running `docker-compose up` in one terminal and in another terminal start your Kalix service with:
 
 
 [.tabset]

--- a/docs/src/modules/java-protobuf/pages/spring-client.adoc
+++ b/docs/src/modules/java-protobuf/pages/spring-client.adoc
@@ -36,7 +36,7 @@ With the source repository downloaded, you can build and run the Kalix Service l
 
 Run the Kalix Service using Maven:
 
-`mvn compile exec:exec`
+`mvn kalix:runAll`
 
 You should see output similar to the following:
 
@@ -44,18 +44,6 @@ You should see output similar to the following:
 [INFO] --- exec-maven-plugin:3.0.0:exec (default-cli) @ valueentity-counter ---
 {"timestamp":"2022-03-02T23:38:12.174Z","thread":"main","logger":"com.example.Main","message":"starting the Kalix service","context":"default","severity":"INFO"}
 {"timestamp":"2022-03-02T23:38:12.829Z","thread":"kalix-akka.actor.default-dispatcher-2","logger":"akka.event.slf4j.Slf4jLogger","message":"Slf4jLogger started","context":"default","severity":"INFO"}
-```
-
-== Build and Run the Kalix proxy locally
-
-In another terminal window, run the Kalix proxy using Docker:
-
-`docker compose up`
-
-You should see output similar to the following:app-name:
-
-```
-kalix-proxy_1   | {"timestamp":"2022-03-02T23:40:40.766Z","mdc":{"akkaAddress":"akka://kalix-proxy@172.21.0.2:25520","akkaSource":"akka://kalix-proxy/user/discovery-manager","sourceActorSystem":"kalix-proxy"},"logger":"io.kalix.proxy.DiscoveryManager","message":"gRPC proxy started at 0.0.0.0:9000","severity":"INFO","thread":"kalix-proxy-akka.actor.default-dispatcher-8"}
 ```
 
 == Building Spring REST Client

--- a/docs/src/modules/java/pages/getting-started.adoc
+++ b/docs/src/modules/java/pages/getting-started.adoc
@@ -105,20 +105,20 @@ TIP: For more details see xref:java:development-process.adoc#_package_service[De
 
 == Run locally
 
-You can run your service locally for manual testing via HTTP requests. To run your application locally, you need to initiate the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-
-To start the proxy, run the following command from the project directory:
-
-[source,bash]
-----
-docker compose up
-----
-
 Start the application locally with the following command:
 
 [source,bash]
 ----
-mvn compile spring-boot:run
+mvn kalix:runAll
+----
+
+This command will start your Kalix application and a Kalix Proxy using the included `docker-compose.yml` file.
+
+If you prefer, you can also start docker-compose directly by running `docker-compose up` in one terminal and in another terminal start your Kalix Application with:
+
+[source,bash]
+----
+mvn kalix:run
 ----
 
 With both the proxy and your application running, any defined endpoints should be available at `localhost:9000`,

--- a/docs/src/modules/java/pages/getting-started.adoc
+++ b/docs/src/modules/java/pages/getting-started.adoc
@@ -105,23 +105,23 @@ TIP: For more details see xref:java:development-process.adoc#_package_service[De
 
 == Run locally
 
-Start the application locally with the following command:
+To start your service locally, run:
 
 [source,bash]
 ----
 mvn kalix:runAll
 ----
 
-This command will start your Kalix application and a Kalix Proxy using the included `docker-compose.yml` file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in `docker-compose.yml` file.
 
-If you prefer, you can also start docker-compose directly by running `docker-compose up` in one terminal and in another terminal start your Kalix Application with:
+If you prefer, you can also start docker-compose directly by running `docker-compose up` in one terminal and in another terminal start your Kalix service with:
 
 [source,bash]
 ----
 mvn kalix:run
 ----
 
-With both the proxy and your application running, any defined endpoints should be available at `localhost:9000`,
+With both the proxy and your service running, any defined endpoints should be available at `localhost:9000`,
 the proxy local address.
 
 [source, command window]

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -26,15 +26,15 @@ mvn compile
 ## Running Locally
 ]]#
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 > Note: if you're looking to use Google Pub/Sub, see comments inside [docker-compose.yml](./docker-compose.yml)
 > on how to enable a Google Pub/Sub emulator that Kalix proxy will connect to.

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -25,21 +25,19 @@ mvn compile
 #[[
 ## Running Locally
 ]]#
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-To start the proxy, run the following command from this directory:
+
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-> Note: if you're looking to use Google Pub/Sub, see comments inside [docker-compose.yml](./docker-compose.yml) 
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+
+> Note: if you're looking to use Google Pub/Sub, see comments inside [docker-compose.yml](./docker-compose.yml)
 > on how to enable a Google Pub/Sub emulator that Kalix proxy will connect to.
-
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -26,7 +26,7 @@ mvn compile
 ## Running Locally
 ]]#
 
-When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
 To start your service locally, run:
 
@@ -39,7 +39,7 @@ This command will start your Kalix service and a companion Kalix Proxy as config
 > Note: if you're looking to use Google Pub/Sub, see comments inside [docker-compose.yml](./docker-compose.yml)
 > on how to enable a Google Pub/Sub emulator that Kalix proxy will connect to.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/${package}.MyServiceEntity/GetValue -d '{"entityId": "foo"}'

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -166,32 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${D}{mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
@@ -26,20 +26,20 @@ mvn compile
 ## Running Locally
 ]]#
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 > Note: if you're looking to use Google Pub/Sub, see comments inside [docker-compose.yml](./docker-compose.yml)
 > on how to enable a Google Pub/Sub emulator that Kalix proxy will connect to.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/${package}.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
@@ -25,19 +25,19 @@ mvn compile
 #[[
 ## Running Locally
 ]]#
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```shell
-mvn compile exec:exec
-```
+> Note: if you're looking to use Google Pub/Sub, see comments inside [docker-compose.yml](./docker-compose.yml)
+> on how to enable a Google Pub/Sub emulator that Kalix proxy will connect to.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -166,32 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${D}{mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
@@ -6,7 +6,7 @@ To understand the Kalix concepts that are the basis for this example, see [Desig
 
 ## Developing
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/) and check Spring-SDK [official documentation](https://docs.kalix.io/spring/index.html). Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
+This project contains the framework to create a Kalix service. To understand more about these components, see [Developing services](https://docs.kalix.io/services/) and check Spring-SDK [official documentation](https://docs.kalix.io/spring/index.html). Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
 
 ## Building
 
@@ -18,17 +18,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ## Deploying
 

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
@@ -18,19 +18,15 @@ mvn compile
 
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
-
-```shell
-mvn spring-boot:run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -180,6 +180,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -223,16 +223,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -219,7 +219,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -135,32 +135,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
@@ -6,7 +6,7 @@ To understand the Kalix concepts that are the basis for this example, see [Desig
 
 ## Developing
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/) and check Spring-SDK [official documentation](https://docs.kalix.io/spring/index.html). Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
+This project contains the framework to create a Kalix service. To understand more about these components, see [Developing services](https://docs.kalix.io/services/) and check Spring-SDK [official documentation](https://docs.kalix.io/spring/index.html). Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
 
 ## Building
 
@@ -18,17 +18,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ## Deploying
 

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
@@ -18,19 +18,15 @@ mvn compile
 
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
-
-```shell
-mvn spring-boot:run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -177,66 +177,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <!-- configure src/it/java and src/it/resources -->
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-integration-test-source</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/it/kotlin</source>
-              </sources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-integration-test-resource</id>
-            <phase>generate-test-resources</phase>
-            <goals>
-              <goal>add-test-resource</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>src/it/resources</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -188,6 +188,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -265,16 +265,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -261,7 +261,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
@@ -21,21 +21,21 @@ mvn compile
 
 ## Running Locally
 
-When running this Kalix sample locally, a few applications are required. The current Kalix application, its companion Kalix Proxy, a Kafka broker and a Zookeeper.
+When running this Kalix service locally, we need to have its companion Kalix Proxy, a Kafka broker and a Zookeeper running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start the Kalix application, the Kalix Proxy, a local Kafka broker and a Zookeeper using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start the Kalix service, the Kalix Proxy, a local Kafka broker and a Zookeeper using the included [docker-compose.yml](./docker-compose.yml) file.
 
 It can make sense to delete the existing containers (if any exist) and start from scratch when starting up the Kafka container.
 
 ### Create topic for eventing out
 
-Every time a customer receives a change, the application also persists that change to a topic in Kafka called `customer_changes`. You can see that this is set in customer_action.proto. In order for the changes to be written to this topic, you need to manually create the topic in Kafka. To do this, run the following command after the Docker container `java-protobuf-customer-registry-kafka-quickstart-kafka-1` is running.
+Every time a customer receives a change, the service also persists that change to a topic in Kafka called `customer_changes`. You can see that this is set in customer_action.proto. In order for the changes to be written to this topic, you need to manually create the topic in Kafka. To do this, run the following command after the Docker container `java-protobuf-customer-registry-kafka-quickstart-kafka-1` is running.
 
 ```shell
 docker-compose exec kafka kafka-topics --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic customer_changes
@@ -43,7 +43,7 @@ docker-compose exec kafka kafka-topics --create --bootstrap-server localhost:909
 
 ### Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 You can connect to the Kafka topic using:
 

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
@@ -22,16 +22,17 @@ mvn compile
 ```
 
 
-## Running Locally 
+## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
+When running this Kalix sample locally, a few applications are required. The current Kalix application, its companion Kalix Proxy, a Kafka broker and a Zookeeper.
 
-It also contains the configuration to start a local Kafka broker and a Zookeeper that the Kalix proxy will connect to.
-To start the proxy, the Kafka broker, and the Zookeeper, run the following command from the root directory:
+To start the applications locally, call the following command:
 
 ```shell
-docker compose -f docker-compose.yml rm -f && docker compose -f docker-compose.yml up
+mvn kalix:runAll
 ```
+
+This command will start the Kalix application, the Kalix Proxy, a local Kafka broker and a Zookeeper using the included [docker-compose.yml](./docker-compose.yml) file.
 
 It can make sense to delete the existing containers (if any exist) and start from scratch when starting up the Kafka container.
 
@@ -41,13 +42,6 @@ Every time a customer receives a change, the application also persists that chan
 
     docker-compose exec kafka kafka-topics --create --bootstrap-server \
     localhost:9092 --replication-factor 1 --partitions 1 --topic customer_changes
-
-### Starting the application
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
@@ -4,13 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/developing/development-process-proto.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
-
 
 ## Building
 
@@ -20,7 +18,6 @@ generating code based on the `.proto` definitions:
 ```shell
 mvn compile
 ```
-
 
 ## Running Locally
 
@@ -40,28 +37,45 @@ It can make sense to delete the existing containers (if any exist) and start fro
 
 Every time a customer receives a change, the application also persists that change to a topic in Kafka called `customer_changes`. You can see that this is set in customer_action.proto. In order for the changes to be written to this topic, you need to manually create the topic in Kafka. To do this, run the following command after the Docker container `java-protobuf-customer-registry-kafka-quickstart-kafka-1` is running.
 
-    docker-compose exec kafka kafka-topics --create --bootstrap-server \
-    localhost:9092 --replication-factor 1 --partitions 1 --topic customer_changes
+```shell
+docker-compose exec kafka kafka-topics --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic customer_changes
+```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+### Exercising the service
 
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+
+You can connect to the Kafka topic using:
+
+```shell
+ docker-compose exec kafka kafka-console-consumer --topic customer_changes --from-beginning --bootstrap-server localhost:9092
+```
+
+Each interaction below will trigger a state change that will then be propagated to the Kafka topic.
 
 * Create a customer with:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
+```
+
 * Retrieve the customer:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
+```
+
 * Change name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
+```
+
 * Change address:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
+```
 
 ## Deploying
 

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   kafka:
     image: confluentinc/cp-kafka:7.1.0
-    # image not available for arm64 so this is needed to run it on Apple m1
+    # image not available for arm64 so this is needed to run it on Apple M1
     platform: linux/amd64
     depends_on:
       - zookeeper
@@ -28,7 +28,9 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://kafka:9092
+      # advertised listner running on port 9092 must be accessible to kalix-proxy container run by kalix:runAll
+      # therefore we need to use host.docker.internal (docker's bridge address) to access it through the host machine
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://host.docker.internal:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       BROKER_CONFIG_FILE: /conf/my-local.kafka.properties
     volumes:
       - .:/conf
+
   kafka:
     image: confluentinc/cp-kafka:7.1.0
     # image not available for arm64 so this is needed to run it on Apple m1
@@ -33,6 +34,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      
   zookeeper:
     image: wurstmeister/zookeeper
     ports:

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      # advertised listner running on port 9092 must be accessible to kalix-proxy container run by kalix:runAll
+      # advertised listener running on port 9092 must be accessible to kalix-proxy container run by kalix:runAll
       # therefore we need to use host.docker.internal (docker's bridge address) to access it through the host machine
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://host.docker.internal:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -164,32 +164,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-customer-registry-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-quickstart/README.md
@@ -33,7 +33,7 @@ This command will start your Kalix application and a Kalix Proxy using the inclu
 
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/java-protobuf-customer-registry-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-quickstart/README.md
@@ -31,6 +31,8 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+## Exercising the service
+
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 * Create a customer with:

--- a/samples/java-protobuf-customer-registry-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-quickstart/README.md
@@ -21,19 +21,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/java-protobuf-customer-registry-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-quickstart/README.md
@@ -4,13 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/developing/development-process-proto.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
-
 
 ## Building
 
@@ -21,42 +19,43 @@ generating code based on the `.proto` definitions:
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
-
 * Create a customer with:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
+```
+
 * Retrieve the customer:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
+```
+
 * Change name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
+```
+
 * Change address:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
+```
 
 ## Deploying
 

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -164,32 +164,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-customer-registry-views-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-views-quickstart/README.md
@@ -4,13 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/developing/development-process-proto.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
-
 
 ## Building
 
@@ -21,50 +19,55 @@ generating code based on the `.proto` definitions:
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
-
 * Create a customer with:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
+```
+
 * Retrieve the customer:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
+```
+
 * Query by email:
-  ```shell
-  grpcurl --plaintext -d '{"email": "wip@example.com"}' localhost:9000 customer.view.CustomerByEmail/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"email": "wip@example.com"}' localhost:9000 customer.view.CustomerByEmail/GetCustomer
+```
+
 * Query by name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
+```
+
 * Change name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
+```
+
 * Change address:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
+```
 
 ## Deploying
 

--- a/samples/java-protobuf-customer-registry-views-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-views-quickstart/README.md
@@ -31,7 +31,7 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/java-protobuf-customer-registry-views-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-views-quickstart/README.md
@@ -21,17 +21,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -164,32 +164,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -166,32 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-eventsourced-counter/README.md
+++ b/samples/java-protobuf-eventsourced-counter/README.md
@@ -21,17 +21,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'        

--- a/samples/java-protobuf-eventsourced-counter/README.md
+++ b/samples/java-protobuf-eventsourced-counter/README.md
@@ -1,17 +1,14 @@
 # eventsourced-counter
 
-
 ## Designing
 
 While designing your service it is useful to read [designing services](https://docs.kalix.io/developing/development-process-proto.html)
-
 
 ## Developing
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
-
 
 ## Building
 
@@ -22,22 +19,17 @@ generating code based on the `.proto` definitions:
 mvn compile
 ```
 
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
@@ -57,7 +49,6 @@ For example, using [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 
 > Note: The failure is to be expected if you have not yet provided an implementation of `GetValue` in
 > your entity.
-
 
 ## Deploying
 

--- a/samples/java-protobuf-eventsourced-counter/README.md
+++ b/samples/java-protobuf-eventsourced-counter/README.md
@@ -31,7 +31,7 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'        

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -166,31 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-       <configuration>
-         <executable>java</executable>
-         <arguments>
-           <argument>-classpath</argument>
-           <classpath/>
-           <argument>${mainClass}</argument>
-         </arguments>
-         <environmentVariables>
-           <!-- needed for the proxy to access the user function on all platforms -->
-           <HOST>0.0.0.0</HOST>
-         </environmentVariables>
-       </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/README.md
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/README.md
@@ -18,7 +18,7 @@ mvn compile
 
 First start the `java-protobuf-eventsourced-customer-registry` service and proxy. It will run with the default service and proxy ports (`8080` and `9000`).
 
-To start the application locally, the `kalix-maven-plugin` is used. Use the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -1,11 +1,11 @@
 # this docker-compose is used by the integration tests. To run it, we must first publish
-# java-spring-eventsourced-customer-registry image locally. To do so, run the following command from the root of the project:
+# java-protobuf-eventsourced-customer-registry image locally. To do so, run the following command from the root of the project:
 # mvn clean install docker:build
 
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.9-M2
+    image: gcr.io/kalix-public/kalix-proxy:1.1.11
     depends_on:
       - kalix-proxy-customer-registry
     ports:
@@ -21,7 +21,7 @@ services:
       USER_FUNCTION_PORT: "8081"
 
   kalix-proxy-customer-registry:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.9-M2
+    image: gcr.io/kalix-public/kalix-proxy:1.1.11
     ports:
       - "9000:9000"
     extra_hosts:

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -164,35 +164,7 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <!--  the customer registry service is running at 8080, this service at 8081 -->
-            <argument>-Dkalix.user-function-port=8081</argument>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
+      
       <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>

--- a/samples/java-protobuf-eventsourced-customer-registry/README.md
+++ b/samples/java-protobuf-eventsourced-customer-registry/README.md
@@ -16,18 +16,19 @@ Use Maven to build your project:
 ```shell
 mvn compile
 ```
+
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
+To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running service.
 It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
 
-To start the application locally, the `kalix-maven-plugin` is used. Use the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Create a customer with:
 

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -166,32 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/java-protobuf-eventsourced-shopping-cart/README.md
@@ -33,7 +33,7 @@ This command will start your Kalix application and a Kalix Proxy using the inclu
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST
-requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Send an AddItem command:
 

--- a/samples/java-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/java-protobuf-eventsourced-shopping-cart/README.md
@@ -20,19 +20,15 @@ mvn compile
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file
-contains the configuration required to run the proxy for a locally running application. It also contains the
-configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to. To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (

--- a/samples/java-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/java-protobuf-eventsourced-shopping-cart/README.md
@@ -20,17 +20,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST
 requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.

--- a/samples/java-protobuf-fibonacci-action/README.md
+++ b/samples/java-protobuf-fibonacci-action/README.md
@@ -21,19 +21,16 @@ mvn verify
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```shell
-mvn compile exec:exec
-```
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 

--- a/samples/java-protobuf-fibonacci-action/README.md
+++ b/samples/java-protobuf-fibonacci-action/README.md
@@ -36,7 +36,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.fibonacci.Fibonacci/NextNumber -d '{"value": 5 }'

--- a/samples/java-protobuf-fibonacci-action/README.md
+++ b/samples/java-protobuf-fibonacci-action/README.md
@@ -21,22 +21,22 @@ mvn verify
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.fibonacci.Fibonacci/NextNumber -d '{"value": 5 }'

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -166,32 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-first-service/README.md
+++ b/samples/java-protobuf-first-service/README.md
@@ -1,17 +1,14 @@
 # first-service
 
-
 ## Designing
 
 While designing your service it is useful to read [designing services](https://docs.kalix.io/developing/development-process-proto.html)
-
 
 ## Developing
 
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it, it may be useful to read up on [developing services](https://docs.kalix.io/services/)
 and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
-
 
 ## Building
 
@@ -22,26 +19,21 @@ generating code based on the `.proto` definitions:
 mvn compile
 ```
 
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
-```
+```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'
 The command handler for `GetCurrentCounter` is not implemented, yet
 ```
@@ -57,7 +49,6 @@ ERROR:
 
 > Note: The failure is to be expected if you have not yet provided an implementation of `GetCurrentCounter` in
 > your entity.
-
 
 ## Deploying
 

--- a/samples/java-protobuf-first-service/README.md
+++ b/samples/java-protobuf-first-service/README.md
@@ -21,17 +21,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/java-protobuf-first-service/README.md
+++ b/samples/java-protobuf-first-service/README.md
@@ -31,7 +31,7 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -166,32 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-reliable-timers/README.md
+++ b/samples/java-protobuf-reliable-timers/README.md
@@ -35,21 +35,21 @@ The integration test uses Docker via [TestContainers](https://www.testcontainers
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/PlaceOrder -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/java-protobuf-reliable-timers/README.md
+++ b/samples/java-protobuf-reliable-timers/README.md
@@ -35,19 +35,15 @@ The integration test uses Docker via [TestContainers](https://www.testcontainers
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -62,7 +58,6 @@ curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actio
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/Confirm -d '{ "number" : "returned-order-number" }'
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/Cancel -d '{ "number" : "returned-order-number" }'
 ```
-
 
 Or, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 

--- a/samples/java-protobuf-reliable-timers/README.md
+++ b/samples/java-protobuf-reliable-timers/README.md
@@ -49,7 +49,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/PlaceOrder -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -175,32 +175,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -164,32 +164,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/README.md
@@ -32,7 +32,7 @@ This command will start your Kalix application and a Kalix Proxy using the inclu
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this
-endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Send an AddItem command:
 

--- a/samples/java-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/README.md
@@ -19,19 +19,15 @@ mvn compile
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file
-contains the configuration required to run the proxy for a locally running application. It also contains the
-configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to. To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (

--- a/samples/java-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/README.md
@@ -19,17 +19,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this
 endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -164,32 +164,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-shopping-cart-quickstart/README.md
+++ b/samples/java-protobuf-shopping-cart-quickstart/README.md
@@ -4,13 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/developing/development-process-proto.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of an Event Sourced Entity.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Java Protobuf SDK section](https://docs.kalix.io/java-protobuf/)
-
 
 ## Building
 
@@ -21,23 +19,17 @@ generating code based on the `.proto` definitions:
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-
-```shell
-docker-compose up
-```
-
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
-mvn compile exec:exec
+mvn kalix:runAll
 ```
+
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 

--- a/samples/java-protobuf-shopping-cart-quickstart/README.md
+++ b/samples/java-protobuf-shopping-cart-quickstart/README.md
@@ -21,17 +21,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 For example, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -165,32 +165,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>${JAVA_HOME}/bin/java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-valueentity-counter-spring-client/README.md
+++ b/samples/java-protobuf-valueentity-counter-spring-client/README.md
@@ -1,7 +1,7 @@
 # Implementing Spring Client for Counter as a Value Entity
 
 This project/module is a spring client to java-protobuf-valueentity-counter module exposed endpoints via REST and GRPC.
-This application exposes REST API endpoints and underneath calls relevant API's in java entity counter application.
+This service exposes REST API endpoints and underneath calls relevant API's in java entity counter service.
 
 It's dependent on java-protobuf-valueentity-counter module.
 
@@ -15,11 +15,11 @@ mvn verify
 
 ## Running Locally
 
-In order to run your application locally, please ensure that module is running in your local setup java-protobuf-valueentity-counter.
-By default, this application connects to java-protobuf-valueentity-counter running on localhost and port 9000. This is configurable in
+In order to run your service locally, please ensure that module is running in your local setup java-protobuf-valueentity-counter.
+By default, this service connects to java-protobuf-valueentity-counter running on localhost and port 9000. This is configurable in
 ``application.properties`` file with properties ``as.host`` and ``as.host``
 
-To start the application locally, the `spring-maven-plugin` is used. Use the following command:
+To start your service locally, run:
 
 ```shell
 mvn spring-boot:run
@@ -27,16 +27,19 @@ mvn spring-boot:run
 
 ## Exercise the service
 
-With both the java-protobuf-valueentity-counter module and your application running, any defined endpoints should be available at `http://localhost:8083`.
-Rest Endpoints are exposed via this application, and they can be invoked using any RestClient.
+With both the java-protobuf-valueentity-counter module and your service running, any defined endpoints should be available at `http://localhost:8083`.
+Rest Endpoints are exposed via this service, and they can be invoked using any RestClient.
+
 ```shell
 curl --request GET 'localhost:8083/counter/foo'
 ```
+
 ```shell
 curl --request POST 'localhost:8083/counter/foo/increase' \
 --header 'Content-Type: application/json' \
 --data-raw '{"counterId": "foo", "value" : 1}'
 ```
+
 ```shell
 curl --request POST 'localhost:8083/counter/foo/decrease' \
 --header 'Content-Type: application/json' \

--- a/samples/java-protobuf-valueentity-counter-spring-client/README.md
+++ b/samples/java-protobuf-valueentity-counter-spring-client/README.md
@@ -3,9 +3,7 @@
 This project/module is a spring client to java-protobuf-valueentity-counter module exposed endpoints via REST and GRPC.
 This application exposes REST API endpoints and underneath calls relevant API's in java entity counter application.
 
-
 It's dependent on java-protobuf-valueentity-counter module.
-
 
 ## Building and running unit tests
 
@@ -21,7 +19,7 @@ In order to run your application locally, please ensure that module is running i
 By default, this application connects to java-protobuf-valueentity-counter running on localhost and port 9000. This is configurable in
 ``application.properties`` file with properties ``as.host`` and ``as.host``
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+To start the application locally, the `spring-maven-plugin` is used. Use the following command:
 
 ```shell
 mvn spring-boot:run

--- a/samples/java-protobuf-valueentity-counter/README.md
+++ b/samples/java-protobuf-valueentity-counter/README.md
@@ -35,21 +35,21 @@ The integration test uses Docker via [TestContainers](https://www.testcontainers
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/java-protobuf-valueentity-counter/README.md
+++ b/samples/java-protobuf-valueentity-counter/README.md
@@ -35,19 +35,15 @@ The integration test uses Docker via [TestContainers](https://www.testcontainers
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 

--- a/samples/java-protobuf-valueentity-counter/README.md
+++ b/samples/java-protobuf-valueentity-counter/README.md
@@ -49,7 +49,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -177,32 +177,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-valueentity-customer-registry/README.md
+++ b/samples/java-protobuf-valueentity-customer-registry/README.md
@@ -9,41 +9,47 @@ Use Maven to build your project:
 ```shell
 mvn compile
 ```
+
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Create a customer with:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
+```
+
 * Retrieve the customer:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
+```
+
 * Query by name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
+```
+
 * Change name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
+```
+
 * Change address:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
+```

--- a/samples/java-protobuf-valueentity-customer-registry/README.md
+++ b/samples/java-protobuf-valueentity-customer-registry/README.md
@@ -12,17 +12,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Create a customer with:
 

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -166,32 +166,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/java-protobuf-valueentity-shopping-cart/README.md
@@ -33,7 +33,7 @@ This command will start your Kalix application and a Kalix Proxy using the inclu
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST
-requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Send an AddItem command:
 

--- a/samples/java-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/java-protobuf-valueentity-shopping-cart/README.md
@@ -20,19 +20,15 @@ mvn compile
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file
-contains the configuration required to run the proxy for a locally running application. It also contains the
-configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to. To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (

--- a/samples/java-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/java-protobuf-valueentity-shopping-cart/README.md
@@ -20,17 +20,17 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST
 requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -167,32 +167,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-view-store/README.md
+++ b/samples/java-protobuf-view-store/README.md
@@ -4,7 +4,6 @@ A simple store example with products, customers, and orders.
 
 Used for code snippets in the Views documentation.
 
-
 ## Building
 
 You can use Maven to build your project, which will also take care of
@@ -14,22 +13,18 @@ generating code based on the `.proto` definitions:
 mvn compile
 ```
 
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-```
-docker-compose up
+To start the applications locally, call the following command:
+
+```shell
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```
-mvn compile exec:exec
-```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
@@ -37,7 +32,7 @@ With both the proxy and your application running, any defined endpoints should b
 
 Create some products:
 
-```
+```shell
 grpcurl -d '{
     "productId": "P123",
     "productName": "Super Duper Thingamajig",
@@ -47,7 +42,7 @@ grpcurl -d '{
   store.product.api.Products/Create
 ```
 
-```
+```shell
 grpcurl -d '{
     "productId": "P987",
     "productName": "Awesome Whatchamacallit",
@@ -59,7 +54,7 @@ grpcurl -d '{
 
 Retrieve a product by id:
 
-```
+```shell
 grpcurl -d '{"productId": "P123"}' \
   --plaintext localhost:9000 \
   store.product.api.Products/Get
@@ -67,7 +62,7 @@ grpcurl -d '{"productId": "P123"}' \
 
 Create a customer:
 
-```
+```shell
 grpcurl -d '{
     "customerId": "C001",
     "email": "someone@example.com",
@@ -80,7 +75,7 @@ grpcurl -d '{
 
 Retrieve a customer by id:
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.customer.api.Customers/Get
@@ -88,7 +83,7 @@ grpcurl -d '{"customerId": "C001"}' \
 
 Create customer orders for the products:
 
-```
+```shell
 grpcurl -d '{
     "orderId": "O1234",
     "productId": "P123",
@@ -99,7 +94,7 @@ grpcurl -d '{
   store.order.api.Orders/Create
 ```
 
-```
+```shell
 grpcurl -d '{
     "orderId": "O5678",
     "productId": "P987",
@@ -112,7 +107,7 @@ grpcurl -d '{
 
 Retrieve an order by id:
 
-```
+```shell
 grpcurl -d '{"orderId": "O5678"}' \
   --plaintext localhost:9000 \
   store.order.api.Orders/Get
@@ -120,7 +115,7 @@ grpcurl -d '{"orderId": "O5678"}' \
 
 Retrieve all product orders for a customer id using a view (with joins):
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.view.joined.JoinedCustomerOrders/Get
@@ -128,7 +123,7 @@ grpcurl -d '{"customerId": "C001"}' \
 
 Retrieve all product orders for a customer id using a view (with joins and nested projection):
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.view.nested.NestedCustomerOrders/Get
@@ -136,12 +131,11 @@ grpcurl -d '{"customerId": "C001"}' \
 
 Retrieve all product orders for a customer id using a view (with joins and structured projection):
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.view.structured.StructuredCustomerOrders/Get
 ```
-
 
 ## Deploying
 

--- a/samples/java-protobuf-view-store/README.md
+++ b/samples/java-protobuf-view-store/README.md
@@ -15,18 +15,18 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 ### Exercising the services
 

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -165,32 +165,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-protobuf-web-resources/README.md
+++ b/samples/java-protobuf-web-resources/README.md
@@ -16,19 +16,15 @@ mvn verify
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `exec-maven-plugin` is used. Use the following command:
-
-```shell
-mvn compile exec:exec
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 

--- a/samples/java-protobuf-web-resources/README.md
+++ b/samples/java-protobuf-web-resources/README.md
@@ -16,21 +16,21 @@ mvn verify
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running open `http://localhost:9000/` in your local browser.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 ## Deploying
 

--- a/samples/java-protobuf-web-resources/pom.xml
+++ b/samples/java-protobuf-web-resources/pom.xml
@@ -167,32 +167,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogback.configurationFile=logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-customer-registry-quickstart/README.md
+++ b/samples/java-spring-customer-registry-quickstart/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the services
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Create a customer with:
 

--- a/samples/java-spring-customer-registry-quickstart/README.md
+++ b/samples/java-spring-customer-registry-quickstart/README.md
@@ -4,13 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Java section](https://docs.kalix.io/java/)
-
 
 ## Building
 
@@ -19,7 +17,6 @@ Use Maven to build your project:
 ```shell
 mvn compile
 ```
-
 
 ## Running Locally
 
@@ -33,39 +30,51 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
+## Exercising the services
 
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Create a customer with:
-  ```shell
-  curl localhost:9000/customer/one/create \
-    --header "Content-Type: application/json" \
-    -XPOST \
-    --data '{"customerId":"one","email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
-  ```
+
+```shell
+curl localhost:9000/customer/one/create \
+  --header "Content-Type: application/json" \
+  -XPOST \
+  --data '{"customerId":"one","email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
+```
+
 * Retrieve the customer:
-  ```shell
-  curl localhost:9000/customer/one
-  ```
+
+```shell
+curl localhost:9000/customer/one
+```
+
 * Query by email:
-  ```shell
-  curl localhost:9000/customer/by_email/test%40example.com
-  ```
+
+```shell
+curl localhost:9000/customer/by_email/test%40example.com
+```
+
 * Query by name:
-  ```shell
-  curl localhost:9000/customer/by_name/Test%20Testsson
-  ```
+
+```shell
+curl localhost:9000/customer/by_name/Test%20Testsson
+```
+
 * Change name:
-  ```shell
-  curl localhost:9000/customer/one/changeName/Jan%20Banan -XPOST
-  ```
+
+```shell
+curl localhost:9000/customer/one/changeName/Jan%20Banan -XPOST
+```
+
 * Change address:
-  ```shell
-  curl localhost:9000/customer/one/changeAddress \
-    --header "Content-Type: application/json" \
-    -XPOST \
-    --data '{"street":"Newstreet 25","city":"Newcity"}'
-  ```
+
+```shell
+curl localhost:9000/customer/one/changeAddress \
+  --header "Content-Type: application/json" \
+  -XPOST \
+  --data '{"street":"Newstreet 25","city":"Newcity"}'
+```
 
 ## Deploying
 

--- a/samples/java-spring-customer-registry-quickstart/README.md
+++ b/samples/java-spring-customer-registry-quickstart/README.md
@@ -23,19 +23,15 @@ mvn compile
 
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
-
-```shell
-mvn spring-boot:run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
 

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -207,17 +207,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
 

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -136,32 +136,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-customer-registry-views-quickstart/README.md
+++ b/samples/java-spring-customer-registry-views-quickstart/README.md
@@ -30,6 +30,8 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+## Exercising the services
+
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 FIXME update for spring

--- a/samples/java-spring-customer-registry-views-quickstart/README.md
+++ b/samples/java-spring-customer-registry-views-quickstart/README.md
@@ -4,13 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Java section](https://docs.kalix.io/java/)
-
 
 ## Building
 
@@ -20,57 +18,63 @@ Use Maven to build your project:
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```shell
-mvn spring-boot:run
-```
-
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 FIXME update for spring
 
 * Create a customer with:
-  ```shell
-  curl localhost:9000/customer/one/create \
-    --header "Content-Type: application/json" \
-    -XPOST \
-    --data '{"customerId":"one","email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
-  ```
+
+```shell
+curl localhost:9000/customer/one/create \
+  --header "Content-Type: application/json" \
+  -XPOST \
+  --data '{"customerId":"one","email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
+```
+
 * Retrieve the customer:
-  ```shell
-  curl localhost:9000/customer/one
-  ```
+
+```shell
+curl localhost:9000/customer/one
+```
+
 * Query by email:
-  ```shell
-  curl localhost:9000/customer/by_email/test%40example.com
-  ```
+
+```shell
+curl localhost:9000/customer/by_email/test%40example.com
+```
+
 * Query by name:
-  ```shell
-  curl localhost:9000/customer/by_name/Test%20Testsson
-  ```
+
+```shell
+curl localhost:9000/customer/by_name/Test%20Testsson
+```
+
 * Change name:
-  ```shell
-  curl localhost:9000/customer/one/changeName/Jan%20Banan -XPOST
-  ```
+
+```shell
+curl localhost:9000/customer/one/changeName/Jan%20Banan -XPOST
+```
+
 * Change address:
-  ```shell
-  curl localhost:9000/customer/one/changeAddress \
-    --header "Content-Type: application/json" \
-    -XPOST \
-    --data '{"street":"Newstreet 25","city":"Newcity"}'
-  ```
+
+```shell
+curl localhost:9000/customer/one/changeAddress \
+  --header "Content-Type: application/json" \
+  -XPOST \
+  --data '{"street":"Newstreet 25","city":"Newcity"}'
+```
 
 ## Deploying
 

--- a/samples/java-spring-customer-registry-views-quickstart/README.md
+++ b/samples/java-spring-customer-registry-views-quickstart/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the services
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 FIXME update for spring
 

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -207,17 +207,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
 

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -136,32 +136,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -224,16 +224,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -134,33 +134,7 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
+      
       <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-eventsourced-counter/README.md
+++ b/samples/java-spring-eventsourced-counter/README.md
@@ -30,6 +30,8 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+## Exercising the services
+
 With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ### Examples

--- a/samples/java-spring-eventsourced-counter/README.md
+++ b/samples/java-spring-eventsourced-counter/README.md
@@ -1,14 +1,16 @@
-# java-spring-eventsourced-counter
+# Event Sourecd Counter
 
-
+## Designing
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
+## Developing
 
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/). Spring-SDK is an experimental feature and so far there is no [official](https://docs.kalix.io/) documentation. Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
-
-
+## Building
 
 Use Maven to build your project:
 
@@ -16,37 +18,36 @@ Use Maven to build your project:
 mvn compile
 ```
 
+## Running Locally
 
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
-
-```shell
-docker-compose up
-```
-
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
-mvn spring-boot:run
+mvn kalix:runAll
 ```
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`. 
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ### Examples
 
 - increase (or create) a counter named `hello` with value `10`
+
 ```shell
 curl -XPOST localhost:9000/counter/hello/increase/10
 ```
 
 - retrieve the value of a counter named `hello`
+
 ```shell
 curl -XGET localhost:9000/counter/hello
 ```
 
 - multiply existing counter named `hello` by value `5`
+
 ```shell
 curl -XPOST localhost:9000/counter/hello/multiply/5
 ```

--- a/samples/java-spring-eventsourced-counter/README.md
+++ b/samples/java-spring-eventsourced-counter/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the services
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ### Examples
 

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -224,16 +224,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -136,32 +136,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/README.md
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/README.md
@@ -18,7 +18,7 @@ mvn compile
 
 First start the `java-spring-eventsourced-customer-registry` service and proxy. It will run with the default service and proxy ports (`8080` and `9000`).
 
-To start the application locally, the `kalix-maven-plugin` is used. Use the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/README.md
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/README.md
@@ -33,8 +33,7 @@ curl localhost:9001/customer/one/create \
   --data '{"email":"test@example.com","name":"Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
 ```
 
-This call is made on the subscriber service and will be forwarded to the 
-`java-spring-eventsourced-customer-registry` service.
+This call is made on the subscriber service and will be forwarded to the `java-spring-eventsourced-customer-registry` service.
 
 >>>>>>> Stashed changes
 

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.9-M2
+    image: gcr.io/kalix-public/kalix-proxy:1.1.11
     depends_on:
       - kalix-proxy-customer-registry
     ports:
@@ -21,7 +21,7 @@ services:
       USER_FUNCTION_PORT: "8081"
 
   kalix-proxy-customer-registry:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.9-M2
+    image: gcr.io/kalix-public/kalix-proxy:1.1.11
     ports:
       - "9000:9000"
     extra_hosts:

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -185,6 +185,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -226,7 +226,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -230,17 +230,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-                <kalix.user-function-port>8081</kalix.user-function-port>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -140,33 +140,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-Dkalix.user-function-port=8081</argument>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-eventsourced-customer-registry/README.md
+++ b/samples/java-spring-eventsourced-customer-registry/README.md
@@ -30,11 +30,9 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Create a customer with:
 

--- a/samples/java-spring-eventsourced-customer-registry/README.md
+++ b/samples/java-spring-eventsourced-customer-registry/README.md
@@ -34,7 +34,7 @@ docker-compose up
 To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
 
 ```shell
-mvn spring-boot:run
+mvn kalix:runAll
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 

--- a/samples/java-spring-eventsourced-customer-registry/README.md
+++ b/samples/java-spring-eventsourced-customer-registry/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Create a customer with:
 

--- a/samples/java-spring-eventsourced-customer-registry/README.md
+++ b/samples/java-spring-eventsourced-customer-registry/README.md
@@ -4,13 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Event Sourced Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Java section](https://docs.kalix.io/java/)
-
 
 ## Building
 
@@ -20,56 +18,65 @@ Use Maven to build your project:
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-```shell
-docker-compose up
-```
-
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
 mvn kalix:runAll
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+
+## Exercising the service
+
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
 
 * Create a customer with:
-  ```shell
-  curl localhost:9000/customer/one/create \
-    --header "Content-Type: application/json" \
-    -XPOST \
-    --data '{"email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
-  ```
+
+```shell
+curl localhost:9000/customer/one/create \
+  --header "Content-Type: application/json" \
+  -XPOST \
+  --data '{"email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
+```
+
 * Retrieve the customer:
-  ```shell
-  curl localhost:9000/customer/one
-  ```
+
+```shell
+curl localhost:9000/customer/one
+```
+
 * Query by email:
-  ```shell
-  curl localhost:9000/customer/by_email/test%40example.com
-  ```
+
+```shell
+curl localhost:9000/customer/by_email/test%40example.com
+```
+
 * Query by name:
-  ```shell
-  curl localhost:9000/customer/by_name/Test%20Testsson
-  ```
+
+```shell
+curl localhost:9000/customer/by_name/Test%20Testsson
+```
+
 * Change name:
-  ```shell
-  curl localhost:9000/customer/one/changeName/Jan%20Banan -XPOST
-  ```
+
+```shell
+curl localhost:9000/customer/one/changeName/Jan%20Banan -XPOST
+```
+
 * Change address:
-  ```shell
-  curl localhost:9000/customer/one/changeAddress \
-    --header "Content-Type: application/json" \
-    -XPOST \
-    --data '{"street":"Newstreet 25","city":"Newcity"}'
-  ```
+
+```shell
+curl localhost:9000/customer/one/changeAddress \
+  --header "Content-Type: application/json" \
+  -XPOST \
+  --data '{"street":"Newstreet 25","city":"Newcity"}'
+```
 
 ## Deploying
 

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -137,32 +137,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -208,17 +208,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -182,6 +182,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -221,7 +221,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
 

--- a/samples/java-spring-eventsourced-shopping-cart/README.md
+++ b/samples/java-spring-eventsourced-shopping-cart/README.md
@@ -1,8 +1,16 @@
-# java-spring-eventsourced-shoppingcart
+# Event Sourced Shopping Cart
+
+## Designing
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/). Spring-SDK is an experimental feature and so far there is no [official](https://docs.kalix.io/) documentation. Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
+## Developing
+
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
+
+## Building
 
 Use Maven to build your project:
 
@@ -10,38 +18,39 @@ Use Maven to build your project:
 mvn compile
 ```
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+## Running Locally
+
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```shell
-mvn spring-boot:run
-```
-
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`. 
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ## Exercise the service
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
 
 - Add items to shopping cart
+
 ```shell
 curl -i -XPOST -H "Content-Type: application/json" localhost:9000/cart/123/add -d '{"productId":"kalix-tshirt", "name":"Akka Tshirt", "quantity": 10}'
 curl -i -XPOST -H "Content-Type: application/json" localhost:9000/cart/123/add -d '{"productId":"scala-tshirt", "name":"Scala Tshirt", "quantity": 20}'
 ```
 
-- See current status of the shopping cart 
+- See current status of the shopping cart
+
 ```shell
 curl -i -XGET -H "Content-Type: application/json" localhost:9000/cart/123
 ```
 
 - Remove an item from the cart
+
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/cart/123/items/kalix-tshirt/remove
 ```

--- a/samples/java-spring-eventsourced-shopping-cart/README.md
+++ b/samples/java-spring-eventsourced-shopping-cart/README.md
@@ -30,11 +30,9 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 - Add items to shopping cart
 

--- a/samples/java-spring-eventsourced-shopping-cart/README.md
+++ b/samples/java-spring-eventsourced-shopping-cart/README.md
@@ -32,7 +32,7 @@ This command will start your Kalix application and a Kalix Proxy using the inclu
 
 With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
-## Exercise the service
+## Exercising the service
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
 

--- a/samples/java-spring-eventsourced-shopping-cart/README.md
+++ b/samples/java-spring-eventsourced-shopping-cart/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 - Add items to shopping cart
 

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -224,16 +224,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -136,32 +136,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-fibonacci-action/README.md
+++ b/samples/java-spring-fibonacci-action/README.md
@@ -30,13 +30,11 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ```shell
 curl -XGET localhost:9000/fibonacci/5/next

--- a/samples/java-spring-fibonacci-action/README.md
+++ b/samples/java-spring-fibonacci-action/README.md
@@ -1,39 +1,36 @@
 # Fibonacci Action Service
 
-This project is based on the Kalix Maven archetype.
+## Designing
+
+To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
+
+## Developing
+
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
+
+## Building
+
+Use Maven to build your project:
 
 ```shell
-mvn archetype:generate \
-  -DarchetypeGroupId=io.kalix \
-  -DarchetypeArtifactId=kalix-maven-archetype \
-  -DarchetypeVersion=LATEST
-```
-
-See the [Kickstart a Maven project](https://docs.kalix.io/java/kickstart.html) in the documentation for details.
-
-## Building and running unit tests
-
-To compile and test the code from the command line, use
-
-```shell
-mvn verify
+mvn compile
 ```
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+mvn kalix:runAll
 ```
 
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```shell
-mvn spring-boot:run
-```
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -41,8 +38,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
-
-```shell 
+```shell
 curl -XGET localhost:9000/fibonacci/5/next
 ```
 

--- a/samples/java-spring-fibonacci-action/README.md
+++ b/samples/java-spring-fibonacci-action/README.md
@@ -20,21 +20,21 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ```shell
 curl -XGET localhost:9000/fibonacci/5/next

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -218,7 +218,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
 

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -205,17 +205,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-            <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -134,32 +134,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -179,6 +179,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-reliable-timers/README.md
+++ b/samples/java-spring-reliable-timers/README.md
@@ -32,13 +32,9 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`. 
-
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/orders/place -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/java-spring-reliable-timers/README.md
+++ b/samples/java-spring-reliable-timers/README.md
@@ -22,19 +22,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/orders/place -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/java-spring-reliable-timers/README.md
+++ b/samples/java-spring-reliable-timers/README.md
@@ -2,13 +2,17 @@
 
 This project provides an example for how to take advantage of the timers API using the Java SDK.
 
+## Designing
+
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
+## Developing
 
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/). Spring-SDK is an experimental feature and so far there is no [official](https://docs.kalix.io/) documentation. Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
-
-
+## Building
 
 Use Maven to build your project:
 
@@ -16,21 +20,19 @@ Use Maven to build your project:
 mvn compile
 ```
 
+## Running Locally
 
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
-
-```shell
-docker-compose up
-```
-
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
-mvn spring-boot:run
+mvn kalix:runAll
 ```
+
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`. 
 

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -137,32 +137,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -221,7 +221,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -182,6 +182,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -225,16 +225,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-shopping-cart-quickstart/README.md
+++ b/samples/java-spring-shopping-cart-quickstart/README.md
@@ -4,7 +4,6 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of an Event Sourced Entity.
@@ -19,26 +18,23 @@ Use Maven to build your project:
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-
-```shell
-docker-compose up
-```
-
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
-mvn compile spring-boot:run
+mvn kalix:runAll
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+
+## Exercising the service
+
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
 
 * Add an item
 
@@ -63,7 +59,6 @@ curl -XPOST localhost:9000/cart/123/items/kalix-tshirt/remove
 ```shell
 curl -XPOST localhost:9000/cart/123/checkout
 ```
-
 
 ## Deploying
 

--- a/samples/java-spring-shopping-cart-quickstart/README.md
+++ b/samples/java-spring-shopping-cart-quickstart/README.md
@@ -30,11 +30,9 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Add an item
 

--- a/samples/java-spring-shopping-cart-quickstart/README.md
+++ b/samples/java-spring-shopping-cart-quickstart/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 * Add an item
 

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -224,16 +224,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -136,32 +136,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-transfer-workflow-compensation/README.md
+++ b/samples/java-spring-transfer-workflow-compensation/README.md
@@ -24,19 +24,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ### Exercising the transfer
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 Create wallet `a` with an initial balance
 

--- a/samples/java-spring-transfer-workflow-compensation/README.md
+++ b/samples/java-spring-transfer-workflow-compensation/README.md
@@ -4,42 +4,37 @@ A simple workflow example of funds transfer between two wallets.
 
 Used for code snippets in the Workflow documentation.
 
+## Designing
+
+To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
 ## Developing
 
-This project demonstrates the use of Workflow Entity with Value Entities.
-
-To understand more about these components, see [developing services](https://docs.kalix.io/services/)
-and in particular the [developing with Spring section](https://docs.kalix.io/spring/).
-
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
 
 ## Building
 
 Use Maven to build your project:
 
-```
+```shell
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-```
-docker-compose up
-```
+To start the applications locally, call the following command:
 
-To start the application locally, use the following command:
-
-```
-mvn spring-boot:run
+```shell
+mvn kalix:runAll
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 ### Exercising the transfer
 
@@ -82,7 +77,6 @@ Get transfer state
 curl http://localhost:9000/transfer/1
 ```
 
-
 ## Running integration tests
 
 The integration tests in `src/it` are added by setting `it` as test source directory.
@@ -91,7 +85,6 @@ To run the Integration Tests in `src/it/java` use
 ```shell
 mvn verify -Pit
 ```
-
 
 ## Deploying
 

--- a/samples/java-spring-transfer-workflow-compensation/README.md
+++ b/samples/java-spring-transfer-workflow-compensation/README.md
@@ -34,9 +34,9 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
 ### Exercising the transfer
+
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 Create wallet `a` with an initial balance
 

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -137,32 +137,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -208,17 +208,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-            <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -182,6 +182,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -221,7 +221,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
 

--- a/samples/java-spring-transfer-workflow/README.md
+++ b/samples/java-spring-transfer-workflow/README.md
@@ -4,38 +4,37 @@ A simple workflow example of funds transfer between two wallets.
 
 Used for code snippets in the Workflow documentation.
 
+## Designing
+
+To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
 ## Developing
 
-This project demonstrates the use of Workflow Entity with Value Entities.
-
-To understand more about these components, see [developing services](https://docs.kalix.io/services/)
-and in particular the [developing with Spring section](https://docs.kalix.io/spring/).
-
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
 
 ## Building
 
 Use Maven to build your project:
 
-```
+```shell
 mvn compile
 ```
 
-
 ## Running Locally
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-```
-docker-compose up
+To start the applications locally, call the following command:
+
+```shell
+mvn kalix:runAll
 ```
 
-To start the application locally, use the following command:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```
-mvn spring-boot:run
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
@@ -82,7 +81,6 @@ Get transfer state
 curl http://localhost:9000/transfer/1
 ```
 
-
 ## Running integration tests
 
 The integration tests in `src/it` are added by setting `it` as test source directory.
@@ -91,7 +89,6 @@ To run the Integration Tests in `src/it/java` use
 ```shell
 mvn verify -Pit
 ```
-
 
 ## Deploying
 

--- a/samples/java-spring-transfer-workflow/README.md
+++ b/samples/java-spring-transfer-workflow/README.md
@@ -34,13 +34,9 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-```
-
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
-
-
 ### Exercising the transfer
+
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 
 Create wallet `a` with an initial balance
 

--- a/samples/java-spring-transfer-workflow/README.md
+++ b/samples/java-spring-transfer-workflow/README.md
@@ -24,19 +24,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ### Exercising the transfer
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 
 Create wallet `a` with an initial balance
 

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -137,32 +137,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -208,17 +208,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-            <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -182,6 +182,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -221,7 +221,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
 

--- a/samples/java-spring-valueentity-counter/README.md
+++ b/samples/java-spring-valueentity-counter/README.md
@@ -1,14 +1,16 @@
-# java-spring-valueentity-counter
+# Value Entity Counter
 
-
+## Designing
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
+## Developing
 
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/). Spring-SDK is an experimental feature and so far there is no [official](https://docs.kalix.io/) documentation. Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
-
-
+## Building
 
 Use Maven to build your project:
 
@@ -16,30 +18,25 @@ Use Maven to build your project:
 mvn compile
 ```
 
+## Running Locally
 
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
-
-```shell
-docker-compose up
-```
-
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
-mvn spring-boot:run
+mvn kalix:runAll
 ```
 
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
-
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`, 
-the proxy local address.
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`, the proxy local address.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/counter/foo/increase -d '{ "value": 10 }'
@@ -48,7 +45,6 @@ curl -XPOST -H "Content-Type: application/json" localhost:9000/counter/foo/incre
 ```shell
 curl localhost:9000/counter/foo
 ```
-
 
 ## Deploying
 

--- a/samples/java-spring-valueentity-counter/README.md
+++ b/samples/java-spring-valueentity-counter/README.md
@@ -30,10 +30,6 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
-For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
-
 ## Exercise the service
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`, the proxy local address.

--- a/samples/java-spring-valueentity-counter/README.md
+++ b/samples/java-spring-valueentity-counter/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`, the proxy local address.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`, the proxy local address.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/counter/foo/increase -d '{ "value": 10 }'

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -185,6 +185,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -225,7 +225,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -140,32 +140,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -229,16 +229,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-valueentity-customer-registry/README.md
+++ b/samples/java-spring-valueentity-customer-registry/README.md
@@ -30,6 +30,8 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+## Exercise the service
+
 With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 * Create a customer with:

--- a/samples/java-spring-valueentity-customer-registry/README.md
+++ b/samples/java-spring-valueentity-customer-registry/README.md
@@ -1,14 +1,16 @@
-# java-spring-valueentity-customer-registry
+# Value Entity Customer Registry
 
-
+## Designing
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
+## Developing
 
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/). Spring-SDK is an experimental feature and so far there is no [official](https://docs.kalix.io/) documentation. Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
-
-
+## Building
 
 Use Maven to build your project:
 
@@ -16,44 +18,46 @@ Use Maven to build your project:
 mvn compile
 ```
 
+## Running Locally
 
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
-
-```shell
-docker-compose up
-```
-
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
-mvn spring-boot:run
+mvn kalix:runAll
 ```
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`. 
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 * Create a customer with:
-  ```shell
-  curl localhost:9000/customer/one/create \
-    --header "Content-Type: application/json" \
-    -XPOST \
-    --data '{"customerId":"one","email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
-  ```
+
+```shell
+curl localhost:9000/customer/one/create \
+  --header "Content-Type: application/json" \
+  -XPOST \
+  --data '{"customerId":"one","email":"test@example.com","name":"Test Testsson","address":{"street":"Teststreet 25","city":"Testcity"}}'
+```
+
 * Retrieve the customer:
-  ```shell
-  curl localhost:9000/customer/one
-  ```
+
+```shell
+curl localhost:9000/customer/one
+```
+
 * Query by name with a wrapped result:
-  ```shell
-  curl localhost:9000/wrapped/by_name/Test%20Testsson
-  ```
+
+```shell
+curl localhost:9000/wrapped/by_name/Test%20Testsson
+```
+
 * Query by name with a response using a summary:
-  ```shell
-  curl localhost:9000/summary/by_name/Test%20Testsson
-  ```
+
+```shell
+curl localhost:9000/summary/by_name/Test%20Testsson
+```
 
 ## Deploying
 

--- a/samples/java-spring-valueentity-customer-registry/README.md
+++ b/samples/java-spring-valueentity-customer-registry/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercise the service
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 * Create a customer with:
 

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -136,32 +136,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -224,16 +224,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-               <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-valueentity-shopping-cart/README.md
+++ b/samples/java-spring-valueentity-shopping-cart/README.md
@@ -1,14 +1,16 @@
-# java-spring-valueentity-shoppingcart
+# Value Entity Shopping Cart
 
-
+## Designing
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
 
+## Developing
 
+This project demonstrates the use of Value Entity and View components.
+To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
+and in particular the [Java section](https://docs.kalix.io/java/)
 
-This project contains the framework to create a Kalix application by adding Kalix components. To understand more about these components, see [Developing services](https://docs.kalix.io/services/). Spring-SDK is an experimental feature and so far there is no [official](https://docs.kalix.io/) documentation. Examples can be found [here](https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples) in the folders with "spring" in their name.
-
-
+## Building
 
 Use Maven to build your project:
 
@@ -16,26 +18,21 @@ Use Maven to build your project:
 mvn compile
 ```
 
+## Running Locally
 
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
-
-```shell
-docker-compose up
-```
-
-To start the application locally, the `spring-boot-maven-plugin` is used. Use the following command:
+To start the applications locally, call the following command:
 
 ```shell
-mvn spring-boot:run
+mvn kalix:runAll
 ```
+
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the service
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`. 
-
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 * Adding a new item:
 

--- a/samples/java-spring-valueentity-shopping-cart/README.md
+++ b/samples/java-spring-valueentity-shopping-cart/README.md
@@ -20,19 +20,19 @@ mvn compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the service
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 * Adding a new item:
 

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -185,6 +185,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -225,7 +225,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -140,32 +140,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -229,16 +229,6 @@
         </configuration>
       </plugin>
       <plugin>
-       <groupId>org.springframework.boot</groupId>
-       <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-            <systemPropertyVariables>
-                <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-                <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-            </systemPropertyVariables>
-          </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0-M1</version>

--- a/samples/java-spring-view-store/README.md
+++ b/samples/java-spring-view-store/README.md
@@ -4,19 +4,19 @@ A simple store example with products, customers, and orders.
 
 Used for code snippets in the Views documentation.
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 mvn kalix:runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 ## Exercising the services
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
+With both the proxy and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 Create some products:
 

--- a/samples/java-spring-view-store/README.md
+++ b/samples/java-spring-view-store/README.md
@@ -14,9 +14,9 @@ mvn kalix:runAll
 
 This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
-
 ## Exercising the services
+
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
 Create some products:
 

--- a/samples/java-spring-view-store/README.md
+++ b/samples/java-spring-view-store/README.md
@@ -4,48 +4,23 @@ A simple store example with products, customers, and orders.
 
 Used for code snippets in the Views documentation.
 
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-## Developing
+To start the applications locally, call the following command:
 
-This project demonstrates the use of advanced View components, with Event Sourced Entities and Value Entities.
-
-To understand more about these components, see [developing services](https://docs.kalix.io/services/)
-and in particular the [developing with Spring section](https://docs.kalix.io/spring/).
-
-
-## Building
-
-Use Maven to build your project:
-
-```
-mvn compile
+```shell
+mvn kalix:runAll
 ```
 
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-## Running Locally
+With both the proxy and your application running, once you have defined endpoints they should be available at `http://localhost:9000`.
 
-To run the example locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
-
-```
-docker-compose up
-```
-
-To start the application locally, use the following command:
-
-```
-mvn spring-boot:run
-```
-
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. 
-
-
-### Exercising the services
+## Exercising the services
 
 Create some products:
 
-```
+```shell
 curl localhost:9000/product/P123/create \
   -XPOST \
   --header "Content-Type: application/json" \
@@ -55,7 +30,7 @@ curl localhost:9000/product/P123/create \
   }'
 ```
 
-```
+```shell
 curl localhost:9000/product/P987/create \
   -XPOST \
   --header "Content-Type: application/json" \
@@ -67,13 +42,13 @@ curl localhost:9000/product/P987/create \
 
 Retrieve a product by id:
 
-```
+```shell
 curl localhost:9000/product/P123
 ```
 
 Create a customer:
 
-```
+```shell
 curl localhost:9000/customer/C001/create \
   -XPOST \
   --header "Content-Type: application/json" \
@@ -86,13 +61,13 @@ curl localhost:9000/customer/C001/create \
 
 Retrieve a customer by id:
 
-```
+```shell
 curl localhost:9000/customer/C001
 ```
 
 Create customer orders for the products:
 
-```
+```shell
 curl localhost:9000/order/O1234/create \
   -XPOST \
   --header "Content-Type: application/json" \
@@ -103,7 +78,7 @@ curl localhost:9000/order/O1234/create \
   }'
 ```
 
-```
+```shell
 curl localhost:9000/order/O5678/create \
   -XPOST \
   --header "Content-Type: application/json" \
@@ -116,28 +91,27 @@ curl localhost:9000/order/O5678/create \
 
 Retrieve an order by id:
 
-```
+```shell
 curl localhost:9000/order/O5678
 ```
 
 Retrieve all product orders for a customer id using a view (with joins):
 
-```
+```shell
 curl localhost:9000/joined-customer-orders/C001
 ```
 
 Retrieve all product orders for a customer id using a view (with joins and nested projection):
 
-```
+```shell
 curl localhost:9000/nested-customer-orders/C001
 ```
 
 Retrieve all product orders for a customer id using a view (with joins and structured projection):
 
-```
+```shell
 curl localhost:9000/structured-customer-orders/C001
 ```
-
 
 ## Deploying
 

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -207,17 +207,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-              <logging.config>src/main/resources/logback-dev-mode.xml</logging.config>
-              <kalix.user-function-interface>0.0.0.0</kalix.user-function-interface>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -220,7 +220,6 @@
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
           <mainClass>${mainClass}</mainClass>
-          <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>
 

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -181,6 +181,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-plugin</artifactId>
         <version>${kalix-sdk.version}</version>

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -136,32 +136,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <classpath/>
-            <argument>-Dlogging.config=src/main/resources/logback-dev-mode.xml</argument>
-            <argument>${mainClass}</argument>
-          </arguments>
-          <environmentVariables>
-            <!-- needed for the proxy to access the user function on all platforms -->
-            <HOST>0.0.0.0</HOST>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <!-- configure src/it/java and src/it/resources -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/samples/scala-protobuf-customer-registry-quickstart/README.md
+++ b/samples/scala-protobuf-customer-registry-quickstart/README.md
@@ -34,7 +34,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/scala-protobuf-customer-registry-quickstart/README.md
+++ b/samples/scala-protobuf-customer-registry-quickstart/README.md
@@ -4,14 +4,11 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/developing/development-process-proto.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Value Entity and View components.
 To understand more about these components, see [Developing services](https://docs.kalix.io/services/)
 and in particular the [Scala section](https://docs.kalix.io/java/)
-
-
 
 ## Building and running unit tests
 
@@ -21,49 +18,53 @@ To compile and test the code from the command line, use
 sbt test
 ```
 
-
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
+## Exercise the service
+
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
-
 * Create a customer with:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
+```
+
 * Retrieve the customer:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
+```
+
 * Query by name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
+```
+
 * Change name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
+```
+
 * Change address:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
+```
 
 ## Deploying
 

--- a/samples/scala-protobuf-customer-registry-quickstart/README.md
+++ b/samples/scala-protobuf-customer-registry-quickstart/README.md
@@ -20,21 +20,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/scala-protobuf-eventsourced-counter/README.md
+++ b/samples/scala-protobuf-eventsourced-counter/README.md
@@ -1,6 +1,5 @@
 # Implementing a Counter as an Event Sourced Entity
 
-
 ## Building and running unit tests
 
 To compile and test the code from the command line, use
@@ -9,23 +8,17 @@ To compile and test the code from the command line, use
 sbt test
 ```
 
-
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -49,7 +42,7 @@ To deploy your service, install the `kalix` CLI as documented in
 [Setting up a local development environment](https://docs.kalix.io/setting-up/)
 and configure a Docker Registry to upload your docker image to.
 
-You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`. 
+You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.
 
 If you are publishing to a different registry than docker hub, you will also need to specify what registry using the system property `docker.registry`.
 
@@ -58,5 +51,4 @@ Refer to
 for more information on how to make your docker image available to Kalix.
 
 Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a Kalix project and then deploy your service into it 
-through the `kalix` CLI. 
+to create a Kalix project and then deploy your service into it through the `kalix` CLI.

--- a/samples/scala-protobuf-eventsourced-counter/README.md
+++ b/samples/scala-protobuf-eventsourced-counter/README.md
@@ -24,7 +24,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-eventsourced-counter/README.md
+++ b/samples/scala-protobuf-eventsourced-counter/README.md
@@ -10,21 +10,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/README.md
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/README.md
@@ -13,7 +13,7 @@ by a separate service, implemented in the `scala-protobuf-eventsourced-customer-
 
 First start the `scala-protobuf-eventsourced-customer-registry` service and proxy. It will run with the default service and proxy ports (`8080` and `9000`).
 
-To start the application locally, use the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
@@ -23,7 +23,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 ### Create a customer
 

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/README.md
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/README.md
@@ -4,7 +4,6 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/developing/development-process-proto.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates consumption of a Service to Service eventing publisher. It consumes events produced and published
@@ -16,9 +15,15 @@ First start the `scala-protobuf-eventsourced-customer-registry` service and prox
 
 To start the application locally, use the following command:
 
-```
+```shell
 sbt runAll
 ```
+
+For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
+
+## Exercise the service
+
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 ### Create a customer
 

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.9-M2
+    image: gcr.io/kalix-public/kalix-proxy:1.1.11
     depends_on:
       - kalix-proxy-customer-registry
     ports:
@@ -21,7 +21,7 @@ services:
       USER_FUNCTION_PORT: "8081"
 
   kalix-proxy-customer-registry:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.9-M2
+    image: gcr.io/kalix-public/kalix-proxy:1.1.11
     ports:
       - "9000:9000"
     extra_hosts:

--- a/samples/scala-protobuf-eventsourced-customer-registry/README.md
+++ b/samples/scala-protobuf-eventsourced-customer-registry/README.md
@@ -23,21 +23,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 * Create a customer with:
 

--- a/samples/scala-protobuf-eventsourced-customer-registry/README.md
+++ b/samples/scala-protobuf-eventsourced-customer-registry/README.md
@@ -4,7 +4,6 @@
 
 To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/developing/development-process-proto.html) in the documentation.
 
-
 ## Developing
 
 This project demonstrates the use of Event Sourced Entity, View and Service to Service eventing components.
@@ -14,68 +13,73 @@ and in particular the [Scala section](https://docs.kalix.io/java/)
 The project scala-customer-registry-subscriber is a downstream consumer of the Service to Service event stream
 provided by this service.
 
-
 ## Building and running unit tests
 
 To compile and test the code from the command line, use
 
 ```shell
 sbt test
-```
-
-
+``
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. 
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 * Create a customer with:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "vip", "email": "vip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "vip", "email": "vip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
+```
+
 * Retrieve the customer:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "vip"}' localhost:9000  customer.api.CustomerService/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "vip"}' localhost:9000  customer.api.CustomerService/GetCustomer
+```
+
 * Query by name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
+```
+
 * Change name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "vip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "vip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
+```
+
 * Change address:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "vip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "vip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
+```
+
 * Query the customer by name view:
-  ```shell
-  grpcurl --plaintext -d '{"customer_name":"Bob"}' localhost:9000 customer.view.CustomerByName/GetCustomers
-  ```
-  
+
+```shell
+grpcurl --plaintext -d '{"customer_name":"Bob"}' localhost:9000 customer.view.CustomerByName/GetCustomers
+```
+
 * Query the streaming customer by city (will stay running listing updates until cancelled with Ctrl+C):
-  ```shell
-  grpcurl --plaintext -d '{"city":"Stockholm"}' localhost:9000 customer.view.CustomerByCityStreaming/GetCustomers
-  ```
+
+```shell
+grpcurl --plaintext -d '{"city":"Stockholm"}' localhost:9000 customer.view.CustomerByCityStreaming/GetCustomers
+```
 
 ## Deploying
 
@@ -83,7 +87,7 @@ To deploy your service, install the `kalix` CLI as documented in
 [Setting up a local development environment](https://docs.kalix.io/setting-up/)
 and configure a Docker Registry to upload your docker image to.
 
-You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`. 
+You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.
 
 If you are publishing to a different registry than docker hub, you will also need to specify what registry using the system property `docker.registry`.
 
@@ -92,5 +96,4 @@ Refer to
 for more information on how to make your docker image available to Kalix.
 
 Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a Kalix project and then deploy your service into it 
-through the `kalix` CLI. 
+to create a Kalix project and then deploy your service into it through the `kalix` CLI.

--- a/samples/scala-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/README.md
@@ -36,7 +36,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST
-requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Send an AddItem command:
 

--- a/samples/scala-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/README.md
@@ -19,21 +19,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`.
 In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (
 see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST
 requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.

--- a/samples/scala-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/README.md
@@ -17,22 +17,17 @@ To compile and test the code from the command line, use
 sbt test
 ```
 
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -69,14 +64,13 @@ grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppin
 grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "kalix-tshirt" }' localhost:9000 com.example.shoppingcart.ShoppingCartService/RemoveItem
 ```
 
-
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
 [Setting up a local development environment](https://docs.kalix.io/setting-up/)
 and configure a Docker Registry to upload your docker image to.
 
-You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`. 
+You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.
 
 If you are publishing to a different registry than docker hub, you will also need to specify what registry using the system property `docker.registry`.
 
@@ -85,5 +79,4 @@ Refer to
 for more information on how to make your docker image available to Kalix.
 
 Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a Kalix project and then deploy your service into it 
-through the `kalix` CLI. 
+to create a Kalix project and then deploy your service into it through the `kalix` CLI.

--- a/samples/scala-protobuf-fibonacci-action/README.md
+++ b/samples/scala-protobuf-fibonacci-action/README.md
@@ -10,21 +10,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.fibonacci.Fibonacci/NextNumber -d '{"value": 5 }'

--- a/samples/scala-protobuf-fibonacci-action/README.md
+++ b/samples/scala-protobuf-fibonacci-action/README.md
@@ -1,6 +1,5 @@
 # Fibonacci Action Service
 
-
 ## Building and running unit tests
 
 To compile and test the code from the command line, use
@@ -9,23 +8,17 @@ To compile and test the code from the command line, use
 sbt test
 ```
 
-
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -49,7 +42,7 @@ To deploy your service, install the `kalix` CLI as documented in
 [Setting up a local development environment](https://docs.kalix.io/setting-up/)
 and configure a Docker Registry to upload your docker image to.
 
-You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`. 
+You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.
 
 If you are publishing to a different registry than docker hub, you will also need to specify what registry using the system property `docker.registry`.
 
@@ -58,5 +51,4 @@ Refer to
 for more information on how to make your docker image available to Kalix.
 
 Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a Kalix project and then deploy your service into it 
-through the `kalix` CLI. 
+to create a Kalix project and then deploy your service into it through the `kalix` CLI.

--- a/samples/scala-protobuf-fibonacci-action/README.md
+++ b/samples/scala-protobuf-fibonacci-action/README.md
@@ -24,7 +24,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.fibonacci.Fibonacci/NextNumber -d '{"value": 5 }'

--- a/samples/scala-protobuf-first-service/README.md
+++ b/samples/scala-protobuf-first-service/README.md
@@ -21,21 +21,21 @@ sbt compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 ```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-first-service/README.md
+++ b/samples/scala-protobuf-first-service/README.md
@@ -15,29 +15,29 @@ and in particular the [JVM section](https://docs.kalix.io/java/)
 You can use [sbt](https://www.scala-sbt.org/) to build your project,
 which will also take care of generating code based on the `.proto` definitions:
 
-```
+```shell
 sbt compile
 ```
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, start it from your IDE or use:
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-```
-sbt run
-```
+For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+## Exercise the service
 
-```
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+
+```shell
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'
 The command handler for `GetCurrentCounter` is not implemented, yet
 ```
@@ -62,7 +62,7 @@ and configure a Docker Registry to upload your docker image to.
 
 You will need to set your `docker.username` as a system property:
 
-```
+```shell
 sbt -Ddocker.username=mary Docker/publish
 ```
 

--- a/samples/scala-protobuf-reliable-timers/README.md
+++ b/samples/scala-protobuf-reliable-timers/README.md
@@ -24,7 +24,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/PlaceOrder -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/scala-protobuf-reliable-timers/README.md
+++ b/samples/scala-protobuf-reliable-timers/README.md
@@ -10,21 +10,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/PlaceOrder -d '{ "item":"Pizza Margherita", "quantity":1 }'

--- a/samples/scala-protobuf-reliable-timers/README.md
+++ b/samples/scala-protobuf-reliable-timers/README.md
@@ -8,23 +8,17 @@ To compile and test the code from the command line, use
 sbt test
 ```
 
-
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -39,7 +33,6 @@ curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actio
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/Confirm -d '{ "number" : "returned-order-number" }'
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.actions.Order/Cancel -d '{ "number" : "returned-order-number" }'
 ```
-
 
 Or, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 
@@ -57,7 +50,7 @@ To deploy your service, install the `kalix` CLI as documented in
 [Setting up a local development environment](https://docs.kalix.io/setting-up/)
 and configure a Docker Registry to upload your docker image to.
 
-You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`. 
+You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.
 
 If you are publishing to a different registry than docker hub, you will also need to specify what registry using the system property `docker.registry`.
 
@@ -66,5 +59,4 @@ Refer to
 for more information on how to make your docker image available to Kalix.
 
 Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a Kalix project and then deploy your service into it 
-through the `kalix` CLI. 
+to create a Kalix project and then deploy your service into it through the `kalix` CLI.

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
@@ -23,21 +23,21 @@ sbt compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 * Send an AddItem command:
 

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
@@ -1,6 +1,7 @@
 # Shopping Cart example (using a Replicated Entity)
 
 This example project implements an API for a shopping cart using a Kalix Replicated Entity.
+
 ## Designing
 
 While designing your service it is useful to read [designing services](https://docs.kalix.io/developing/development-process-proto.html)
@@ -16,30 +17,27 @@ and in particular the [JVM section](https://docs.kalix.io/java/)
 You can use [sbt](https://www.scala-sbt.org/) to build your project,
 which will also take care of generating code based on the `.proto` definitions:
 
-```
+```shell
 sbt compile
 ```
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-> On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
-> or for a `USER_FUNCTION_HOST` environment variable to be set manually.
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-To start the application locally, start it from your IDE or use:
+For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
-```
-sbt run
-```
+## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 * Send an AddItem command:
 
@@ -67,7 +65,6 @@ grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppin
 grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "kalix-tshirt", "name": "Kalix t-shirt" }' localhost:9000 com.example.shoppingcart.ShoppingCartService/RemoveItem
 ```
 
-
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
@@ -76,7 +73,7 @@ and configure a Docker Registry to upload your docker image to.
 
 You will need to set your `docker.username` as a system property:
 
-```
+```shell
 sbt -Ddocker.username=mary Docker/publish
 ```
 

--- a/samples/scala-protobuf-valueentity-counter/README.md
+++ b/samples/scala-protobuf-valueentity-counter/README.md
@@ -1,6 +1,5 @@
 # Implementing a Counter as a Value Entity
 
-
 ## Building and running unit tests
 
 To compile and test the code from the command line, use
@@ -9,23 +8,17 @@ To compile and test the code from the command line, use
 sbt test
 ```
 
-
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -49,7 +42,7 @@ To deploy your service, install the `kalix` CLI as documented in
 [Setting up a local development environment](https://docs.kalix.io/setting-up/)
 and configure a Docker Registry to upload your docker image to.
 
-You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`. 
+You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.
 
 If you are publishing to a different registry than docker hub, you will also need to specify what registry using the system property `docker.registry`.
 
@@ -58,5 +51,4 @@ Refer to
 for more information on how to make your docker image available to Kalix.
 
 Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a Kalix project and then deploy your service into it 
-through the `kalix` CLI. 
+to create a Kalix project and then deploy your service into it through the `kalix` CLI.

--- a/samples/scala-protobuf-valueentity-counter/README.md
+++ b/samples/scala-protobuf-valueentity-counter/README.md
@@ -24,7 +24,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-valueentity-counter/README.md
+++ b/samples/scala-protobuf-valueentity-counter/README.md
@@ -10,21 +10,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ```shell
 curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'

--- a/samples/scala-protobuf-valueentity-customer-registry/README.md
+++ b/samples/scala-protobuf-valueentity-customer-registry/README.md
@@ -24,7 +24,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/scala-protobuf-valueentity-customer-registry/README.md
+++ b/samples/scala-protobuf-valueentity-customer-registry/README.md
@@ -10,21 +10,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Create a customer with:
 

--- a/samples/scala-protobuf-valueentity-customer-registry/README.md
+++ b/samples/scala-protobuf-valueentity-customer-registry/README.md
@@ -1,6 +1,5 @@
 # Customer Registry example (using a Value Entity)
 
-
 ## Building and running unit tests
 
 To compile and test the code from the command line, use
@@ -9,23 +8,17 @@ To compile and test the code from the command line, use
 sbt test
 ```
 
-
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
@@ -34,25 +27,34 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 * Create a customer with:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "email": "wip@example.com", "name": "Very Important", "address": {"street": "Road 1", "city": "The Capital"}}' localhost:9000  customer.api.CustomerService/Create
+```
+
 * Retrieve the customer:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip"}' localhost:9000  customer.api.CustomerService/GetCustomer
+```
+
 * Query by name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_name": "Very Important"}' localhost:9000 customer.view.CustomerByName/GetCustomers
+```
+
 * Change name:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_name": "Most Important"}' localhost:9000 customer.api.CustomerService/ChangeName
+```
+
 * Change address:
-  ```shell
-  grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
-  ```
+
+```shell
+grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street 1", "city": "The City"}}' localhost:9000 customer.api.CustomerService/ChangeAddress
+```
 
 ## Deploying
 
@@ -60,7 +62,7 @@ To deploy your service, install the `kalix` CLI as documented in
 [Setting up a local development environment](https://docs.kalix.io/setting-up/)
 and configure a Docker Registry to upload your docker image to.
 
-You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`. 
+You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.
 
 If you are publishing to a different registry than docker hub, you will also need to specify what registry using the system property `docker.registry`.
 
@@ -69,5 +71,4 @@ Refer to
 for more information on how to make your docker image available to Kalix.
 
 Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a Kalix project and then deploy your service into it 
-through the `kalix` CLI. 
+to create a Kalix project and then deploy your service into it through the `kalix` CLI.

--- a/samples/scala-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-valueentity-shopping-cart/README.md
@@ -37,7 +37,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Send an AddItem command:
 

--- a/samples/scala-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-valueentity-shopping-cart/README.md
@@ -1,6 +1,7 @@
 # Shopping Cart example (using a Value Entity)
 
 This example project implements an API for a shopping cart using a Kalix Value Entity.
+
 ## Designing
 
 While designing your service it is useful to read [designing services](https://docs.kalix.io/developing/development-process-proto.html)
@@ -16,28 +17,25 @@ and in particular the [JVM section](https://docs.kalix.io/java/)
 You can use [sbt](https://www.scala-sbt.org/) to build your project,
 which will also take care of generating code based on the `.proto` definitions:
 
-```
+```shell
 sbt compile
 ```
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-> On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
-> or for a `USER_FUNCTION_HOST` environment variable to be set manually.
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-To start the application locally, start it from your IDE or use:
+For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
-```
-sbt run
-```
+## Exercise the service
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
@@ -67,7 +65,6 @@ grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppin
 grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "kalix-tshirt", "name": "Kalix t-shirt" }' localhost:9000 com.example.shoppingcart.ShoppingCartService/RemoveItem
 ```
 
-
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
@@ -76,7 +73,7 @@ and configure a Docker Registry to upload your docker image to.
 
 You will need to set your `docker.username` as a system property:
 
-```
+```shell
 sbt -Ddocker.username=mary Docker/publish
 ```
 

--- a/samples/scala-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-valueentity-shopping-cart/README.md
@@ -23,21 +23,21 @@ sbt compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 * Send an AddItem command:
 

--- a/samples/scala-protobuf-view-store/README.md
+++ b/samples/scala-protobuf-view-store/README.md
@@ -4,43 +4,37 @@ A simple store example with products, customers, and orders.
 
 Used for code snippets in the Views documentation.
 
-
 ## Building
 
 You can use [sbt](https://www.scala-sbt.org/) to build this project,
 which will also take care of generating code based on the `.proto` definitions:
 
-```
+```shell
 sbt compile
 ```
 
-
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker-compose.yml` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
 
-```
-docker-compose up
-```
+To start the applications locally, call the following command:
 
-> On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
-> or for a `USER_FUNCTION_HOST` environment variable to be set manually.
-
-To start the application locally, start it from your IDE or use:
-
-```
-sbt run
+```shell
+sbt runAll
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
-### Exercising the services
+For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
+
+## Exercise the service
+
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+
 
 Create some products:
 
-```
+```shell
 grpcurl -d '{
     "productId": "P123",
     "productName": "Super Duper Thingamajig",
@@ -50,7 +44,7 @@ grpcurl -d '{
   store.product.api.Products/Create
 ```
 
-```
+```shell
 grpcurl -d '{
     "productId": "P987",
     "productName": "Awesome Whatchamacallit",
@@ -62,7 +56,7 @@ grpcurl -d '{
 
 Retrieve a product by id:
 
-```
+```shell
 grpcurl -d '{"productId": "P123"}' \
   --plaintext localhost:9000 \
   store.product.api.Products/Get
@@ -70,7 +64,7 @@ grpcurl -d '{"productId": "P123"}' \
 
 Create a customer:
 
-```
+```shell
 grpcurl -d '{
     "customerId": "C001",
     "email": "someone@example.com",
@@ -83,7 +77,7 @@ grpcurl -d '{
 
 Retrieve a customer by id:
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.customer.api.Customers/Get
@@ -91,7 +85,7 @@ grpcurl -d '{"customerId": "C001"}' \
 
 Create customer orders for the products:
 
-```
+```shell
 grpcurl -d '{
     "orderId": "O1234",
     "productId": "P123",
@@ -102,7 +96,7 @@ grpcurl -d '{
   store.order.api.Orders/Create
 ```
 
-```
+```shell
 grpcurl -d '{
     "orderId": "O5678",
     "productId": "P987",
@@ -115,7 +109,7 @@ grpcurl -d '{
 
 Retrieve an order by id:
 
-```
+```shell
 grpcurl -d '{"orderId": "O5678"}' \
   --plaintext localhost:9000 \
   store.order.api.Orders/Get
@@ -123,7 +117,7 @@ grpcurl -d '{"orderId": "O5678"}' \
 
 Retrieve all product orders for a customer id using a view (with joins):
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.view.joined.JoinedCustomerOrders/Get
@@ -131,7 +125,7 @@ grpcurl -d '{"customerId": "C001"}' \
 
 Retrieve all product orders for a customer id using a view (with joins and nested projection):
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.view.nested.NestedCustomerOrders/Get
@@ -139,12 +133,11 @@ grpcurl -d '{"customerId": "C001"}' \
 
 Retrieve all product orders for a customer id using a view (with joins and structured projection):
 
-```
+```shell
 grpcurl -d '{"customerId": "C001"}' \
   --plaintext localhost:9000 \
   store.view.structured.StructuredCustomerOrders/Get
 ```
-
 
 ## Deploying
 
@@ -154,7 +147,7 @@ and configure a Docker Registry to upload your Docker image to.
 
 You will need to set your `docker.username` as a system property:
 
-```
+```shell
 sbt -Ddocker.username=mary docker:publish
 ```
 
@@ -163,7 +156,7 @@ for more information on how to make your Docker image available to Kalix.
 
 You can now deploy your service through the [kalix](https://docs.kalix.io/kalix/using-cli.html) CLI:
 
-```
+```shell
 $ kalix auth login
 ```
 
@@ -172,7 +165,7 @@ register an account, create your first project and set it as the default.
 
 Now:
 
-```
+```shell
 $ kalix services deploy \
     my-service \
     my-container-uri/container-name:tag-name
@@ -181,13 +174,13 @@ $ kalix services deploy \
 Once the service has been successfully started (this may take a while),
 you can create an ad-hoc proxy to call it from your local machine:
 
-```
+```shell
 $ kalix services proxy my-service
 Listening on 127.0.0.1:8080
 ```
 
 Or expose it to the Internet:
 
-```
+```shell
 kalix service expose my-service
 ```

--- a/samples/scala-protobuf-view-store/README.md
+++ b/samples/scala-protobuf-view-store/README.md
@@ -15,21 +15,21 @@ sbt compile
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`.
 
 
 Create some products:

--- a/samples/scala-protobuf-web-resources/README.md
+++ b/samples/scala-protobuf-web-resources/README.md
@@ -12,21 +12,21 @@ sbt test
 
 ## Running Locally
 
-When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+When running a Kalix service locally, we need to have its companion Kalix Proxy running alongside it.
 
-To start the applications locally, call the following command:
+To start your service locally, run:
 
 ```shell
 sbt runAll
 ```
 
-This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
+This command will start your Kalix service and a companion Kalix Proxy as configured in [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
+With both the proxy and your service running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ## Deploying
 

--- a/samples/scala-protobuf-web-resources/README.md
+++ b/samples/scala-protobuf-web-resources/README.md
@@ -26,7 +26,7 @@ For further details see [Running a service locally](https://docs.kalix.io/develo
 
 ## Exercise the service
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`.
 
 ## Deploying
 

--- a/samples/scala-protobuf-web-resources/README.md
+++ b/samples/scala-protobuf-web-resources/README.md
@@ -12,25 +12,21 @@ sbt test
 
 ## Running Locally
 
-In order to run your application locally, you must run the Kalix proxy. The included `docker compose` file contains the configuration required to run the proxy for a locally running application.
-It also contains the configuration to start a local Google Pub/Sub emulator that the Kalix proxy will connect to.
-To start the proxy, run the following command from this directory:
+When running a Kalix application locally, at least two applications are required. The current Kalix application and its companion Kalix Proxy.
+
+To start the applications locally, call the following command:
 
 ```shell
-docker-compose up
+sbt runAll
 ```
 
-To start the application locally, use the following command:
-
-```
-sbt run
-```
+This command will start your Kalix application and a Kalix Proxy using the included [docker-compose.yml](./docker-compose.yml) file.
 
 For further details see [Running a service locally](https://docs.kalix.io/developing/running-service-locally.html) in the documentation.
 
 ## Exercise the service
 
-With both the proxy and your application running open `http://localhost:9000/` in your local browser.
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java-protobuf/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ## Deploying
 


### PR DESCRIPTION
Still in progress, so draft for now.

For the docs, we need to revisit how we present it. 

Scala Protobuf SDK shares a page with Java Protobuf and it contains a section about docker-compose. 

We still need such a section, but `docker-compose` becomes optional for Java now. Of course, the plan is to make it optional for `sbt run`, but we are not there yet.

Also, we must instruct users how to run `kalix:run` in combination with `docker-compose` in case they prefer so. 