### PR TITLE
chore: use java block for sample json

### DIFF
--- a/samples/java-protobuf-doc-snippets/src/it/java/com/example/JwtIntegrationTest.java
+++ b/samples/java-protobuf-doc-snippets/src/it/java/com/example/JwtIntegrationTest.java
@@ -58,7 +58,8 @@ public class JwtIntegrationTest {
 
   private String bearerTokenWith(Map<String, String> claims) throws JsonProcessingException {
     // setting algorithm to none
-    String alg = Base64.getEncoder().encodeToString("{\"alg\":\"none\"}".getBytes()); // <4>
+    String alg = Base64.getEncoder()
+        .encodeToString("{\"alg\":\"none\"}".getBytes()); // <4>
     byte[] jsonClaims = new ObjectMapper().writeValueAsBytes(claims);
 
     // no validation is done for integration tests, thus no valid signature required

--- a/samples/java-spring-doc-snippets/src/it/java/com/example/jwt/JwtIntegrationTest.java
+++ b/samples/java-spring-doc-snippets/src/it/java/com/example/jwt/JwtIntegrationTest.java
@@ -40,7 +40,11 @@ public class JwtIntegrationTest extends KalixIntegrationTestKitSupport {
 
   private String bearerTokenWith(Map<String, String> claims) throws JsonProcessingException {
     // setting algorithm to none
-    String alg = Base64.getEncoder().encodeToString("{\"alg\":\"none\"}".getBytes()); // <3>
+    String alg = Base64.getEncoder().encodeToString("""
+        {
+          "alg": "none"
+        }
+        """.getBytes()); // <3>
     byte[] jsonClaims = new ObjectMapper().writeValueAsBytes(claims);
 
     // no validation is done for integration tests, thus no valid signature required


### PR DESCRIPTION
Tiny follow-up of https://github.com/lightbend/kalix-jvm-sdk/pull/1787