### PR TITLE
docs: use entity id instead of key

### DIFF
--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -42,13 +42,13 @@ include::example$java-spring-eventsourced-shopping-cart/src/main/java/com/exampl
 
 IMPORTANT: The use of logical names for subtypes is essential for maintainability purposes. Since that information is persisted, failing to do so might lead to the use of a FQCN preventing the application from correctly deserialize the events in case of a package change. Our recommendation is to use logical names (i.e. `@TypeName`) that are unique per Kalix service.
 
-include::partial$entity-keys.adoc[]
+include::partial$entity-ids.adoc[]
 
 == Implementing behavior
 
 Now that we have our Entity state defined along with its events, the remaining steps can be summarized as follows:
 
-- declare your entity and pick an entity key (it needs to be unique as it will be used for sharding purposes);
+- declare your entity and pick an entity id (it needs to be unique as it will be used for sharding purposes);
 - define an access point (i.e. a route path) to your entity;
 - implement how each command is handled and which event(s) it generates;
 - provide a handler for each event and how it affects the entity's state.
@@ -139,7 +139,7 @@ When you give the instruction to delete the entity it will still exist from some
 
 It is not allowed to emit more events after the entity has been "marked" as deleted. You can still handle read requests of the entity until it has been completely removed.
 
-It is best to not reuse the same entity key after deletion, but if that happens after the entity has been completely removed it will be instantiated as a completely new entity without any knowledge of previous state.
+It is best to not reuse the same entity id after deletion, but if that happens after the entity has been completely removed it will be instantiated as a completely new entity without any knowledge of previous state.
 
 Note that xref:views.adoc#ve_delete[deleting View state] must be handled explicitly.
 

--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
@@ -62,8 +62,8 @@ Create a class named `CustomerEntity` in package `customer.api`.
 include::example$java-spring-customer-registry-quickstart/src/main/java/customer/api/CustomerEntity.java[tag=customer]
 ----
 <1> Each Entity needs a unique logical type name. This must be unique per Kalix service.
-<2> The entity needs to be address by a unique identifier. The `@EntityKey` declares the name of the path variable that Kalix should use as unique identifier.
-<3> The `@RequestMapping` defines the base path to access the entity. Note that the `\{customer_id\}` matches the value of `@EntityKey`.
+<2> The entity needs to be address by a unique identifier. The `@Id` declares the name of the path variable that Kalix should use as unique identifier.
+<3> The `@RequestMapping` defines the base path to access the entity. Note that the `\{customer_id\}` matches the value of `@Id`.
 <4> `CustomerEntity` must inherit from `kalix.javasdk.valueentity.ValueEntity`.
 <5> Each API method must be exposed as a REST endpoint using Spring's REST annotations.
 <6> The implementation instructs Kalix to persist the state `customer`.

--- a/docs/src/modules/java/pages/quickstart/sc-eventsourced-entity-java.adoc
+++ b/docs/src/modules/java/pages/quickstart/sc-eventsourced-entity-java.adoc
@@ -47,8 +47,8 @@ Create a class named `ShoppingCartEntity` in package `shoppingcart.api`.
 include::example$java-spring-shopping-cart-quickstart/src/main/java/shoppingcart/api/ShoppingCartEntity.java[tag=class]
 ----
 <1> Each Entity needs a unique logical type name. This must be unique per Kalix service.
-<2> The entity needs to be addressed by a unique identifier. The `@EntityKey` declares the name of the path variable that Kalix should use as unique identifier.
-<3> The `@RequestMapping` defines the base path to access the entity. Note that the `\{cartId\}` matches the value of `@EntityKey`.
+<2> The entity needs to be addressed by a unique identifier. The `@Id` declares the name of the path variable that Kalix should use as unique identifier.
+<3> The `@RequestMapping` defines the base path to access the entity. Note that the `\{cartId\}` matches the value of `@Id`.
 <4> `ShoppingCartEntity` must inherit from `kalix.javasdk.eventsourcedentity.EventSourcedEntity`.
 <5> The `emptyState` method returns the initial state of the shopping cart.
 <6> External API methods are be exposed as a REST endpoint using Spring's REST annotations.

--- a/docs/src/modules/java/pages/spring-boot-integration.adoc
+++ b/docs/src/modules/java/pages/spring-boot-integration.adoc
@@ -35,6 +35,6 @@ In Kalix, data storage and retrieval follows the https://developer.lightbend.com
 
 The persistent Kalix entities (xref:java:event-sourced-entities.adoc[Event Sourced Entity] and xref:java:value-entity.adoc[Value Entity]) represent the command-model in the CQRS pattern. They receive `Commands` and mutate data in their own transaction.
 
-Data produced by entities can be propagated to xref:java:views.adoc[Views] in order to generate query-models, also known as view-models. Views are indexed representations of your model. You can query your data using different fields, while Entities are only accessible by their entity key.
+Data produced by entities can be propagated to xref:java:views.adoc[Views] in order to generate query-models, also known as view-models. Views are indexed representations of your model. You can query your data using different fields, while Entities are only accessible by their entity id.
 
 In both cases, Kalix manages all persistence aspects and your code only need to specify the business logic.

--- a/docs/src/modules/java/pages/value-entity.adoc
+++ b/docs/src/modules/java/pages/value-entity.adoc
@@ -23,14 +23,14 @@ As mentioned above, to help us illustrate a Value Entity, you will be implementi
 include::example$java-spring-valueentity-counter/src/main/java/com/example/Number.java[]
 ----
 
-include::partial$entity-keys.adoc[]
+include::partial$entity-ids.adoc[]
 
 [#entity-behavior]
 == Implementing behavior
 
 Now that you have a good idea of what we want to build and what its API looks like, you will need to:
 
-- Declare your entity and pick an entity key (it needs to be a unique identifier).
+- Declare your entity and pick an entity id (it needs to be a unique identifier).
 - Define an access point (i.e. a route path) to your entity.
 - Implement how each command is handled.
 
@@ -82,7 +82,7 @@ It is not allowed to make further changes after the entity has been "marked" as 
 
 NOTE: If you want to make changes after deleting the state you should use the `updateState` effect with an empty state instead of using `deleteEntity`.
 
-It is best to not reuse the same entity key after deletion, but if that happens after the entity has been completely removed it will be instantiated as a completely new entity without any knowledge of previous state.
+It is best to not reuse the same entity id after deletion, but if that happens after the entity has been completely removed it will be instantiated as a completely new entity without any knowledge of previous state.
 
 Note that xref:views.adoc#ve_delete[deleting View state] must be handled explicitly.
 

--- a/docs/src/modules/java/partials/entity-ids.adoc
+++ b/docs/src/modules/java/partials/entity-ids.adoc
@@ -15,7 +15,7 @@ For instance, `@Id("id")` will instruct Kalix to look up a matching path variabl
 
 === Composite identifiers
 
-It's also possible to have a composite identifier. For example, `@Id({"groupId", "id"})` defines a composite identitier made of `groupId` and `id`. In such a case, the endpoints for this entity will need to have both path variables, e.g.:  `@RequestMapping("/users/\{groupId}/\{id}")`.
+It's also possible to have a composite identifier. For example, `@Id({"groupId", "id"})` defines a composite identifier made of `groupId` and `id`. In such a case, the endpoints for this entity will need to have both path variables, e.g.:  `@RequestMapping("/users/\{groupId}/\{id}")`.
 
 === Generated identifier
 

--- a/docs/src/modules/java/partials/entity-ids.adoc
+++ b/docs/src/modules/java/partials/entity-ids.adoc
@@ -8,16 +8,16 @@ In order to interact with an Entity in Kalix, we need to assign an *type id* and
 
 The entity id can be defined in different ways, as detailed below.
 
-=== Single keys
+=== Single identifier
 
 The most common use is to annotate the class with `@Id` and assign one path variable name to it.
 For instance, `@Id("id")` will instruct Kalix to look up a matching path variable. For an endpoint defined with `@RequestMapping("/users/\{id}")`, Kalix will extract whatever path segment is used to replace `\{id}` and treat it as the Entity unique identifier.
 
-=== Composite keys
+=== Composite identifiers
 
-It's also possible to have composite keys. For example, `@Id({"groupId", "id"})` defines a composite key made of `groupId` and `id`. In such a case, the endpoints for this entity will need to have both path variables, e.g.:  `@RequestMapping("/users/\{groupId}/\{id}")`.
+It's also possible to have a composite identifier. For example, `@Id({"groupId", "id"})` defines a composite identitier made of `groupId` and `id`. In such a case, the endpoints for this entity will need to have both path variables, e.g.:  `@RequestMapping("/users/\{groupId}/\{id}")`.
 
-=== Generated keys
+=== Generated identifier
 
 Finally, you can ask Kalix to generate an unique identifier, this is typically useful when creating an Entity, and the id is a surrogate id. To indicate to Kalix that an Entity id should be generated rather than extracted from the path, be sure to annotate the corresponding command method with `@GenerateId`. Typically, an Entity has only one method annotated with `@GenerateId`. The one that creates the Entity. All other methods will have `@Id` annotation in order to extract the surrogate id from the endpoint path.
 

--- a/docs/src/modules/java/partials/entity-ids.adoc
+++ b/docs/src/modules/java/partials/entity-ids.adoc
@@ -13,7 +13,7 @@ The entity id can be defined in different ways, as detailed below.
 The most common use is to annotate the class with `@Id` and assign one path variable name to it.
 For instance, `@Id("id")` will instruct Kalix to look up a matching path variable. For an endpoint defined with `@RequestMapping("/users/\{id}")`, Kalix will extract whatever path segment is used to replace `\{id}` and treat it as the Entity unique identifier.
 
-=== Composite identifiers
+=== Composite identifier
 
 It's also possible to have a composite identifier. For example, `@Id({"groupId", "id"})` defines a composite identifier made of `groupId` and `id`. In such a case, the endpoints for this entity will need to have both path variables, e.g.:  `@RequestMapping("/users/\{groupId}/\{id}")`.
 

--- a/samples/java-spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartEntity.java
+++ b/samples/java-spring-eventsourced-shopping-cart/src/main/java/com/example/shoppingcart/ShoppingCartEntity.java
@@ -8,7 +8,6 @@ import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
 import kalix.javasdk.annotations.Id;
 import kalix.javasdk.annotations.TypeId;
 import kalix.javasdk.annotations.EventHandler;
-import kalix.javasdk.annotations.GenerateEntityKey;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;

--- a/samples/java-spring-valueentity-counter/src/main/java/com/example/CounterEntity.java
+++ b/samples/java-spring-valueentity-counter/src/main/java/com/example/CounterEntity.java
@@ -3,7 +3,6 @@ package com.example;
 import kalix.javasdk.valueentity.ValueEntity;
 import kalix.javasdk.annotations.Id;
 import kalix.javasdk.annotations.TypeId;
-import kalix.javasdk.annotations.GenerateEntityKey;
 
 
 import org.springframework.web.bind.annotation.*;

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
@@ -77,7 +77,7 @@ public class EventSourcedEntitiesTestModels {
 
 
   @TypeId("counter")
-  public static class CounterEventSourcedEntityWithEntityKeyOnMethod extends EventSourcedEntity<Integer, Object> {
+  public static class CounterEventSourcedEntityWithIdOnMethod extends EventSourcedEntity<Integer, Object> {
     @Id("id")
     @GetMapping("/eventsourced/{id}/int/{number}")
     public Integer getInteger(@PathVariable Integer number) {
@@ -87,7 +87,7 @@ public class EventSourcedEntitiesTestModels {
 
   @Id("id")
   @TypeId("counter")
-  public static class CounterEventSourcedEntityWithEntityKeyMethodOverride extends EventSourcedEntity<Integer, Object> {
+  public static class CounterEventSourcedEntityWithIdMethodOverride extends EventSourcedEntity<Integer, Object> {
 
     @Id("counter_id")
     @GetMapping("/eventsourced/{counter_id}/int/{number}")
@@ -97,7 +97,7 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @TypeId("counter")
-  public static class CounterEventSourcedEntityWithEntityKeyGenerator extends EventSourcedEntity<Integer, Object> {
+  public static class CounterEventSourcedEntityWithIdGenerator extends EventSourcedEntity<Integer, Object> {
     @GenerateId
     @PutMapping("/eventsourced/int/{number}")
     public Integer getInteger(@PathVariable Integer number) {
@@ -106,7 +106,7 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @TypeId("counter")
-  public static class IllDefinedEntityWithEntityKeyGeneratorAndEntityKey extends EventSourcedEntity<Integer, Object> {
+  public static class IllDefinedEntityWithIdGeneratorAndId extends EventSourcedEntity<Integer, Object> {
     @GenerateId
     @Id("id")
     @GetMapping("/eventsourced/{id}/int/{number}")
@@ -116,7 +116,7 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @TypeId("counter")
-  public static class IllDefinedEntityWithoutEntityKeyGeneratorNorEntityKey extends EventSourcedEntity<Integer, Object> {
+  public static class IllDefinedEntityWithoutIdGeneratorNorId extends EventSourcedEntity<Integer, Object> {
     @GetMapping("/eventsourced/{id}/int/{number}")
     public Integer getInteger(@PathVariable Integer number) {
       return number;

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/valueentity/ValueEntitiesTestModels.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/valueentity/ValueEntitiesTestModels.java
@@ -33,7 +33,7 @@ public class ValueEntitiesTestModels {
   @Id( {"userId", "cartId"})
   @TypeId("user")
   @RequestMapping("/user/{userId}/{cartId}")
-  public static class PostWithEntityKeys extends ValueEntity<User> {
+  public static class PostWithIds extends ValueEntity<User> {
     @Override
     public User emptyState() {
       return null;

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/workflow/WorkflowTestModels.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/workflow/WorkflowTestModels.java
@@ -89,7 +89,7 @@ public class WorkflowTestModels {
 
   @TypeId("transfer-workflow")
   @RequestMapping("/transfer/{transferId}")
-  public static class WorkflowWithoutIdGeneratorAndEntityKey extends Workflow<WorkflowState> {
+  public static class WorkflowWithoutIdGeneratorAndId extends Workflow<WorkflowState> {
     @Override
     public WorkflowDef<WorkflowState> definition() {
       return null;

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/EventSourcedEntityDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/EventSourcedEntityDescriptorFactorySpec.scala
@@ -21,20 +21,20 @@ import kalix.JwtMethodOptions.JwtMethodMode
 import kalix.KeyGeneratorMethodOptions.Generator
 import kalix.javasdk.impl.reflection.ServiceIntrospectionException
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntity
-import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithEntityKeyGenerator
-import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithEntityKeyMethodOverride
-import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithEntityKeyOnMethod
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithIdGenerator
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithIdMethodOverride
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithIdOnMethod
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithJWT
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EventSourcedEntityWithMethodLevelAcl
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EventSourcedEntityWithServiceLevelAcl
-import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.IllDefinedEntityWithEntityKeyGeneratorAndEntityKey
-import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.IllDefinedEntityWithoutEntityKeyGeneratorNorEntityKey
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.IllDefinedEntityWithIdGeneratorAndId
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.IllDefinedEntityWithoutIdGeneratorNorId
 import org.scalatest.wordspec.AnyWordSpec
 
 class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuite {
 
   "EventSourced descriptor factory" should {
-    "generate mappings for a Event Sourced with entity keys in path" in {
+    "generate mappings for a Event Sourced with entity ids in path" in {
       assertDescriptor[CounterEventSourcedEntity] { desc =>
         val method = desc.commandHandlers("GetInteger")
         assertRequestFieldJavaType(method, "id", JavaType.STRING)
@@ -48,8 +48,8 @@ class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with Component
       }
     }
 
-    "generate mappings for a Event Sourced with entity keys in path and EntityKey on method" in {
-      assertDescriptor[CounterEventSourcedEntityWithEntityKeyOnMethod] { desc =>
+    "generate mappings for a Event Sourced with entity ids in path and EntityKey on method" in {
+      assertDescriptor[CounterEventSourcedEntityWithIdOnMethod] { desc =>
         val method = desc.commandHandlers("GetInteger")
         assertRequestFieldJavaType(method, "id", JavaType.STRING)
         assertEntityKeyField(method, "id")
@@ -57,8 +57,8 @@ class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with Component
       }
     }
 
-    "generate mappings for a Event Sourced with EntityKey on method overrides EntityKey on type" in {
-      assertDescriptor[CounterEventSourcedEntityWithEntityKeyMethodOverride] { desc =>
+    "generate mappings for a Event Sourced with Id on method overrides EntityKey on type" in {
+      assertDescriptor[CounterEventSourcedEntityWithIdMethodOverride] { desc =>
         val method = desc.commandHandlers("GetInteger")
         assertRequestFieldJavaType(method, "counter_id", JavaType.STRING)
         assertEntityKeyField(method, "counter_id")
@@ -66,20 +66,20 @@ class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with Component
       }
     }
 
-    "fail if mix EntityKey and GenerateEntityKey on method" in {
+    "fail if mix EntityKey and GenerateId on method" in {
       intercept[ServiceIntrospectionException] {
-        descriptorFor[IllDefinedEntityWithEntityKeyGeneratorAndEntityKey]
+        descriptorFor[IllDefinedEntityWithIdGeneratorAndId]
       }.getMessage should include("Invalid annotation usage. Found both @Id and @GenerateId annotations.")
     }
 
-    "fail if no EntityKey nor GenerateEntityKey is defined" in {
+    "fail if no EntityKey nor GenerateId is defined" in {
       intercept[ServiceIntrospectionException] {
-        descriptorFor[IllDefinedEntityWithoutEntityKeyGeneratorNorEntityKey]
+        descriptorFor[IllDefinedEntityWithoutIdGeneratorNorId]
       }.getMessage should include("Invalid command method. No @Id nor @GenerateId annotations found.")
     }
 
-    "generate mappings for a Event Sourced with GenerateEntityKey" in {
-      assertDescriptor[CounterEventSourcedEntityWithEntityKeyGenerator] { desc =>
+    "generate mappings for a Event Sourced with GenerateId" in {
+      assertDescriptor[CounterEventSourcedEntityWithIdGenerator] { desc =>
         val method = desc.commandHandlers("GetInteger")
         assertRequestFieldJavaType(method, "number", JavaType.INT)
 
@@ -88,7 +88,7 @@ class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with Component
       }
     }
 
-    "generate mappings for a Event Sourced with entity keys in path and JWT annotations" in {
+    "generate mappings for a Event Sourced with entity ids in path and JWT annotations" in {
       assertDescriptor[CounterEventSourcedEntityWithJWT] { desc =>
         val method = desc.commandHandlers("GetInteger")
         assertRequestFieldJavaType(method, "id", JavaType.STRING)

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ValueEntityDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ValueEntityDescriptorFactorySpec.scala
@@ -19,7 +19,7 @@ package kalix.javasdk.impl
 import com.google.protobuf.Any
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import kalix.spring.testmodels.valueentity.ValueEntitiesTestModels.GetWithQueryParams
-import kalix.spring.testmodels.valueentity.ValueEntitiesTestModels.PostWithEntityKeys
+import kalix.spring.testmodels.valueentity.ValueEntitiesTestModels.PostWithIds
 import kalix.spring.testmodels.valueentity.ValueEntitiesTestModels.ValueEntityWithMethodLevelAcl
 import kalix.spring.testmodels.valueentity.ValueEntitiesTestModels.ValueEntityWithServiceLevelAcl
 import org.scalatest.wordspec.AnyWordSpec
@@ -27,8 +27,8 @@ import org.scalatest.wordspec.AnyWordSpec
 class ValueEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuite {
 
   "ValueEntity descriptor factory" should {
-    "generate mappings for a Value Entity with entity keys in path" in {
-      assertDescriptor[PostWithEntityKeys] { desc =>
+    "generate mappings for a Value Entity with entity ids in path" in {
+      assertDescriptor[PostWithIds] { desc =>
         val method = desc.commandHandlers("CreateEntity")
         assertRequestFieldJavaType(method, "json_body", JavaType.MESSAGE)
         assertRequestFieldMessageType(method, "json_body", Any.getDescriptor.getFullName)

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/WorkflowEntityDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/WorkflowEntityDescriptorFactorySpec.scala
@@ -29,13 +29,13 @@ import kalix.spring.testmodels.workflow.WorkflowTestModels.WorkflowWithKeyOverri
 import kalix.spring.testmodels.workflow.WorkflowTestModels.WorkflowWithMethodLevelAcl
 import kalix.spring.testmodels.workflow.WorkflowTestModels.WorkflowWithMethodLevelKey
 import kalix.spring.testmodels.workflow.WorkflowTestModels.WorkflowWithTypeLevelKey
-import kalix.spring.testmodels.workflow.WorkflowTestModels.WorkflowWithoutIdGeneratorAndEntityKey
+import kalix.spring.testmodels.workflow.WorkflowTestModels.WorkflowWithoutIdGeneratorAndId
 import org.scalatest.wordspec.AnyWordSpec
 
 class WorkflowEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuite {
 
   "Workflow descriptor factory" should {
-    "generate mappings for a Workflow with entity keys in path" in {
+    "generate mappings for a Workflow with entity ids in path" in {
       assertDescriptor[WorkflowWithTypeLevelKey] { desc =>
         val method = desc.commandHandlers("StartTransfer")
         val fieldKey = "transferId"
@@ -55,7 +55,7 @@ class WorkflowEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDesc
       }
     }
 
-    "generate mappings for a Workflow with EntityKey on method overrides EntityKey on type" in {
+    "generate mappings for a Workflow with Id on method overrides EntityKey on type" in {
       assertDescriptor[WorkflowWithKeyOverridden] { desc =>
         val method = desc.commandHandlers("StartTransfer")
         val fieldKey = "transferId"
@@ -65,15 +65,15 @@ class WorkflowEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDesc
       }
     }
 
-    "fail if mix EntityKey and GenerateEntityKey on method" in {
+    "fail if mix Id and GenerateId on method" in {
       intercept[ServiceIntrospectionException] {
         descriptorFor[WorkflowWithIllDefinedIdGenerator]
       }.getMessage should include("Invalid annotation usage. Found both @Id and @GenerateId annotations.")
     }
 
-    "fail if no EntityKey nor GenerateEntityKey is defined" in {
+    "fail if no Id nor GenerateId is defined" in {
       intercept[ServiceIntrospectionException] {
-        descriptorFor[WorkflowWithoutIdGeneratorAndEntityKey]
+        descriptorFor[WorkflowWithoutIdGeneratorAndId]
       }.getMessage should include("Invalid command method. No @Id nor @GenerateId annotations found.")
     }
 


### PR DESCRIPTION
I spotted a few more usages of 'key'.

We still mention it in the protobuf docs and glossary, we will be able to change it once in have the new annotations in the proxy protocol. 



