### PR TITLE
chore: move sys props to JAVA_TOOL_OPTIONS section

### DIFF
--- a/docs/src/modules/java/pages/access-control.adoc
+++ b/docs/src/modules/java/pages/access-control.adoc
@@ -124,7 +124,6 @@ When running a service during local development, it may be useful to enable ACL 
 ```yaml
 kalix-proxy:
   image: gcr.io/kalix-public/kalix-proxy:latest
-  command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
   ports:
     - "9000:9000"
   environment:
@@ -144,7 +143,6 @@ If running multiple services in local development, you may want to run with ACLs
 ```yaml
 kalix-proxy:
   image: gcr.io/kalix-public/kalix-proxy:latest
-  command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
   ports:
     - "9000:9000"
   environment:

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -1,17 +1,19 @@
 #[[
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -1,17 +1,19 @@
 #[[
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -1,17 +1,19 @@
 #[[
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -1,17 +1,19 @@
 #[[
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
@@ -2,12 +2,15 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=kafka
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=kafka
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       BROKER_CONFIG_FILE: /conf/my-local.kafka.properties

--- a/samples/java-protobuf-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-quickstart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-eventsourced-counter/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-counter/docker-compose.yml
@@ -2,12 +2,15 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=google-pubsub-emulator
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -1,15 +1,16 @@
 version: "3"
 services:
   # note the ports being different from other sample docker-compose files to allow this service to run
-  # on the same local machine as the scala-customer-registry-
+  # on the same local machine as the java-protobuf-eventsourced-customer-registry
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.http-port=9001 -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
-      - "9001:9001"
+      - "9001:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8081}
-# no google pub/sub to not conflict with producer service (and also no eventing out used in sample)

--- a/samples/java-protobuf-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry/docker-compose.yml
@@ -2,12 +2,15 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=google-pubsub-emulator
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-fibonacci-action/docker-compose.yml
+++ b/samples/java-protobuf-fibonacci-action/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-first-service/docker-compose.yml
+++ b/samples/java-protobuf-first-service/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-reliable-timers/docker-compose.yml
+++ b/samples/java-protobuf-reliable-timers/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-replicatedentity-examples/docker-compose.yml
+++ b/samples/java-protobuf-replicatedentity-examples/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-shopping-cart-quickstart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-valueentity-counter/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-counter/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-customer-registry/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-view-store/docker-compose.yml
+++ b/samples/java-protobuf-view-store/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Enable advanced view features locally (note: disabled in deployed services by default)

--- a/samples/java-protobuf-web-resources/docker-compose.yml
+++ b/samples/java-protobuf-web-resources/docker-compose.yml
@@ -2,11 +2,13 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.6
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}

--- a/samples/java-spring-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-spring-customer-registry-quickstart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-spring-customer-registry-views-quickstart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-doc-snippets/docker-compose.yml
+++ b/samples/java-spring-doc-snippets/docker-compose.yml
@@ -3,12 +3,15 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=google-pubsub-emulator
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-eventsourced-counter/docker-compose.yml
+++ b/samples/java-spring-eventsourced-counter/docker-compose.yml
@@ -2,12 +2,15 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=google-pubsub-emulator
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -4,12 +4,13 @@ services:
   # on the same local machine as the java-spring-customer-registry
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9001:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8081}
-# no google pub/sub to not conflict with producer service (and also no eventing out used in sample)

--- a/samples/java-spring-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/java-spring-eventsourced-customer-registry/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-spring-eventsourced-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-fibonacci-action/docker-compose.yml
+++ b/samples/java-spring-fibonacci-action/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-reliable-timers/docker-compose.yml
+++ b/samples/java-spring-reliable-timers/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-spring-shopping-cart-quickstart/docker-compose.yml
@@ -1,17 +1,19 @@
 
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-spring-transfer-workflow-compensation/docker-compose.yml
+++ b/samples/java-spring-transfer-workflow-compensation/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-transfer-workflow/docker-compose.yml
+++ b/samples/java-spring-transfer-workflow/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-valueentity-counter/docker-compose.yml
+++ b/samples/java-spring-valueentity-counter/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-spring-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-spring-valueentity-customer-registry/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-spring-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-spring-valueentity-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-view-store/docker-compose.yml
+++ b/samples/java-spring-view-store/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Enable advanced view features locally (note: disabled in deployed services by default)

--- a/samples/scala-protobuf-customer-registry-quickstart/docker-compose.yml
+++ b/samples/scala-protobuf-customer-registry-quickstart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-eventsourced-counter/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-counter/docker-compose.yml
@@ -2,12 +2,15 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=google-pubsub-emulator
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -4,12 +4,13 @@ services:
   # on the same local machine as the scala-customer-registry-
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.http-port=9001 -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
-      - "9001:9001"
+      - "9001:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8081}
-# no google pub/sub to not conflict with producer service (and also no eventing out used in sample)

--- a/samples/scala-protobuf-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry/docker-compose.yml
@@ -2,12 +2,15 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=google-pubsub-emulator
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-fibonacci-action/docker-compose.yml
+++ b/samples/scala-protobuf-fibonacci-action/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-first-service/docker-compose.yml
+++ b/samples/scala-protobuf-first-service/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-reliable-timers/docker-compose.yml
+++ b/samples/scala-protobuf-reliable-timers/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-replicatedentity-examples/docker-compose.yml
+++ b/samples/scala-protobuf-replicatedentity-examples/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-valueentity-counter/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-counter/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-valueentity-customer-registry/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-customer-registry/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-shopping-cart/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-view-store/docker-compose.yml
+++ b/samples/scala-protobuf-view-store/docker-compose.yml
@@ -1,16 +1,18 @@
 # If you're looking to use eventing with Google PubSub, to get an emulator running:
-# - uncomment property "-Dkalix.proxy.eventing.support=google-pubsub-emulator"
+# - add property "-Dkalix.proxy.eventing.support=google-pubsub-emulator" to the JAVA_TOOL_OPTIONS environment map under the kalix-proxy service
 # - uncomment the env var PUBSUB_EMULATOR_HOST and the section below for gcloud-pubsub-emulator service
 version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.8
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml #-Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Enable advanced view features locally (note: disabled in deployed services by default)

--- a/samples/scala-protobuf-web-resources/docker-compose.yml
+++ b/samples/scala-protobuf-web-resources/docker-compose.yml
@@ -2,11 +2,13 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.6
-    command: -Dconfig.resource=dev-mode.conf -Dlogback.configurationFile=logback-dev-mode.xml
     ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dconfig.resource=dev-mode.conf
+        -Dlogback.configurationFile=logback-dev-mode.xml
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}


### PR DESCRIPTION
This is in preparation for the changes to document `sbt runAll`/`mvn kalix:runAll`.

As the number of properties might grow, it's inconvenient to pass it as a single line. 

When we break it on different lines, we can't have uncommented lines. Typical for the google-pubsub-emulator. So, instead, we instruct how to add the PubSub extra property.

Last but not least, we should avoid using `command:` and prefer `JAVA_TOOL_OPTIONS`. The reason is that `command` works because of the way `sbt-native-pacakger` builds the docker image, but it's not necessarily a standard. If we want to pass `-D` properties to other JVM containers (for example one running the user function), then we need to use `JAVA_TOOL_OPTIONS`. 

As we document how to build a large docker-compose containing multiple proxies and user functions, we don't want to have two ways of passing `-D` properties. Therefore, we should standardize on `JAVA_TOOL_OPTIONS`


