### PR TITLE
bump: align Akka gRPC version in Maven with sbt

### DIFF
--- a/docs/src/modules/java-protobuf/pages/spring-client.adoc
+++ b/docs/src/modules/java-protobuf/pages/spring-client.adoc
@@ -143,7 +143,7 @@ Download the resulting ZIP file, which is an archive of a web application that i
 
 ----
   <properties>
-        <akka-grpc.version>2.1.4</akka-grpc.version>
+        <akka-grpc.version>2.1.6</akka-grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
         <grpc.version>1.44.0</grpc.version>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>@project.version@</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>@project.version@</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val ProtobufVersion = // akka.grpc.gen.BuildInfo.googleProtobufVersion
     "3.21.12" // explicitly overriding the 3.21.1 version from Akka gRPC 2.1.6 (even though its build says 3.20.1)
 
-  val AkkaVersion = "2.6.20"
+  val AkkaVersion = "2.6.21"
   val AkkaHttpVersion = "10.2.10" // Note: should at least the Akka HTTP version required by Akka gRPC
   val ScalaTestVersion = "3.2.14"
   val JacksonVersion = "2.14.3"

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <kalix-sdk.version>1.3.3</kalix-sdk.version>
-        <akka-grpc.version>2.1.4</akka-grpc.version>
+        <akka-grpc.version>2.1.6</akka-grpc.version>
     </properties>
 
     <build>

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -21,7 +21,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <kalix-sdk.version>1.3.3</kalix-sdk.version>
-      <akka-grpc.version>2.1.4</akka-grpc.version>
+      <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -21,7 +21,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <kalix-sdk.version>1.3.3</kalix-sdk.version>
-      <akka-grpc.version>2.1.4</akka-grpc.version>
+      <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -19,7 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-valueentity-counter-spring-client/pom.xml
+++ b/samples/java-protobuf-valueentity-counter-spring-client/pom.xml
@@ -21,7 +21,7 @@
         <java.version>11</java.version>
         <jdk.target>11</jdk.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <akka-grpc.version>2.1.4</akka-grpc.version>
+        <akka-grpc.version>2.1.6</akka-grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
         <grpc.version>1.44.0</grpc.version>

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -21,7 +21,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -21,7 +21,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <kalix-sdk.version>1.3.3</kalix-sdk.version>
-      <akka-grpc.version>2.1.4</akka-grpc.version>
+      <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-protobuf-web-resources/pom.xml
+++ b/samples/java-protobuf-web-resources/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <kalix-sdk.version>1.3.3</kalix-sdk.version>
-    <akka-grpc.version>2.1.4</akka-grpc.version>
+    <akka-grpc.version>2.1.6</akka-grpc.version>
     <protobuf-java.version>3.22.2</protobuf-java.version>
   </properties>
 


### PR DESCRIPTION
Akka 2.6.21 is the last build of the 2.6 line.

https://github.com/lightbend/kalix-jvm-sdk/blob/ba0c30d1c5efe35df3a3f840ebfcd683299732c8/project/plugins.sbt#L3-L4

Fixes 
- #1709 