### PR TITLE
docs: eventing testkit for java sdk

### DIFF
--- a/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
@@ -229,35 +229,14 @@ When adding the `ignore: true` annotation the corresponding implementation is no
 
 It is possible to use environment variables to control the name of the topic that is used for consuming from or producing events to, this is useful for example for using the same image in staging and production deployments but having them interact with separate topics.
 
-Referencing environment variables is done with the syntax `$\{VAR_NAME}` in the `topic` string in `eventing.in.topic` or `eventing.out.topic` blocks.
+Referencing environment variables is done with the syntax `$\{VAR_NAME}` in the `topic` string in `eventing.in.topic` or `eventing.out.topic` blocks. See https://docs.kalix.io/kalix/kalix_services_deploy.html[kalix service deploy] for details on how to set environment variables when deploying a service.
 
-Note that if changing the `topic` name after it has once been deployed for an event consumer means the consumer will start over from the beginning of the topic.
-
-See https://docs.kalix.io/kalix/kalix_services_deploy.html[kalix service deploy] for details on how to set environment variables when deploying a service.
+WARNING: Changing the `topic` name after it has once been deployed for an event consumer means the consumer will start over from the beginning of the topic.
 
 
 == Testing the Integration
 
-When a Kalix service relies on a broker, it might be useful to use integration tests to assert that those boundaries work as intended. For such scenarios, you can either:
-
-* Use TestKit's mocked topic:
-** this offers a general API to inject messages into topics or read the messages written to another topic, regardless of the specific broker integration you have configured.
-* Run an external broker instance:
-** if you're interested in running your integration tests against a real instance, you need to provide the broker instance yourself by running it in a separate process in your local setup and make sure to disable the use of TestKit's test broker. Currently, **the only external broker supported in integration tests is Google PubSub Emulator.**
-
-=== TestKit Mocked Topic
-
-Following up on the counter entity example used above, let's consider an example (composed by 2 Actions and 1 Event Sourced entity) as pictured below:
-
-ifdef::todo[TODO: convert this diagram once we have a standard language for this]
-image::java:eventing-testkit-sample.svg[]
-
-In this example:
-
-* commands are consumed from an external topic `event-commands` and forwarded to a Counter entity;
-* the Counter entity is an Event Sourced Entity and has its events published to another topic `counter-events`.
-
-To test this flow, we will take advantage of the TestKit to be able to push commands into the `event-commands` topic and check what messages are produced to topic `counter-events`.
+include::java:partial$eventing-testkit-intro.adoc[leveloffset=1]
 
 [.tabset]
 Java::

--- a/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
@@ -254,10 +254,10 @@ image::java:eventing-testkit-sample.svg[]
 
 In this example:
 
-* commands are consumed from an external topic `event-commands` and forwarded to a Counter entity;
-* the Counter entity is an Event Sourced Entity and has its events published to another topic `counter-events`.
+* commands are consumed from an external topic `event-commands` and forwarded to a Counter entity
+* the Counter entity is an Event Sourced Entity and has its events published to another topic `counter-events`
 
-To test this flow, we will take advantage of the TestKit to be able to push commands into the `event-commands` topic and check what messages are produced to topic `counter-events`.
+To test this flow, we will take advantage of the TestKit to be able to push commands into the `event-commands` topic and check on what messages are produced to topic `counter-events`.
 
 [.tabset]
 Java::

--- a/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
@@ -254,10 +254,10 @@ image::java:eventing-testkit-sample.svg[]
 
 In this example:
 
-* commands are consumed from an external topic `event-commands` and forwarded to a Counter entity
-* the Counter entity is an Event Sourced Entity and has its events published to another topic `counter-events`
+* commands are consumed from an external topic `event-commands` and forwarded to a Counter entity;
+* the Counter entity is an Event Sourced Entity and has its events published to another topic `counter-events`.
 
-To test this flow, we will take advantage of the TestKit to be able to push commands into the `event-commands` topic and check on what messages are produced to topic `counter-events`.
+To test this flow, we will take advantage of the TestKit to be able to push commands into the `event-commands` topic and check what messages are produced to topic `counter-events`.
 
 [.tabset]
 Java::

--- a/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
@@ -104,4 +104,66 @@ For many use cases, a subscriber to an event log will trigger other services and
 You can access the link:{attachmentsdir}/api/kalix/javasdk/action/ActionContext.html[`ActionContext`{tab-icon}, window="new"] through method `actionContext()`.
 
 
+== Deployment dependent topic names
 
+It is possible to use environment variables to control the name of the topic that is used for consuming from or producing events to, this is useful for example for using the same image in staging and production deployments but having them interact with separate topics.
+
+Referencing environment variables is done with the syntax `$\{VAR_NAME}` in the `topic` string in `eventing.in.topic` or `eventing.out.topic` blocks. See https://docs.kalix.io/kalix/kalix_services_deploy.html[kalix service deploy] for details on how to set environment variables when deploying a service.
+
+WARNING: Changing the `topic` name after it has once been deployed for an event consumer means the consumer will start over from the beginning of the topic.
+
+
+== Testing the Integration
+
+include::java:partial$eventing-testkit-intro.adoc[leveloffset=1]
+
+[source,java]
+.src/it/java/com/example/CounterIntegrationTest.java
+----
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java[tag=test-topic]
+----
+<1> Start the TestKit, booting up both the service and its proxy.
+<2> Wire the Kalix TestKit automatically.
+<3> Get a mocked topic named `counter-commands` and another one named `counter-events` from the TestKit.
+<4> Build 2 commands and publish both to the topic. Note the `counterId` is passed as the subject id of the message.
+<5> Read 2 messages, one at a time. Note we pass in the expected class type for the next message.
+<6> Assert the received messages have the same value as the commands sent.
+
+TIP: In the example above we take advantage of the TestKit to serialize / deserialize the messages and pass all the required metadata automatically for us. However, the API also offers the possibility to read and write raw bytes, construct your metadata or read multiple messages at once.
+
+==== Metadata
+
+Typically, messages are published with associated metadata. If you want to construct your own `Metadata` to be consumed by a service or make sure the messages published out of your service have specific metadata attached, you can do so using the TestKit, as shown below.
+
+[source,java,indent=0]
+.src/it/java/com/example/CounterTopicIntegrationTest.java
+----
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java[tag=test-topic-metadata]
+----
+<1> Build a `CloudEvent` object with the 3 required attributes, respectively: `id`, `source` and `type`.
+<2> Add the subject to which the message is related, that is the `counterId`.
+<3> Set the mandatory header "Content-Type" accordingly.
+<4> Publish the message along with its metadata to topic `commandsTopic`.
+<5> Upon receiving the message, access the metadata.
+<6> Assert the headers `Content-Type` and `ce-subject` (every CloudEvent header is prefixed with "ce-") have the expected values.
+
+
+==== One Suite, Multiple Tests
+
+When running multiple test cases under the same test suite and thus using a common TestKit instance, you might face some if unconsumed messages from previous tests mess up with the current one. To avoid this, be sure to:
+
+- have the tests run in sequence, not in parallel;
+- clear the contents of the topics in use before the test.
+
+As an alternative, you can consider using different test suites which will use independent TestKit instances.
+
+
+[source,java,indent=0]
+.src/it/java/com/example/CounterTopicIntegrationTest.java
+----
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java[tag=clear-topics]
+----
+<1> Run this before each test.
+<2> Clear the topic ignoring any unread messages.
+
+NOTE: Despite the example, you are neither forced to clear all topics nor to do it before each test. You can do it selectively, or you might not even need it depending on your tests and the flows they test.

--- a/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
@@ -120,7 +120,7 @@ include::java:partial$eventing-testkit-intro.adoc[leveloffset=1]
 [source,java]
 .src/it/java/com/example/CounterIntegrationTest.java
 ----
-include::example$java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java[tag=test-topic]
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java[tags=class;test-topic]
 ----
 <1> Start the TestKit, booting up both the service and its proxy.
 <2> Wire the Kalix TestKit automatically.

--- a/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
@@ -150,7 +150,7 @@ include::example$java-spring-eventsourced-counter/src/it/java/com/example/Counte
 
 ==== One Suite, Multiple Tests
 
-When running multiple test cases under the same test suite and thus using a common TestKit instance, you might face some if unconsumed messages from previous tests mess up with the current one. To avoid this, be sure to:
+When running multiple test cases under the same test suite and thus using a common TestKit instance, you might face some issues if unconsumed messages from previous tests mess up with the current one. To avoid this, be sure to:
 
 - have the tests run in sequence, not in parallel;
 - clear the contents of the topics in use before the test.

--- a/docs/src/modules/java/partials/eventing-testkit-intro.adoc
+++ b/docs/src/modules/java/partials/eventing-testkit-intro.adoc
@@ -1,0 +1,20 @@
+When a Kalix service relies on a broker, it might be useful to use integration tests to assert that those boundaries work as intended. For such scenarios, you can either:
+
+* Use TestKit's mocked topic:
+** this offers a general API to inject messages into topics or read the messages written to another topic, regardless of the specific broker integration you have configured.
+* Run an external broker instance:
+** if you're interested in running your integration tests against a real instance, you need to provide the broker instance yourself by running it in a separate process in your local setup and make sure to disable the use of TestKit's test broker. Currently, **the only external broker supported in integration tests is Google PubSub Emulator.**
+
+== TestKit Mocked Topic
+
+Following up on the counter entity example used above, let's consider an example (composed by 2 Actions and 1 Event Sourced entity) as pictured below:
+
+ifdef::todo[TODO: convert this diagram once we have a standard language for this]
+image::java:eventing-testkit-sample.svg[]
+
+In this example:
+
+* commands are consumed from an external topic `event-commands` and forwarded to a Counter entity;
+* the Counter entity is an Event Sourced Entity and has its events published to another topic `counter-events`.
+
+To test this flow, we will take advantage of the TestKit to be able to push commands into the `event-commands` topic and check what messages are produced to topic `counter-events`.

--- a/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
+++ b/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 // Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
 // tag::test-topic[]
 
-@FixMethodOrder
 public class CounterTopicIntegrationTest {
 
   /**

--- a/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
+++ b/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
@@ -33,7 +33,6 @@ public class CounterTopicIntegrationTest {
   public static final KalixTestKitResource testKit =
       new KalixTestKitResource(Main.createKalix()); // <1>
 
-  // tag::test-topic[]
   private static EventingTestKit.Topic commandsTopic;
   private static EventingTestKit.Topic eventsTopic;
   // end::test-topic[]

--- a/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
+++ b/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
@@ -34,11 +34,11 @@ public class CounterTopicIntegrationTest {
   public static final KalixTestKitResource testKit =
       new KalixTestKitResource(Main.createKalix()); // <1>
 
-  private static EventingTestKit.Topic commandsTopic;
-  private static EventingTestKit.Topic eventsTopic;
+  private EventingTestKit.Topic commandsTopic;
+  private EventingTestKit.Topic eventsTopic;
   // end::test-topic[]
 
-  private static EventingTestKit.Topic eventsTopicWithMeta;
+  private EventingTestKit.Topic eventsTopicWithMeta;
 
  // tag::test-topic[]
 

--- a/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
+++ b/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
@@ -14,6 +14,7 @@ import kalix.javasdk.testkit.junit.KalixTestKitResource;
 // end::test-topic[]
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 
 import java.net.URI;
@@ -24,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 // Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
 // tag::test-topic[]
 
+@FixMethodOrder
 public class CounterTopicIntegrationTest {
 
   /**

--- a/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
+++ b/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
@@ -6,6 +6,7 @@ package com.example;
 
 import com.example.actions.CounterTopicApi;
 import kalix.javasdk.CloudEvent;
+import kalix.javasdk.Metadata;
 // tag::test-topic[]
 import kalix.javasdk.testkit.EventingTestKit;
 import kalix.javasdk.testkit.junit.KalixTestKitResource;
@@ -33,6 +34,7 @@ public class CounterTopicIntegrationTest {
   public static final KalixTestKitResource testKit =
       new KalixTestKitResource(Main.createKalix()); // <1>
 
+  // tag::test-topic[]
   private static EventingTestKit.Topic commandsTopic;
   private static EventingTestKit.Topic eventsTopic;
   // end::test-topic[]

--- a/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
+++ b/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
@@ -14,7 +14,6 @@ import kalix.javasdk.testkit.junit.KalixTestKitResource;
 // end::test-topic[]
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 
 import java.net.URI;

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -1,11 +1,16 @@
 package com.example;
 
 import com.example.actions.CounterCommandFromTopicAction;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import kalix.javasdk.CloudEvent;
+// tag::test-topic[]
 import kalix.javasdk.testkit.EventingTestKit;
 import kalix.javasdk.testkit.KalixTestKit;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
+// ...
 
+// end::test-topic[]
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,6 +19,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.net.URI;
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -21,27 +27,48 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // tag::class[]
 @SpringBootTest(classes = Main.class)
-@Import(TestkitConfig.class)  // <1>
-public class CounterIntegrationTest extends KalixIntegrationTestKitSupport {
+@Import(TestkitConfig.class)
+public class CounterIntegrationTest extends KalixIntegrationTestKitSupport { // <1>
+
 // end::class[]
 
+    private Duration timeout = Duration.of(10, SECONDS);
 
     @Autowired
     private WebClient webClient;
 
+    // tag::test-topic[]
     @Autowired
-    private KalixTestKit kalixTestKit;
-
-    private Duration timeout = Duration.of(10, SECONDS);
-
+    private KalixTestKit kalixTestKit; // <2>
     private EventingTestKit.Topic commandsTopic;
     private EventingTestKit.Topic eventsTopic;
+    // end::test-topic[]
+
+    private EventingTestKit.Topic eventsTopicWithMeta;
+
+    // tag::test-topic[]
 
     @BeforeAll
     public void beforeAll() {
-        commandsTopic = kalixTestKit.getTopic("counter-commands");
+        commandsTopic = kalixTestKit.getTopic("counter-commands"); // <3>
         eventsTopic = kalixTestKit.getTopic("counter-events");
+        // end::test-topic[]
+
+        eventsTopicWithMeta = kalixTestKit.getTopic("counter-events-with-meta");
+        // tag::test-topic[]
     }
+    // end::test-topic[]
+
+    // since multiple tests are using the same topics, make sure to reset them before each new test
+    // so unread messages from previous tests do not mess with the current one
+    // tag::clear-topics[]
+    @BeforeEach // <1>
+    public void clearTopics() {
+        commandsTopic.clear(); // <2>
+        eventsTopic.clear();
+        eventsTopicWithMeta.clear();
+    }
+    // end::clear-topics[]
 
 
     @Test
@@ -73,22 +100,47 @@ public class CounterIntegrationTest extends KalixIntegrationTestKitSupport {
         Assertions.assertEquals("\"200\"", counterGet);
     }
 
+    // tag::test-topic[]
+
     @Test
     public void verifyCounterEventSourcedPublishToTopic() {
+        var counterId = "test-topic";
+        var increaseCmd = new CounterCommandFromTopicAction.IncreaseCounter(counterId, 3);
+        var multipleCmd = new CounterCommandFromTopicAction.MultiplyCounter(counterId, 4);
 
-        var counterId = "pubsub-test";
-        var increaseCmd1 = new CounterCommandFromTopicAction.IncreaseCounter(counterId, 3);
-        var increaseCmd2 = new CounterCommandFromTopicAction.IncreaseCounter(counterId, 4);
+        commandsTopic.publish(increaseCmd, counterId); // <4>
+        commandsTopic.publish(multipleCmd, counterId);
 
-        commandsTopic.publish(increaseCmd1, counterId);
-        commandsTopic.publish(increaseCmd2, counterId);
+        var eventIncreased = eventsTopic.expectOneTyped(CounterEvent.ValueIncreased.class); // <5>
+        var eventMultiplied = eventsTopic.expectOneTyped(CounterEvent.ValueMultiplied.class);
 
-        var eventIncreased1 = eventsTopic.expectOneTyped(CounterEvent.ValueIncreased.class);
-        assertEquals(new CounterEvent.ValueIncreased(increaseCmd1.value()), eventIncreased1.getPayload());
-
-        var eventIncreased2 = eventsTopic.expectOneTyped(CounterEvent.ValueIncreased.class);
-        assertEquals(new CounterEvent.ValueIncreased(increaseCmd2.value()), eventIncreased2.getPayload());
+        assertEquals(increaseCmd.value(), eventIncreased.getPayload().value()); // <6>
+        assertEquals(multipleCmd.value(), eventMultiplied.getPayload().value());
     }
+    // end::test-topic[]
+
+    // tag::test-topic-metadata[]
+    @Test
+    public void verifyCounterCommandsAndPublishWithMetadata() {
+        var counterId = "test-topic-metadata";
+        var increaseCmd = new CounterCommandFromTopicAction.IncreaseCounter(counterId, 10);
+
+        var metadata = CloudEvent.of( // <1>
+                "cmd1",
+                URI.create("CounterTopicIntegrationTest"),
+                increaseCmd.getClass().getName())
+            .withSubject(counterId) // <2>
+            .asMetadata()
+            .add("Content-Type", "application/json"); // <3>
+
+        commandsTopic.publish(EventingTestKit.Message.of(increaseCmd, metadata)); // <4>
+
+        var increasedEvent = eventsTopicWithMeta.expectOneTyped(CounterCommandFromTopicAction.IncreaseCounter.class);
+        var actualMd = increasedEvent.getMetadata(); // <5>
+        assertEquals(counterId, actualMd.asCloudEvent().subject().get()); // <6>
+        assertEquals("application/json", actualMd.get("Content-Type").get());
+    }
+    // end::test-topic-metadata[]
 // tag::class[]
 }
 // end::class[]

--- a/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterCommandFromTopicAction.java
+++ b/samples/java-spring-eventsourced-counter/src/main/java/com/example/actions/CounterCommandFromTopicAction.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 public class CounterCommandFromTopicAction extends Action {
 
   public record IncreaseCounter(String counterId, int value) { }
+  public record MultiplyCounter(String counterId, int value) { }
 
   private KalixClient kalixClient;
 
@@ -22,6 +23,12 @@ public class CounterCommandFromTopicAction extends Action {
   public Effect<String> onValueIncreased(IncreaseCounter increase) {
     logger.info("Received increase command: " + increase.toString());
     var deferredCall = kalixClient.post("/counter/"+ increase.counterId + "/increase/" + increase.value, String.class);
+    return effects().forward(deferredCall);
+  }
+
+  public Effect<String> onValueDecreased(MultiplyCounter increase) {
+    logger.info("Received increase command: " + increase.toString());
+    var deferredCall = kalixClient.post("/counter/"+ increase.counterId + "/multiply/" + increase.value, String.class);
     return effects().forward(deferredCall);
   }
 

--- a/samples/scala-protobuf-eventsourced-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
+++ b/samples/scala-protobuf-eventsourced-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
@@ -6,9 +6,9 @@ import kalix.scalasdk.CloudEvent
 import java.net.URI
 // tag::test-topic[]
 import kalix.scalasdk.testkit.{KalixTestKit, Message}
-import org.scalatest.BeforeAndAfterEach
 // ...
 // end::test-topic[]
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -107,9 +107,9 @@ class CounterServiceIntegrationSpec extends AnyWordSpec with Matchers with Befor
     "allow passing and reading metadata for messages" in {
       val increaseCmd = IncreaseValue(counterId, 4)
       val md = CloudEvent( // <1>
-          id = "cmd1",
-          source = URI.create("CounterServiceIntegrationSpec"),
-          `type` = increaseCmd.companion.javaDescriptor.getFullName)
+        id = "cmd1",
+        source = URI.create("CounterServiceIntegrationSpec"),
+        `type` = increaseCmd.companion.javaDescriptor.getFullName)
         .withSubject(counterId) // <2>
         .asMetadata
         .add("Content-Type", "application/protobuf"); // <3>
@@ -124,6 +124,7 @@ class CounterServiceIntegrationSpec extends AnyWordSpec with Matchers with Befor
     // end::test-topic-metadata[]
     // tag::test-topic[]
   }
+
 
   override def afterAll(): Unit = {
     testKit.stop()

--- a/samples/scala-protobuf-eventsourced-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
+++ b/samples/scala-protobuf-eventsourced-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
@@ -6,6 +6,7 @@ import kalix.scalasdk.CloudEvent
 import java.net.URI
 // tag::test-topic[]
 import kalix.scalasdk.testkit.{KalixTestKit, Message}
+import org.scalatest.BeforeAndAfterEach
 // ...
 // end::test-topic[]
 import org.scalatest.BeforeAndAfterEach
@@ -107,9 +108,9 @@ class CounterServiceIntegrationSpec extends AnyWordSpec with Matchers with Befor
     "allow passing and reading metadata for messages" in {
       val increaseCmd = IncreaseValue(counterId, 4)
       val md = CloudEvent( // <1>
-        id = "cmd1",
-        source = URI.create("CounterServiceIntegrationSpec"),
-        `type` = increaseCmd.companion.javaDescriptor.getFullName)
+          id = "cmd1",
+          source = URI.create("CounterServiceIntegrationSpec"),
+          `type` = increaseCmd.companion.javaDescriptor.getFullName)
         .withSubject(counterId) // <2>
         .asMetadata
         .add("Content-Type", "application/protobuf"); // <3>


### PR DESCRIPTION
References https://github.com/lightbend/kalix/issues/7883

Depends on https://github.com/lightbend/kalix-jvm-sdk/pull/1688 to pass CI, so opening against it.

This PR:
- adds eventing teskit docs for java sdk