### PR TITLE
docs: fix missing image in eventing testkit

### DIFF
--- a/docs/src/modules/java/partials/eventing-testkit-intro.adoc
+++ b/docs/src/modules/java/partials/eventing-testkit-intro.adoc
@@ -10,6 +10,7 @@ When a Kalix service relies on a broker, it might be useful to use integration t
 Following up on the counter entity example used above, let's consider an example (composed by 2 Actions and 1 Event Sourced entity) as pictured below:
 
 ifdef::todo[TODO: convert this diagram once we have a standard language for this]
+
 image::java:eventing-testkit-sample.svg[]
 
 In this example:


### PR DESCRIPTION
There should be an image [here](https://docs.kalix.dev/java/actions-publishing-subscribing.html#_testkit_mocked_topic), but there is not.

<img width="980" alt="Screenshot 2023-06-28 at 16 11 30" src="https://github.com/lightbend/kalix-jvm-sdk/assets/1105359/3c27f01d-bfc9-43df-b40d-ea14d033d3d7">

All because of a missing `\n`...