### PR TITLE
service reference matches example code

### DIFF
--- a/docs/src/modules/java/pages/access-control.adoc
+++ b/docs/src/modules/java/pages/access-control.adoc
@@ -15,7 +15,7 @@ Here is an example ACL on a method:
 include::example$java-spring-doc-snippets/src/main/java/com/example/acl/MyAction.java[tag=allow-deny]
 ----
 
-The above ACL allows traffic to all services except the service called `my-service`. 
+The above ACL allows traffic to all services except the service called `service-b`.
 
 To allow all traffic:
 


### PR DESCRIPTION
No issue.  Just noticed...

The example looks like:
![image](https://github.com/lightbend/kalix-jvm-sdk/assets/40366664/99e174c4-d852-4275-acbd-cbe5d907f257)

This change just makes the text match the example.