### PR TITLE
docs(java): fix missing redirect to component calls page

### DIFF
--- a/docs/src/modules/java/pages/component-and-service-calls.adoc
+++ b/docs/src/modules/java/pages/component-and-service-calls.adoc
@@ -1,5 +1,5 @@
 = Component and Service Calls
-:page-aliases: spring:component-and-service-calls.adoc
+:page-aliases: spring:call-another-service.adoc, java:call-another-service.adoc
 
 == Kalix components
 


### PR DESCRIPTION
Follow-up fix from https://github.com/lightbend/kalix-jvm-sdk/pull/1751/files

The aliases were changed inadvertly and missed the old name.