### PR TITLE
chore: add auto-gen test to sample

### DIFF
--- a/samples/java-protobuf-eventsourced-customer-registry/src/test/java/customer/api/CustomerEventsServiceActionTest.java
+++ b/samples/java-protobuf-eventsourced-customer-registry/src/test/java/customer/api/CustomerEventsServiceActionTest.java
@@ -1,0 +1,46 @@
+package customer.api;
+
+import akka.stream.javadsl.Source;
+import customer.api.CustomerEventsApi;
+import customer.api.CustomerEventsServiceAction;
+import customer.api.CustomerEventsServiceActionTestKit;
+import customer.domain.CustomerDomain;
+import kalix.javasdk.testkit.ActionResult;
+import org.junit.Ignore;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CustomerEventsServiceActionTest {
+
+  @Test
+  @Ignore("to be implemented")
+  public void exampleTest() {
+    CustomerEventsServiceActionTestKit service = CustomerEventsServiceActionTestKit.of(CustomerEventsServiceAction::new);
+    // // use the testkit to execute a command
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ActionResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
+  }
+
+  @Test
+  @Ignore("to be implemented")
+  public void transformCustomerCreatedTest() {
+    CustomerEventsServiceActionTestKit testKit = CustomerEventsServiceActionTestKit.of(CustomerEventsServiceAction::new);
+    // ActionResult<CustomerEventsApi.Created> result = testKit.transformCustomerCreated(CustomerDomain.CustomerCreated.newBuilder()...build());
+  }
+
+  @Test
+  @Ignore("to be implemented")
+  public void transformCustomerNameChangedTest() {
+    CustomerEventsServiceActionTestKit testKit = CustomerEventsServiceActionTestKit.of(CustomerEventsServiceAction::new);
+    // ActionResult<CustomerEventsApi.NameChanged> result = testKit.transformCustomerNameChanged(CustomerDomain.CustomerNameChanged.newBuilder()...build());
+  }
+
+}


### PR DESCRIPTION
I'm splitting some of the things that I found along the work on eventing testkit into some more small bits.

This is about adding an auto-gen test that is missing on git and gets generated evry time one runs that sample.