### PR TITLE
doc: view from topic documentation

### DIFF
--- a/docs/src/modules/java-protobuf/pages/service-to-service.adoc
+++ b/docs/src/modules/java-protobuf/pages/service-to-service.adoc
@@ -20,7 +20,7 @@ Java::
 [source,protobuf,indent=0]
 .src/main/proto/customer/api/direct_customer_events.proto
 ----
-include::example$java-protobuf-eventsourced-customer-registry/src/main/proto/customer/api/direct_customer_events.proto[tag=publisher]
+include::example$java-protobuf-eventsourced-customer-registry/src/main/proto/customer/api/customer_events.proto[tag=publisher]
 ----
 <1> `eventing.in` identifying which event sourced entity to publish events for.
 <2> Ignore any event types not handled by a method and move on with the event stream, rather than fail which is the default.
@@ -31,9 +31,9 @@ include::example$java-protobuf-eventsourced-customer-registry/src/main/proto/cus
 Scala::
 +
 [source,protobuf,indent=0]
-.src/main/proto/customer/api/direct_customer_events.proto
+.src/main/proto/customer/api/customer_events.proto
 ----
-include::example$scala-protobuf-eventsourced-customer-registry/src/main/proto/customer/api/direct_customer_events.proto[tag=publisher]
+include::example$scala-protobuf-eventsourced-customer-registry/src/main/proto/customer/api/customer_events.proto[tag=publisher]
 ----
 <1> `eventing.in` identifying which event sourced entity to publish events for.
 <2> Ignore any event types not handled by a method and move on with the event stream, rather than fail which is the default.

--- a/docs/src/modules/java-protobuf/pages/views.adoc
+++ b/docs/src/modules/java-protobuf/pages/views.adoc
@@ -321,7 +321,34 @@ include::example$scala-protobuf-eventsourced-customer-registry/src/main/scala/cu
 [#topic-view]
 == Creating a View from a topic
 
-The source of a View can be an eventing topic. You define it in the same way as shown in <<event-sourced-entity>> or <<value-entity>>, but leave out the `eventing.in` annotation in the Protobuf file.
+The source of a View can be a broker topic.
+You define it in the same way as shown in <<event-sourced-entity>> or <<value-entity>>.
+Note that, on your producer side you must manually pass the `ce-subject` metadata, required by the View component.
+
+[.tabset]
+Java::
++
+[source,proto,indent=0]
+.src/main/java/customer/api/CustomerEventsToTopicServiceAction.java
+----
+include::example$java-protobuf-eventsourced-customer-registry/src/main/java/customer/api/CustomerEventsToTopicServiceAction.java[tags=topic-publisher]
+----
+
+<1> The `ce-subject` attribute is the entity id.
+<2> The effect replies updated metadata together with the message payload.
+
+Scala::
++
+[source,proto,indent=0]
+.src/main/scala/customer/api/CustomerEventsToTopicServiceAction.java
+----
+include::example$scala-protobuf-eventsourced-customer-registry/src/main/java/customer/api/CustomerEventsToTopicServiceAction.java[tags=topic-publisher]
+----
+
+<1> The `ce-subject` attribute is the entity id.
+<2> The effect replies updated metadata together with the message payload.
+
+The View definition must set `eventing.in` to a given topic name.
 
 [.tabset]
 Java::
@@ -329,8 +356,9 @@ Java::
 [source,proto,indent=0]
 .src/main/proto/customer/view/customer_view.proto
 ----
-include::example$java-protobuf-eventsourced-customer-registry/src/main/proto/customer/view/customer_view.proto[tags=declarations;service-topic]
+include::example$java-protobuf-eventsourced-customer-registry-subscriber/src/main/proto/customer/view/customer_view.proto[tags=view-from-topic]
 ----
+
 <1> This is the only difference from <<event-sourced-entity>>.
 
 Scala::
@@ -338,8 +366,9 @@ Scala::
 [source,proto,indent=0]
 .src/main/proto/customer/view/customer_view.proto
 ----
-include::example$scala-protobuf-eventsourced-customer-registry/src/main/proto/customer/view/customer_view.proto[tags=declarations;service-topic]
+include::example$scala-protobuf-eventsourced-customer-registry-subscriber/src/main/proto/customer/view/customer_view.proto[tags=declarations;service-topic]
 ----
+
 <1> This is the only difference from <<event-sourced-entity>>.
 
 [#transform-results]

--- a/docs/src/modules/java-protobuf/pages/views.adoc
+++ b/docs/src/modules/java-protobuf/pages/views.adoc
@@ -321,9 +321,7 @@ include::example$scala-protobuf-eventsourced-customer-registry/src/main/scala/cu
 [#topic-view]
 == Creating a View from a topic
 
-The source of a View can be a broker topic.
-You define it in the same way as shown in <<event-sourced-entity>> or <<value-entity>>.
-Note that, on your producer side you must manually pass the `ce-subject` metadata, required by the View component.
+The source of a View can be a broker topic. You define it in the same way as shown in <<event-sourced-entity>> or <<value-entity>>. Note that, on your producer side you must manually pass the `ce-subject` metadata, required by the View component.
 
 [.tabset]
 Java::

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       JAVA_TOOL_OPTIONS: >
         -Dconfig.resource=dev-mode.conf
         -Dlogback.configurationFile=logback-dev-mode.xml
+        -Dkalix.proxy.eventing.support=google-pubsub-emulator
         -Dkalix.dev-mode.service-port-mappings.customer-registry=host.docker.internal:9000
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: "8081"
+      PUBSUB_EMULATOR_HOST: host.docker.internal

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/java/customer/Main.java
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/java/customer/Main.java
@@ -2,6 +2,7 @@ package customer;
 
 import customer.action.CustomerActionImpl;
 import customer.view.AllCustomersViewImpl;
+import customer.view.CustomerByNameFromTopicView;
 import kalix.javasdk.Kalix;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,8 @@ public final class Main {
     // `new Kalix()` instance.
     return KalixFactory.withComponents(
       AllCustomersViewImpl::new,
-      CustomerActionImpl::new);
+      CustomerActionImpl::new,
+      CustomerByNameFromTopicView::new);
   }
 
   public static void main(String[] args) throws Exception {

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/java/customer/view/CustomerByNameFromTopicView.java
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/java/customer/view/CustomerByNameFromTopicView.java
@@ -1,0 +1,60 @@
+package customer.view;
+
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import customer.api.PublisherApi;
+import kalix.javasdk.view.View;
+import kalix.javasdk.view.ViewContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+// This is the implementation for the View Service described in your customer/view/customer_view.proto file.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CustomerByNameFromTopicView extends AbstractCustomerByNameFromTopicView {
+
+  private static Logger log = LoggerFactory.getLogger(CustomerByNameFromTopicView.class);
+
+  public CustomerByNameFromTopicView(ViewContext context) {}
+
+  @Override
+  public CustomerViewModel.Customer emptyState() {
+    return CustomerViewModel.Customer.getDefaultInstance();
+  }
+
+  @Override
+  public View.UpdateEffect<CustomerViewModel.Customer> processCustomerCreated(
+      CustomerViewModel.Customer state,
+      PublisherApi.Created created) {
+    log.info("Customer {} created: {}", updateContext().eventSubject(), created);
+    Timestamp now = Timestamps.fromMillis(Instant.now().toEpochMilli());
+    return effects().updateState(CustomerViewModel.Customer.newBuilder()
+      .setCustomerId(created.getCustomerId())
+      .setName(created.getCustomerName())
+      .setEmail(created.getEmail())
+      .setUpdates(1)
+      .setCreated(now)
+      .setLastUpdate(now)
+      .build());
+  }
+
+  @Override
+  public View.UpdateEffect<CustomerViewModel.Customer> processCustomerNameChanged(
+      CustomerViewModel.Customer state,
+      PublisherApi.NameChanged nameChanged) {
+    log.info("Customer {} name changed: {}", updateContext().eventSubject(), nameChanged);
+    Timestamp now = Timestamps.fromMillis(Instant.now().toEpochMilli());
+    return effects().updateState(state.toBuilder()
+      .setName(nameChanged.getCustomerName())
+      .setUpdates(1)
+      .setLastUpdate(now)
+      .build());
+  }
+
+}
+

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/proto/customer/view/customer_view.proto
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/proto/customer/view/customer_view.proto
@@ -33,6 +33,11 @@ message Customer {
   google.protobuf.Timestamp created = 5;
   google.protobuf.Timestamp lastUpdate = 6;
 }
+
+message ByNameRequest {
+  string customer_name = 1;
+}
+
 // tag::view[]
 service AllCustomersView {
   option (kalix.codegen) = {
@@ -40,7 +45,7 @@ service AllCustomersView {
   };
 
   // consume events published by java-protobuf-eventsourced-customer-registry/CustomerEventsServiceAction
-  option (kalix.service).eventing.in.direct = { // <1>
+  option (kalix.service).eventing.in.direct = {// <1>
     service: "customer-registry" // <2>
     event_stream_id: "customer_events" // <3>
   };
@@ -64,3 +69,35 @@ service AllCustomersView {
   }
 }
 // end::view[]
+
+// tag::view-from-topic[]
+service CustomerByNameFromTopic {
+  option (kalix.codegen) = {
+    view: {}
+  };
+
+  rpc ProcessCustomerCreated(api.Created) returns (Customer) {
+    option (kalix.method).eventing.in = {
+      topic: "customer_events" // <1>
+    };
+    option (kalix.method).view.update = {
+      table: "customers"
+    };
+  }
+
+  rpc ProcessCustomerNameChanged(api.NameChanged) returns (Customer) {
+    option (kalix.method).eventing.in = {
+      topic: "customer_events"
+    };
+    option (kalix.method).view.update = {
+      table: "customers"
+    };
+  }
+
+  rpc GetCustomers(ByNameRequest) returns (stream Customer) {
+    option (kalix.method).view.query = {
+      query: "SELECT * FROM customers WHERE name = :customer_name"
+    };
+  }
+}
+// end::view-from-topic[]

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/resources/logback-dev-mode.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/src/main/resources/logback-dev-mode.xml
@@ -10,8 +10,6 @@
     </appender>
 
     <logger name="akka" level="WARN"/>
-    <logger name="kalix.javasdk.KalixRunner" level="DEBUG"/>
-    <logger name="kalix.javasdk.impl" level="DEBUG"/>
 
     <!-- Silence some details from Akka, should not be important to user/SDK dev mode -->
     <root level="INFO">

--- a/samples/java-protobuf-eventsourced-customer-registry/src/main/java/customer/Main.java
+++ b/samples/java-protobuf-eventsourced-customer-registry/src/main/java/customer/Main.java
@@ -17,6 +17,7 @@
 package customer;
 
 import customer.api.CustomerEventsServiceAction;
+import customer.api.CustomerEventsToTopicServiceAction;
 import kalix.javasdk.Kalix;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,10 +37,11 @@ public final class Main {
       CustomerByCityStreamingView::new,
       // tag::register[]
       CustomerByNameView::new
-        // end::register[]
-        ,
-      CustomerEventsServiceAction::new
-        // tag::register[]
+      // end::register[]
+      ,
+      CustomerEventsServiceAction::new,
+      CustomerEventsToTopicServiceAction::new
+      // tag::register[]
     );
   }
   // end::register[]

--- a/samples/java-protobuf-eventsourced-customer-registry/src/main/java/customer/api/CustomerEventsServiceAction.java
+++ b/samples/java-protobuf-eventsourced-customer-registry/src/main/java/customer/api/CustomerEventsServiceAction.java
@@ -4,7 +4,7 @@ import customer.domain.CustomerDomain;
 import kalix.javasdk.action.ActionCreationContext;
 
 // This class was initially generated based on the .proto definition by Kalix tooling.
-// This is the implementation for the Action Service described in your customer/api/direct_customer_events.proto file.
+// This is the implementation for the Action Service described in your customer/api/customer_events.proto file.
 //
 // As long as this file exists it will not be overwritten: you can maintain it yourself,
 // or delete it so it is regenerated as needed.

--- a/samples/java-protobuf-eventsourced-customer-registry/src/main/java/customer/api/CustomerEventsToTopicServiceAction.java
+++ b/samples/java-protobuf-eventsourced-customer-registry/src/main/java/customer/api/CustomerEventsToTopicServiceAction.java
@@ -1,0 +1,45 @@
+package customer.api;
+
+import customer.api.CustomerEventsApi.Created;
+import customer.api.CustomerEventsApi.NameChanged;
+import customer.domain.CustomerDomain;
+import customer.domain.CustomerDomain.CustomerState;
+import kalix.javasdk.Metadata;
+import kalix.javasdk.action.ActionCreationContext;
+import kalix.javasdk.impl.MetadataImpl;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+// This is the implementation for the Action Service described in your customer/api/customer_events.proto file.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+// tag::topic-publisher[]
+public class CustomerEventsToTopicServiceAction extends AbstractCustomerEventsToTopicServiceAction {
+
+  public CustomerEventsToTopicServiceAction(ActionCreationContext creationContext) {}
+
+  // end::topic-publisher[]
+  @Override
+  public Effect<Created> transformCustomerCreated(CustomerDomain.CustomerCreated customerCreated) {
+    CustomerState customer = customerCreated.getCustomer();
+    String customerId = actionContext().metadata().get("ce-subject").orElseThrow();
+    Metadata metadata = Metadata.EMPTY.add("ce-subject", customerId);
+    Created message = Created.newBuilder()
+      .setCustomerId(customer.getCustomerId())
+      .setCustomerName(customer.getName())
+      .setEmail(customer.getEmail())
+      .build();
+    return effects().reply(message, metadata);
+  }
+
+  // tag::topic-publisher[]
+  @Override
+  public Effect<NameChanged> transformCustomerNameChanged(CustomerDomain.CustomerNameChanged customerNameChanged) {
+    String customerId = actionContext().metadata().get("ce-subject").orElseThrow(); // <1>
+    Metadata metadata = Metadata.EMPTY.add("ce-subject", customerId);
+    NameChanged nameChanged = NameChanged.newBuilder().setCustomerName(customerNameChanged.getNewName()).build();
+    return effects().reply(nameChanged, metadata); // <2>
+  }
+}
+// end::topic-publisher[]

--- a/samples/java-protobuf-eventsourced-customer-registry/src/main/proto/customer/api/customer_events.proto
+++ b/samples/java-protobuf-eventsourced-customer-registry/src/main/proto/customer/api/customer_events.proto
@@ -37,18 +37,35 @@ service CustomerEventsService {
     option (kalix.codegen) = {
         action: {}
     };
-    option (kalix.service).eventing.in = { // <1>
+    option (kalix.service).eventing.in = {// <1>
         event_sourced_entity: "customers"
         // skip/filter events that there is no transform method for (AddressChanged)
         ignore_unknown: true // <2>
     };
     option (kalix.service).eventing.out.direct.event_stream_id = "customer_events"; // <3>
     // limit access to only other services in same project
-    option (kalix.service).acl.allow = { service: "*" }; // <4>
+    option (kalix.service).acl.allow = {service: "*"}; // <4>
 
     // transform methods for turning internal event types to public API
-    rpc TransformCustomerCreated(domain.CustomerCreated) returns (Created) { } // <5>
+    rpc TransformCustomerCreated(domain.CustomerCreated) returns (Created) {} // <5>
     rpc TransformCustomerNameChanged(domain.CustomerNameChanged) returns (NameChanged) {}
-
 }
 // end::publisher[]
+
+service CustomerEventsToTopicService {
+    option (kalix.codegen) = {
+        action: {}
+    };
+    option (kalix.service).eventing.in = {
+        event_sourced_entity: "customers"
+        ignore_unknown: true
+    };
+    option (kalix.service).acl.allow = {service: "*"};
+
+    rpc TransformCustomerCreated(domain.CustomerCreated) returns (Created) {
+        option (kalix.method).eventing.out.topic = "customer_events";
+    }
+    rpc TransformCustomerNameChanged(domain.CustomerNameChanged) returns (NameChanged) {
+        option (kalix.method).eventing.out.topic = "customer_events";
+    }
+}

--- a/samples/java-protobuf-eventsourced-customer-registry/src/main/proto/customer/view/customer_view.proto
+++ b/samples/java-protobuf-eventsourced-customer-registry/src/main/proto/customer/view/customer_view.proto
@@ -81,50 +81,6 @@ service CustomerByName {
 }
 // end::service-event-sourced[]
 
-// tag::service-topic[]
-service CustomerByNameFromTopic {
-  rpc ProcessCustomerCreated(domain.CustomerCreated) returns (api.Customer) {
-    option (kalix.method).eventing.in = {
-      topic: "customers" // <1>
-    };
-    option (kalix.method).view.update = {
-      table: "customers"
-    };
-  }
-
-  rpc ProcessCustomerNameChanged(domain.CustomerNameChanged) returns (api.Customer) {
-    option (kalix.method).eventing.in = {
-      topic: "customers"
-    };
-    option (kalix.method).view.update = {
-      table: "customers"
-    };
-  }
-
-  rpc ProcessCustomerAddressChanged(domain.CustomerAddressChanged) returns (api.Customer) {
-    option (kalix.method).eventing.in = {
-      topic: "customers"
-    };
-    option (kalix.method).view.update = {
-      table: "customers"
-    };
-  }
-
-  rpc IgnoreOtherEvents(google.protobuf.Any) returns (api.Customer) {
-    option (kalix.method).eventing.in = {
-      topic: "customers"
-      ignore: true
-     };
-  };
-
-  rpc GetCustomers(ByNameRequest) returns (stream api.Customer) {
-    option (kalix.method).view.query = {
-      query: "SELECT * FROM customers WHERE name = :customer_name"
-    };
-  }
-}
-// end::service-topic[]
-
 
 // tag::stream-updates[]
 message ByCityRequest {

--- a/samples/java-protobuf-eventsourced-customer-registry/src/test/java/customer/api/CustomerEventsToTopicServiceActionTest.java
+++ b/samples/java-protobuf-eventsourced-customer-registry/src/test/java/customer/api/CustomerEventsToTopicServiceActionTest.java
@@ -1,0 +1,46 @@
+package customer.api;
+
+import akka.stream.javadsl.Source;
+import customer.api.CustomerEventsApi;
+import customer.api.CustomerEventsToTopicServiceAction;
+import customer.api.CustomerEventsToTopicServiceActionTestKit;
+import customer.domain.CustomerDomain;
+import kalix.javasdk.testkit.ActionResult;
+import org.junit.Ignore;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+// This class was initially generated based on the .proto definition by Kalix tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CustomerEventsToTopicServiceActionTest {
+
+  @Test
+  @Ignore("to be implemented")
+  public void exampleTest() {
+    CustomerEventsToTopicServiceActionTestKit service = CustomerEventsToTopicServiceActionTestKit.of(CustomerEventsToTopicServiceAction::new);
+    // // use the testkit to execute a command
+    // SomeCommand command = SomeCommand.newBuilder()...build();
+    // ActionResult<SomeResponse> result = service.someOperation(command);
+    // // verify the reply
+    // SomeReply reply = result.getReply();
+    // assertEquals(expectedReply, reply);
+  }
+
+  @Test
+  @Ignore("to be implemented")
+  public void transformCustomerCreatedTest() {
+    CustomerEventsToTopicServiceActionTestKit testKit = CustomerEventsToTopicServiceActionTestKit.of(CustomerEventsToTopicServiceAction::new);
+    // ActionResult<CustomerEventsApi.Created> result = testKit.transformCustomerCreated(CustomerDomain.CustomerCreated.newBuilder()...build());
+  }
+
+  @Test
+  @Ignore("to be implemented")
+  public void transformCustomerNameChangedTest() {
+    CustomerEventsToTopicServiceActionTestKit testKit = CustomerEventsToTopicServiceActionTestKit.of(CustomerEventsToTopicServiceAction::new);
+    // ActionResult<CustomerEventsApi.NameChanged> result = testKit.transformCustomerNameChanged(CustomerDomain.CustomerNameChanged.newBuilder()...build());
+  }
+
+}


### PR DESCRIPTION
References #1644 

After the initial approach, I changed my mind and decided to put additional view-from-topic example in 
 - *eventsourced-customer-registry
 - *eventsourced-customer-registry-subscriber 
 samples. It feels better to have it there. Currently, only java-protobuf sample is updated, once we agree that it is ok, I will do similar changes to scala-protobuf and java-spring. 