### PR TITLE
bump: protobuf-java 3.21.12 (was 3.21.1)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val ScalaVersionForTooling = "2.12.15"
 
   val ProtobufVersion = // akka.grpc.gen.BuildInfo.googleProtobufVersion
-    "3.20.3" // explicitly overriding the 3.20.1 version from Akka gRPC 2.1.6
+    "3.21.12" // explicitly overriding the 3.21.1 version from Akka gRPC 2.1.6 (even though its build says 3.20.1)
 
   val AkkaVersion = "2.6.20"
   val AkkaHttpVersion = "10.2.10" // Note: should at least the Akka HTTP version required by Akka gRPC


### PR DESCRIPTION
Trying to get rid of some CVEs that are reported against even older protobuf-java versions.

As it turns out, Akka gRPC 2.1.6 pulls protobuf-java 3.21.1 as the 3.20.1 version is consistently evicted.

References
- https://github.com/lightbend/kalix/issues/9434
- https://github.com/lightbend/kalix/issues/9429