### PR TITLE
fix: enable todos in dev

### DIFF
--- a/docs/dev/antora.yml
+++ b/docs/dev/antora.yml
@@ -17,6 +17,8 @@ runtime:
 
 asciidoc:
   attributes:
+    review: ''
+    todo: ''
     page-pagination: ''
     page-toctitle: 'On This Page'
 


### PR DESCRIPTION
Partially reverting #1625. 

These settings are used when building the docs locally in dev mode. Something else is enabling this in prod.