### PR TITLE
chore: add env var to debug tests

### DIFF
--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixProxyContainer.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixProxyContainer.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
@@ -92,8 +93,10 @@ public class KalixProxyContainer extends GenericContainer<KalixProxyContainer> {
     Testcontainers.exposeHostPorts(googlePubSubPort);
     super.start();
     // Debug tooling: pass the Proxy logs into the client SLF4J
-    // Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LoggerFactory.getLogger("proxy-logs"));
-    // followOutput(logConsumer);
+    if ("true".equals(System.getenv("KALIX_TESTKIT_DEBUG"))) {
+      Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LoggerFactory.getLogger("proxy-logs"));
+      followOutput(logConsumer);
+    }
   }
 
   /**


### PR DESCRIPTION
This is very useful when debugging failures in integration tests and having a env var makes it easier to turn on/off. I guess we can use this ENV var to turn on other things as well in future, thus why I made it about debugging and not about forwarding logs specifically.