### PR TITLE
fix: always use host.docker.internal in container

### DIFF
--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/HostAndPort.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/HostAndPort.scala
@@ -18,23 +18,28 @@ package kalix.javasdk.impl
 
 object HostAndPort {
 
-  private val HostPortPattern = """(.+):(\d+)""".r
-  private val PortPattern = """(\d+)""".r
+  private val HostPortPattern = """([\w+\-_.]+):(\d{1,5})""".r
+  private val PortPattern = """(\d{1,5})""".r
+
+  // regex to match from 1 to 99999
+  // private val PortPattern = """(\d{1,5})""".r
 
   /**
    * When running locally, users can configure service port mappings associating a name and a port. In such a case, we
-   * will resolve to 0.0.0.0:port and that just enough. However, when build a docker-compose file containing more than
-   * one service, the config will need to include the docker host address, for example:
+   * will resolve to 0.0.0.0:port and that's just enough. However, when building a docker-compose file containing more
+   * than one service, the config will need to include the docker host address, for example:
    * -Dkalix.dev-mode.service-port-mappings.my-service=host.docker.internal:9001
    *
    * We should not default to host.docker.internal because it might depend on docker environment, for example: Docker
    * Desktop, Podman, Colima, Linux, etc.
    */
-  def extract(hostPort: String): (String, Int) =
+  def extract(hostPort: String): (String, Int) = {
+    def isValidPort(port: String): Boolean = port.toInt >= 0 && port.toInt <= 65535
     hostPort match {
-      case HostPortPattern(h, p) => (h, p.toInt)
-      case PortPattern(p)        => ("0.0.0.0", p.toInt)
+      case HostPortPattern(h, p) if isValidPort(p) => (h, p.toInt)
+      case PortPattern(p) if isValidPort(p)        => ("0.0.0.0", p.toInt)
       case _ =>
         throw new IllegalArgumentException(s"Invalid service port mapping: $hostPort")
     }
+  }
 }

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/HostAndPortSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/HostAndPortSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.javasdk.impl
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class HostAndPortSpec extends AnyWordSpec with Matchers {
+
+  "HostAndPort util" should {
+
+    "extract host and port from 'somehost:9001'" in {
+      val (host, port) = HostAndPort.extract("somehost:9001")
+      host shouldBe "somehost"
+      port shouldBe 9001
+    }
+
+    "extract host and port from 'some.host:9001'" in {
+      val (host, port) = HostAndPort.extract("some.host:9001")
+      host shouldBe "some.host"
+      port shouldBe 9001
+    }
+
+    "extract port from '9001'" in {
+      val (host, port) = HostAndPort.extract("9001")
+      host shouldBe "0.0.0.0"
+      port shouldBe 9001
+    }
+
+    "throw IllegalArgumentException if port is invalid" in {
+      List("", "-1", "-81", "65536", "123456", "1234567890")
+        .foreach { port =>
+          intercept[IllegalArgumentException] {
+            println(s">=> DEBUG: => ${HostAndPort.extract(port)}")
+          }
+        }
+    }
+
+    "throw IllegalArgumentException if host:port is invalid" in {
+
+      List(
+        "localhost-5678", // dash
+        "localhost:-5678", // negative port
+        "localhost", // no port
+        "foo.bar.com",
+        "localhost|5678", // pipe
+        "localhost:port", // not number
+        "localhost;1234", // semi-colon
+        "localhost:123456", // port too large
+        "localhost:1234:4321", // double colon
+        "localhost:65536").foreach { hostPort =>
+        intercept[IllegalArgumentException] {
+          HostAndPort.extract(hostPort)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ensure that `host.docker.internal` is used to resolve host in container