### PR TITLE
chore: run Scripted Tests as GH workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,20 +262,6 @@ jobs:
           command: sbt javaSdkSpring/IntegrationTest/test
       - save_deps_cache
 
-  scripted-tests:
-    docker:
-      - image: cimg/openjdk:11.0
-    description: "sbt plugin scripted tests"
-    steps:
-      - checkout-and-merge-to-main
-      - setup_sbt
-      - restore_deps_cache
-      - run:
-          name: Run tests
-          # would be nice to just depend on publish-local but that's slow because of maven part
-          command: sbt coreSdk/publishLocal javaSdkProtobuf/publishLocal scalaSdkProtobuf/publishLocal javaSdkProtobufTestKit/publishLocal scalaSdkProtobufTestKit/publishLocal scripted
-      - save_deps_cache
-
   tck-tests:
     machine:
       image: ubuntu-2004:202201-02

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,9 +443,6 @@ workflows:
       - tests:
           requires:
             - checks
-      - scripted-tests:
-          requires:
-            - checks
 
       - tck-tests:
           requires:

--- a/.github/workflows/scripted-tests.yml
+++ b/.github/workflows/scripted-tests.yml
@@ -1,0 +1,39 @@
+name: Scripted Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  fossa:
+    name: Fossa
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        # https://github.com/actions/checkout/releases
+        # v3.5.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+
+      - name: Cache Coursier cache
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.3
+        uses: coursier/cache-action@566e01fea33492e5a89706b43fb0d3fc884154f9
+
+      - name: Set up JDK 17
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.3
+        uses: coursier/setup-action@6a582d7f7292a865e72c497ca64c3ef447cdb6c7
+        with:
+          jvm: temurin:1.17
+
+      - name: sbt scripted
+        run: |-
+          # would be nice to just depend on publish-local but that's slow because of maven part
+          sbt coreSdk/publishLocal javaSdkProtobuf/publishLocal scalaSdkProtobuf/publishLocal javaSdkProtobufTestKit/publishLocal scalaSdkProtobufTestKit/publishLocal scripted


### PR DESCRIPTION
I'm a bit surprised Circle used the JDK11 image.