### PR TITLE
fix: logback config not working when packaged

### DIFF
--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/logging/KalixJoranConfigurator.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/logging/KalixJoranConfigurator.scala
@@ -73,7 +73,9 @@ class KalixJoranConfigurator extends DefaultJoranConfigurator {
       status
 
     } else {
-      ExecutionStatus.INVOKE_NEXT_IF_ANY
+      val status = super.configure(loggerContext)
+      addInfo("Kalix application running in packaged mode")
+      status
     }
   }
 }


### PR DESCRIPTION
Fix #1758 

I have confirmed both locally and when deploying to Kalix cloud. The current jvm sdk v1.3.2 causes the logs of deployed services to be in DEBUG and formatted in plaintext instead of JSON.