### PR TITLE
feat: pass service port mappings to KalixTestKit

### DIFF
--- a/devtools/src/main/scala/kalix/devtools/impl/KalixProxyContainer.scala
+++ b/devtools/src/main/scala/kalix/devtools/impl/KalixProxyContainer.scala
@@ -109,7 +109,7 @@ class KalixProxyContainer private (image: DockerImageName, config: KalixProxyCon
     }
 
   private val finalArgs = containerArgs ++ eventingArgs ++ servicePortMappingsArgs
-  withCommand(finalArgs: _*)
+  withEnv("JAVA_TOOL_OPTIONS", finalArgs.mkString(""))
 
   private val kafkaBootstrapServers: Option[String] =
     config.brokerConfigFile.flatMap { file =>

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -167,9 +167,9 @@ public class KalixTestKit {
      * Add a service port mapping from serviceName to host:port.
      * @return The updated settings.
      */
-    public Settings withServicePortMapping(String serviceName, String hostAndPort) {
+    public Settings withServicePortMapping(String serviceName, String host, int port) {
       var updatedMappings = new HashMap<>(servicePortMappings);
-      updatedMappings.put(serviceName, hostAndPort);
+      updatedMappings.put(serviceName, host + ":" + port);
       return new Settings(stopTimeout, serviceName, aclEnabled, advancedViews, workflowTickInterval, Map.copyOf(updatedMappings));
     }
 

--- a/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/KalixTestKit.scala
+++ b/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/KalixTestKit.scala
@@ -50,6 +50,8 @@ object KalixTestKit {
     def withAclDisabled(): Settings = new Settings(jSettings.withAclDisabled())
     def withAclEnabled(): Settings = new Settings(jSettings.withAclEnabled())
     def withAdvancedViews(): Settings = new Settings(jSettings.withAdvancedViews())
+    def withServicePortMapping(serviceName: String, hostPort: String): Settings =
+      new Settings(jSettings.withServicePortMapping(serviceName, hostPort))
   }
 
   val DefaultSettings: Settings = new Settings(JTestKit.Settings.DEFAULT)

--- a/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/KalixTestKit.scala
+++ b/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/KalixTestKit.scala
@@ -50,8 +50,8 @@ object KalixTestKit {
     def withAclDisabled(): Settings = new Settings(jSettings.withAclDisabled())
     def withAclEnabled(): Settings = new Settings(jSettings.withAclEnabled())
     def withAdvancedViews(): Settings = new Settings(jSettings.withAdvancedViews())
-    def withServicePortMapping(serviceName: String, hostPort: String): Settings =
-      new Settings(jSettings.withServicePortMapping(serviceName, hostPort))
+    def withServicePortMapping(serviceName: String, host: String, port: Int): Settings =
+      new Settings(jSettings.withServicePortMapping(serviceName, host, port))
   }
 
   val DefaultSettings: Settings = new Settings(JTestKit.Settings.DEFAULT)


### PR DESCRIPTION
This is needed to make the ubiquitous shopping cart work. This app will listen to itself through s2s and therefore we should be able to configure the proxy correctly from inside the KalixTestKit.

