### PR TITLE
chore: update proxy version to 1.1.12

### DIFF
--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.11
+    image: gcr.io/kalix-public/kalix-proxy:1.1.12
     depends_on:
       - kalix-proxy-customer-registry
     ports:
@@ -21,7 +21,7 @@ services:
       USER_FUNCTION_PORT: "8081"
 
   kalix-proxy-customer-registry:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.11
+    image: gcr.io/kalix-public/kalix-proxy:1.1.12
     ports:
       - "9000:9000"
     extra_hosts:

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.11
+    image: gcr.io/kalix-public/kalix-proxy:1.1.12
     depends_on:
       - kalix-proxy-customer-registry
     ports:
@@ -21,7 +21,7 @@ services:
       USER_FUNCTION_PORT: "8081"
 
   kalix-proxy-customer-registry:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.11
+    image: gcr.io/kalix-public/kalix-proxy:1.1.12
     ports:
       - "9000:9000"
     extra_hosts:

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.11
+    image: gcr.io/kalix-public/kalix-proxy:1.1.12
     depends_on:
       - kalix-proxy-customer-registry
     ports:
@@ -21,7 +21,7 @@ services:
       USER_FUNCTION_PORT: "8081"
 
   kalix-proxy-customer-registry:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.11
+    image: gcr.io/kalix-public/kalix-proxy:1.1.12
     ports:
       - "9000:9000"
     extra_hosts:

--- a/sdk/java-sdk-spring/docker-compose-integration.yml
+++ b/sdk/java-sdk-spring/docker-compose-integration.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.11
+    image: gcr.io/kalix-public/kalix-proxy:1.1.12
     ports:
       - "9000:9000"
     extra_hosts:


### PR DESCRIPTION
New docker-compose-integration.yml were left out from bot PR