### PR TITLE
chore: reference.conf - disable descriptor source

### DIFF
--- a/sdk/java-sdk-spring/src/main/resources/reference.conf
+++ b/sdk/java-sdk-spring/src/main/resources/reference.conf
@@ -1,0 +1,4 @@
+
+ # it doesn't make sense to try to load descriptor source for 
+ # the Java SDK, so better to just disable it
+kalix.discovery.protobuf-descriptor-with-source-info-path=disabled

--- a/sdk/java-sdk-spring/src/main/scala/kalix/spring/impl/KalixSpringApplication.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/spring/impl/KalixSpringApplication.scala
@@ -345,16 +345,7 @@ case class KalixSpringApplication(applicationContext: ApplicationContext, config
       }
     }
 
-  private lazy val kalixRunner = {
-    val finalConfig =
-      ConfigFactory
-        // it doesn't make sense to try to load descriptor source for
-        // the Java SDK, so better to just disable it
-        .parseString("kalix.discovery.protobuf-descriptor-with-source-info-path=disabled")
-        .withFallback(config)
-
-    kalix.createRunner(finalConfig)
-  }
+  private lazy val kalixRunner = kalix.createRunner(config)
 
   def start(): Future[Done] = {
     logger.info("Starting Kalix Application...")


### PR DESCRIPTION
This was already done inside the KalixSpringApplication, but it makes not sense to do it programmatically. Better to simply use the reference.conf. 

And it was also not working when running integration tests. We still could see a warning in the logs.

```java
2023-05-05 18:19:32,952 WARN  kalix.javasdk.impl.DiscoveryImpl - Source info descriptor [/protobuf/descriptor-sets/user-function.desc] not found on classpath. Reporting descriptor errors against source locations will be disabled. To fix this, ensure that the following configuration applied to the protobuf maven plugin:

<writeDescriptorSet>true</writeDescriptorSet>
<includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
<descriptorSetFileName>user-function.desc</descriptorSetFileName>

and also that the generated resources directory is included in the classpath:

  <build>
    <resources>
      <resource>
        <directory>${project.build.directory}/generated-resources</directory>
      </resource>
    </resources>
    ...
```

