### PR TITLE
fix!: update enum for gpubsub and add docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,7 +575,6 @@ jobs:
           - { sample: java-spring-valueentity-shopping-cart, it: true }
           - { sample: java-spring-valueentity-customer-registry, it: true }
 
-          # FIXME add eventing integration tests (related to https://github.com/lightbend/kalix/issues/7811)
           - { sample: java-spring-eventsourced-counter, pre_cmd: 'docker-compose -f ../../.circleci/google-pubsub-emulator-docker-compose.yml up -d', it: true }
 
           - { sample: java-protobuf-replicatedentity-shopping-cart, it: true }

--- a/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java-protobuf/pages/actions-publishing-subscribing.adoc
@@ -636,3 +636,23 @@ include::example$scala-protobuf-eventsourced-counter/src/test/scala/com/example/
 <2> Clear the topic ignoring any unread messages.
 
 NOTE: Despite the example, you are neither forced to clear all topics nor to do it before each test. You can do it selectively, or you might not even need it depending on your tests and the flows they test.
+
+=== External Broker
+
+To run an integration test against a real instance of Google PubSub (or its Emulator), use the TestKit settings to override the default eventing support, as shown below:
+
+[.tabset]
+Java::
++
+[source,java]
+private static final KalixTestKitResource testKit = new KalixTestKitResource(
+        Main.createKalix(),
+        Settings.DEFAULT.withEventingSupport(EventingSupport.GOOGLE_PUBSUB)
+    );
+Scala::
++
+[source,scala,indent=0]
+private val testKit = KalixTestKit(
+    Main.createKalix(),
+    DefaultSettings.withEventingSupport(GooglePubSub)
+  ).start()

--- a/docs/src/modules/java/pages/access-control.adoc
+++ b/docs/src/modules/java/pages/access-control.adoc
@@ -175,7 +175,7 @@ When running integration tests, ACLs are disabled by default but can be explicit
 
 [source, java]
 ----
-include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestkitConfig.java[tag=class]
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestkitConfig.java[tags=class;acls]
 ----
 <1> Using the DEFAULT `Settings` and enabling ACL.
 

--- a/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
@@ -253,3 +253,13 @@ include::example$java-spring-eventsourced-counter/src/it/java/com/example/Counte
 <2> Clear the topic ignoring any unread messages.
 
 NOTE: Despite the example, you are neither forced to clear all topics nor to do it before each test. You can do it selectively, or you might not even need it depending on your tests and the flows they test.
+
+=== External Broker
+
+To run an integration test against a real instance of Google PubSub (or its Emulator), use the TestKit settings to override the default eventing support, as shown below:
+
+[source,java]
+.src/it/java/com/example/TestkitConfig.java
+----
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestkitConfig.java[tags=class;pubsub]
+----

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/src/it/java/customer/api/CustomerActionIntegrationTest.java
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/src/it/java/customer/api/CustomerActionIntegrationTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static kalix.javasdk.testkit.KalixTestKit.Settings.EventingSupport.GOOGLE_PUBSUB_EMULATOR;
+import static kalix.javasdk.testkit.KalixTestKit.Settings.EventingSupport.GOOGLE_PUBSUB;
 import static org.junit.Assert.assertEquals;
 
 // This class was initially generated based on the .proto definition by Kalix tooling.

--- a/samples/java-spring-eventsourced-counter/README.md
+++ b/samples/java-spring-eventsourced-counter/README.md
@@ -69,3 +69,17 @@ to create a project and then deploy your service into the project either by usin
 will conveniently package, publish your docker image, and deploy your service to Kalix, or by first packaging and
 publishing the docker image through `mvn deploy` and then deploying the image
 through the `kalix` CLI.
+
+## Integration Tests
+
+This sample showcases how to have integration tests with and without a real broker. Thus, to run the integration tests locally, you need to have Google PubSub Emulator running.
+
+First run:
+```shell
+docker-compose up -d gcloud-pubsub-emulator
+```
+
+Then run:
+```shell
+mvn verify -Pit
+```

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -255,12 +255,16 @@
       <version>${kalix-sdk.version}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationWithRealPubSubTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationWithRealPubSubTest.java
@@ -72,18 +72,21 @@ public class CounterIntegrationWithRealPubSubTest extends KalixIntegrationTestKi
     // builds a message in PubSub format, ready to be injected
     private String buildMessageBody(String jsonMsg, String ceType) {
         var data = Base64.getEncoder().encodeToString(jsonMsg.getBytes());
-        return "{\n" +
-            "    \"messages\": [\n" +
-            "        {\n" +
-            "            \"data\": \"" + data + "\",\n" +
-            "            \"attributes\": {\n" +
-            "                \"Content-Type\": \"application/json\",\n" +
-            "                \"ce-specversion\": \"1.0\",\n" +
-            "                \"ce-type\": \"" + ceType + "\"\n" +
-            "            }\n" +
-            "        }\n" +
-            "    ]\n" +
-            "}";
+
+        return """
+            {
+                "messages": [
+                    {
+                        "data": "%s",
+                        "attributes": {
+                            "Content-Type": "application/json",
+                            "ce-specversion": "1.0",
+                            "ce-type": "%s"
+                        }
+                    }
+                ]
+            }
+            """.formatted(data, ceType);
     }
 
 // tag::class[]

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationWithRealPubSubTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationWithRealPubSubTest.java
@@ -1,0 +1,91 @@
+package com.example;
+
+import com.example.actions.CounterCommandFromTopicAction;
+import kalix.javasdk.testkit.KalixTestKit;
+import kalix.spring.testkit.KalixIntegrationTestKitSupport;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// tag::class[]
+@SpringBootTest(classes = Main.class)
+@Import(TestkitConfig.class)
+@ActiveProfiles("with-pubsub")
+public class CounterIntegrationWithRealPubSubTest extends KalixIntegrationTestKitSupport { // <1>
+
+// end::class[]
+
+    private Duration timeout = Duration.of(10, SECONDS);
+
+    @Autowired
+    private WebClient webClient;
+
+    @Test
+    public void verifyCounterEventSourcedConsumesFromPubSub() {
+        WebClient pubsubClient = WebClient.builder()
+            .baseUrl("http://localhost:8085")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+
+        var counterId = "testRealPubSub";
+        var messageBody = buildMessageBody(
+            "{\"counterId\":\"" + counterId + "\",\"value\":20}",
+            CounterCommandFromTopicAction.IncreaseCounter.class.getName());
+
+        var projectId = "test";
+        var injectMsgResult = pubsubClient.post()
+            .uri("/v1/projects/{projectId}/topics/counter-commands:publish", projectId)
+            .bodyValue(messageBody)
+            .retrieve()
+            .toBodilessEntity().block();
+        assertTrue(injectMsgResult.getStatusCode().is2xxSuccessful());
+
+        await()
+            .ignoreExceptions()
+            .atMost(20, TimeUnit.SECONDS)
+            .until(() ->
+                    webClient.get()
+                        .uri("/counter/" + counterId)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block(timeout),
+                new IsEqual("\"20\"")
+            );
+    }
+    // end::test-topic[]
+
+    // builds a message in PubSub format, ready to be injected
+    private String buildMessageBody(String jsonMsg, String ceType) {
+        var data = Base64.getEncoder().encodeToString(jsonMsg.getBytes());
+        return "{\n" +
+            "    \"messages\": [\n" +
+            "        {\n" +
+            "            \"data\": \"" + data + "\",\n" +
+            "            \"attributes\": {\n" +
+            "                \"Content-Type\": \"application/json\",\n" +
+            "                \"ce-specversion\": \"1.0\",\n" +
+            "                \"ce-type\": \"" + ceType + "\"\n" +
+            "            }\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
+    }
+
+// tag::class[]
+}
+// end::class[]

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/TestkitConfig.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/TestkitConfig.java
@@ -1,14 +1,33 @@
 package com.example;
+import kalix.javasdk.testkit.KalixTestKit.Settings.EventingSupport;
+
 // tag::class[]
 import kalix.javasdk.testkit.KalixTestKit;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
 public class TestkitConfig {
+    // end::class[]
+
+    @Profile("with-acls")
+    // tag::acls[]
     @Bean
     public KalixTestKit.Settings settings() {
         return KalixTestKit.Settings.DEFAULT.withAclEnabled(); // <1>
     }
+    // end::acls[]
+
+    @Profile("with-pubsub")
+    // tag::pubsub[]
+    @Bean
+    public KalixTestKit.Settings settingsWithPubSub() {
+        return KalixTestKit.Settings.DEFAULT.withAclEnabled()
+            .withEventingSupport(EventingSupport.GOOGLE_PUBSUB);
+    }
+    // end::pubsub[]
+
+// tag::class[]
 }
 // end::class[]

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -108,7 +108,7 @@ public class KalixTestKit {
        *
        * Note: the Google PubSub Emulator need to be started independently.
        */
-      GOOGLE_PUBSUB_EMULATOR
+      GOOGLE_PUBSUB
     }
 
     private Settings(
@@ -286,7 +286,7 @@ public class KalixTestKit {
 
     testSystem = ActorSystem.create("KalixTestkit", ConfigFactory.parseString("akka.http.server.preview.enable-http2 = true"));
 
-    int eventingBackendPort = settings.eventingSupport.equals(Settings.EventingSupport.GOOGLE_PUBSUB_EMULATOR) ? DEFAULT_GOOGLE_PUBSUB_PORT : startEventingTestkit();
+    int eventingBackendPort = settings.eventingSupport.equals(Settings.EventingSupport.GOOGLE_PUBSUB) ? DEFAULT_GOOGLE_PUBSUB_PORT : startEventingTestkit();
     runProxy(useTestContainers, port, eventingBackendPort);
 
     started = true;

--- a/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/KalixTestKit.scala
+++ b/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/KalixTestKit.scala
@@ -24,7 +24,7 @@ import kalix.scalasdk.{ Kalix, Principal }
 import kalix.javasdk.testkit.{ KalixTestKit => JTestKit }
 import kalix.javasdk.testkit.KalixTestKit.Settings.{ EventingSupport => JEventingSupport }
 import kalix.scalasdk.testkit.KalixTestKit.Settings.EventingSupport
-import kalix.scalasdk.testkit.KalixTestKit.Settings.GooglePubSubEmulator
+import kalix.scalasdk.testkit.KalixTestKit.Settings.GooglePubSub
 import kalix.scalasdk.testkit.KalixTestKit.Settings.TestBroker
 
 import scala.concurrent.duration.FiniteDuration
@@ -58,8 +58,8 @@ object KalixTestKit {
       new Settings(jSettings.withServicePortMapping(serviceName, host, port))
     def withEventingSupport(eventingSupport: EventingSupport): Settings = {
       val jEventingSupport = eventingSupport match {
-        case TestBroker           => JEventingSupport.TEST_BROKER
-        case GooglePubSubEmulator => JEventingSupport.GOOGLE_PUBSUB_EMULATOR
+        case TestBroker   => JEventingSupport.TEST_BROKER
+        case GooglePubSub => JEventingSupport.GOOGLE_PUBSUB
       }
       new Settings(jSettings.withEventingSupport(jEventingSupport))
     }
@@ -83,7 +83,7 @@ object KalixTestKit {
      *
      * Note: the Google PubSub Emulator need to be started independently.
      */
-    object GooglePubSubEmulator extends EventingSupport
+    object GooglePubSub extends EventingSupport
   }
 
   val DefaultSettings: Settings = new Settings(JTestKit.Settings.DEFAULT)


### PR DESCRIPTION
Close #1694 

While adding docs on how to configure an integration test to run against a real pubsub instance, I noticed that the enum value we provide on the settings is wrong (we've called it `GOOGLE_PUBSUB_EMULATOR` instead of `GOOGLE_PUBSUB`).. Using "emulator" suffix does not make much sense because in theory you could also run against a real gpubsub instance.

So along with docs, I'm changing the enum as well.

This is a breaking change but.. this option/enum was something recently introduced in 1.3.0, was not documented properly and is only for testkits, so I believe it's not a big deal to change it. But let me know your thoughts.