### PR TITLE
feat: eventing teskit for java sdk

### DIFF
--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -74,7 +74,7 @@ public class CounterIntegrationTest extends KalixIntegrationTestKitSupport {
     }
 
     @Test
-    public void verifyCounterEventSourcedPublishToTopic() throws JsonProcessingException {
+    public void verifyCounterEventSourcedPublishToTopic() {
 
         var counterId = "pubsub-test";
         var increaseCmd1 = new CounterCommandFromTopicAction.IncreaseCounter(counterId, 3);

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -1,17 +1,24 @@
 package com.example;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import kalix.javasdk.testkit.EventingTestKit;
+import kalix.javasdk.testkit.KalixTestKit;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 // tag::class[]
 @SpringBootTest(classes = Main.class)
 @Import(TestkitConfig.class)  // <1>
@@ -22,7 +29,18 @@ public class CounterIntegrationTest extends KalixIntegrationTestKitSupport {
     @Autowired
     private WebClient webClient;
 
+    @Autowired
+    private KalixTestKit kalixTestKit;
+
     private Duration timeout = Duration.of(10, SECONDS);
+
+    private EventingTestKit.Topic outTopic;
+
+    @BeforeAll
+    public void beforeAll() {
+        outTopic = kalixTestKit.getTopic("counter-events");
+    }
+
 
     @Test
     public void verifyCounterEventSourcedWiring() {
@@ -51,6 +69,34 @@ public class CounterIntegrationTest extends KalixIntegrationTestKitSupport {
                 webClient.get().uri("/counter/hello").retrieve().bodyToMono(String.class).block(timeout);
 
         Assertions.assertEquals("\"200\"", counterGet);
+    }
+
+    @Test
+    public void verifyCounterEventSourcedPublishToTopic() throws JsonProcessingException {
+
+        String counterIncrease =
+            webClient
+                .post()
+                .uri("/counter/to-topic/increase/10")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block(timeout);
+        assertEquals("\"10\"", counterIncrease);
+
+        String counterMultiply =
+            webClient
+                .post()
+                .uri("/counter/to-topic/multiply/20")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block(timeout);
+        assertEquals("\"200\"", counterMultiply);
+
+        var eventIncreased = outTopic.expectOneTyped(CounterEvent.ValueIncreased.class);
+        assertEquals(new CounterEvent.ValueIncreased(10), eventIncreased.getPayload());
+
+        var eventMultiply = outTopic.expectOneTyped(CounterEvent.ValueMultiplied.class);
+        assertEquals(new CounterEvent.ValueMultiplied(20), eventMultiply.getPayload());
     }
 // tag::class[]
 }

--- a/samples/java-spring-eventsourced-counter/src/it/resources/logback-test.xml
+++ b/samples/java-spring-eventsourced-counter/src/it/resources/logback-test.xml
@@ -6,12 +6,13 @@
     </appender>
 
     <logger name="akka" level="INFO"/>
-    <logger name="kalix" level="INFO"/>
+    <logger name="kalix" level="DEBUG"/>
     <logger name="com.github.dockerjava" level="INFO"/>
     <logger name="io.grpc.netty" level="INFO"/>
     <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.springframework" level="INFO"/>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterCommandFromTopicAction.java
+++ b/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterCommandFromTopicAction.java
@@ -1,0 +1,29 @@
+package com.example.actions;
+
+import kalix.javasdk.action.Action;
+import kalix.javasdk.annotations.Subscribe;
+import kalix.spring.KalixClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CounterCommandFromTopicAction extends Action {
+
+  public record IncreaseCounter(String counterId, int value) { }
+
+  private KalixClient kalixClient;
+
+  public CounterCommandFromTopicAction(KalixClient kalixClient) {
+    this.kalixClient = kalixClient;
+  }
+
+  private Logger logger = LoggerFactory.getLogger(CounterCommandFromTopicAction.class);
+
+  @Subscribe.Topic(value = "counter-commands")
+  public Effect<String> onValueIncreased(IncreaseCounter increase) {
+    logger.info("Received increase command: " + increase.toString());
+    var deferredCall = kalixClient.post("/counter/"+ increase.counterId + "/increase/" + increase.value, String.class);
+    return effects().forward(deferredCall);
+  }
+
+}
+// end::class[]

--- a/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterCommandFromTopicAction.java
+++ b/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterCommandFromTopicAction.java
@@ -6,6 +6,7 @@ import kalix.spring.KalixClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Subscribe.Topic(value = "counter-commands", ignoreUnknown = true)
 public class CounterCommandFromTopicAction extends Action {
 
   public record IncreaseCounter(String counterId, int value) { }
@@ -18,7 +19,6 @@ public class CounterCommandFromTopicAction extends Action {
 
   private Logger logger = LoggerFactory.getLogger(CounterCommandFromTopicAction.class);
 
-  @Subscribe.Topic(value = "counter-commands")
   public Effect<String> onValueIncreased(IncreaseCounter increase) {
     logger.info("Received increase command: " + increase.toString());
     var deferredCall = kalixClient.post("/counter/"+ increase.counterId + "/increase/" + increase.value, String.class);
@@ -26,4 +26,3 @@ public class CounterCommandFromTopicAction extends Action {
   }
 
 }
-// end::class[]

--- a/samples/java-spring-eventsourced-counter/src/test/resources/logback-test.xml
+++ b/samples/java-spring-eventsourced-counter/src/test/resources/logback-test.xml
@@ -6,12 +6,13 @@
     </appender>
 
     <logger name="akka" level="INFO"/>
-    <logger name="kalix" level="INFO"/>
+    <logger name="kalix" level="DEBUG"/>
     <logger name="com.github.dockerjava" level="INFO"/>
     <logger name="io.grpc.netty" level="INFO"/>
     <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.springframework" level="INFO"/>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/EventingTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/EventingTestKit.java
@@ -221,7 +221,7 @@ public interface EventingTestKit {
      * @return a typed object from the payload
      * @param <T> the type of the payload
      */
-    <T extends GeneratedMessageV3> T expectType(Class<T> clazz);
+    <T> T expectType(Class<T> clazz);
 
     /**
      * Create a message from a payload plus a subject (that is, the entity key).
@@ -232,7 +232,7 @@ public interface EventingTestKit {
      * @return a Message object to be used in the context of the Testkit
      * @param <T>
      */
-    static <T extends GeneratedMessageV3> Message<T> of(T payload, String subject) {
+    static <T> Message<T> of(T payload, String subject) {
       return new TestKitMessageImpl<>(payload, TestKitMessageImpl.defaultMetadata(payload, subject));
     }
 
@@ -244,7 +244,7 @@ public interface EventingTestKit {
      * @return a Message object to be used in the context of the Testkit
      * @param <T>
      */
-    static <T extends GeneratedMessageV3> Message<T> of(T payload, Metadata metadata) {
+    static <T> Message<T> of(T payload, Metadata metadata) {
       return new TestKitMessageImpl<>(payload, metadata);
     }
   }

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/EventingTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/EventingTestKit.java
@@ -169,7 +169,6 @@ public interface EventingTestKit {
      */
     void publish(ByteString message);
 
-
     /**
      * Simulate the publishing of a raw message to this topic for the purposes
      * of testing eventing.in flows into a specific service.
@@ -185,7 +184,7 @@ public interface EventingTestKit {
      *
      * @param message to be published in the topic
      */
-    <T extends GeneratedMessageV3> void publish(Message<T> message);
+    void publish(Message<?> message);
 
     /**
      * Simulate the publishing of a message to this topic for the purposes
@@ -195,7 +194,7 @@ public interface EventingTestKit {
      * @param subject to identify the entity
      * @param <T>
      */
-    <T extends GeneratedMessageV3> void publish(T message, String subject);
+    <T> void publish(T message, String subject);
 
     /**
      * Publish multiple messages to this topic for the purposes
@@ -204,7 +203,7 @@ public interface EventingTestKit {
      * @param messages to be published in the topic
      * @param <T>
      */
-    <T extends GeneratedMessageV3> void publish(List<Message<T>> messages);
+    void publish(List<Message<?>> messages);
 
   }
 

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/EventingTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/EventingTestKit.java
@@ -114,7 +114,7 @@ public interface EventingTestKit {
      * @return a Message of type T
      * @param <T> a given domain type
      */
-    <T extends GeneratedMessageV3> Message<T> expectOneTyped(Class<T> instance);
+    <T> Message<T> expectOneTyped(Class<T> instance);
 
     /**
      * Waits and returns the next unread message on this topic and automatically parses
@@ -125,7 +125,7 @@ public interface EventingTestKit {
      * @param timeout amount of time to wait for a message if it was not received already
      * @return message including ByteString payload and metadata
      */
-    <T extends GeneratedMessageV3> Message<T> expectOneTyped(Class<T> instance, Duration timeout);
+    <T> Message<T> expectOneTyped(Class<T> instance, Duration timeout);
 
     /**
      * Waits for a default amount of time before returning all unread messages in the topic.

--- a/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventingTestKitImpl.scala
+++ b/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventingTestKitImpl.scala
@@ -335,7 +335,7 @@ private[testkit] class TopicImpl(
   override def publish(message: ByteString, metadata: SdkMetadata): Unit =
     brokerProbe.emit(message, metadata)
 
-  override def publish(message: TestKitMessage[?]): Unit = message.getPayload match {
+  override def publish(message: TestKitMessage[_]): Unit = message.getPayload match {
     case javaPb: GeneratedMessageV3 => publish(javaPb.toByteString, message.getMetadata)
     case scalaPb: GeneratedMessage  => publish(scalaPb.toByteString, message.getMetadata)
     case str: String                => publish(ByteString.copyFromUtf8(str), message.getMetadata)
@@ -351,7 +351,7 @@ private[testkit] class TopicImpl(
     publish(TestKitMessageImpl(message, md))
   }
 
-  override def publish(message: JList[TestKitMessage[?]]): Unit =
+  override def publish(message: JList[TestKitMessage[_]]): Unit =
     message.asScala.foreach(m => publish(m))
 
 }


### PR DESCRIPTION
Opened this draft PR on the side to track the discussion on what would mean to have no upper type on the `expect` methods.

This would mean that both users from protocol-first or code-first would use the same API. I think this could work but opening for discussion.

~This is draft only, so might be missing some edge cases.~