### PR TITLE
bump: require Maven 3.6.0 (align with docs)

### DIFF
--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -172,8 +172,9 @@
             </goals>
             <configuration>
               <rules>
+                <!-- keep in sync with maven-java/pom.xml#L49 -->
                 <requireMavenVersion>
-                  <version>3.5.0</version>
+                  <version>3.6.0</version>
                 </requireMavenVersion>
               </rules>
               <rules>

--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -42,7 +42,11 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
-    <maven.version>3.5.0</maven.version>
+    <!-- keep in sync with
+     maven-java/kalix-maven-plugin/pom.xml#L176 and
+     docs/build/src/managed/modules/java/partials/attributes.adoc#L4
+    -->
+    <maven.version>3.6.0</maven.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Our docs demand Maven 3.6.0 already. Let the Kalix Maven plugin do that, as well.

References 
- https://docs.kalix.io/java/getting-started.html#_prerequisites
- #1805 