### PR TITLE
test: update some test timing for projections

### DIFF
--- a/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
+++ b/samples/java-protobuf-eventsourced-counter/src/it/java/com/example/CounterTopicIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.URI;
+import java.time.Duration;
 
 import static org.junit.Assert.assertEquals;
 
@@ -97,7 +98,7 @@ public class CounterTopicIntegrationTest {
 
     commandsTopic.publish(testKit.getMessageBuilder().of(increaseCmd, metadata)); // <4>
 
-    var increasedEvent = eventsTopicWithMeta.expectOneTyped(CounterTopicApi.Increased.class);
+    var increasedEvent = eventsTopicWithMeta.expectOneTyped(CounterTopicApi.Increased.class, Duration.ofSeconds(10));
     var actualMd = increasedEvent.getMetadata(); // <5>
     assertEquals(counterId, actualMd.asCloudEvent().subject().get()); // <6>
     assertEquals("application/protobuf", actualMd.get("Content-Type").get());

--- a/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventingTestKitImpl.scala
+++ b/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/EventingTestKitImpl.scala
@@ -376,7 +376,7 @@ private[testkit] class OutgoingMessagesImpl(
     expectOneTyped(clazz, DefaultTimeout)
 
   override def expectOneTyped[T](clazz: Class[T], timeout: time.Duration): TestKitMessage[T] = {
-    val msg = destinationProbe.expectMsgType[EmitSingleCommand]
+    val msg = destinationProbe.expectMsgType[EmitSingleCommand](timeout.toScala)
     val metadata = new MetadataImpl(msg.getMessage.getMetadata.entries)
     val scalaPb = ScalaPbAny(typeUrlFor(metadata), msg.getMessage.payload)
 

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
@@ -389,8 +389,15 @@ public class SpringSdkIntegrationTest {
     TestUser user = new TestUser("123", "john@doe.com", "JohnDoe");
 
     createUser(user);
-    updateUser(user.withName("JohnDoeJr"));
 
+    // the view is eventually updated
+    await()
+      .ignoreExceptions()
+      .atMost(15, TimeUnit.of(SECONDS))
+      .until(() -> getUserByEmail(user.email).version,
+        new IsEqual(1));
+
+    updateUser(user.withName("JohnDoeJr"));
 
     // the view is eventually updated
     await()

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/DockerIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/DockerIntegrationTest.java
@@ -119,7 +119,7 @@ public abstract class DockerIntegrationTest {
     await()
       .ignoreExceptions()
       .pollInterval(5, TimeUnit.SECONDS)
-      .atMost(60, TimeUnit.SECONDS)
+      .atMost(120, TimeUnit.SECONDS)
       .until(() -> assertSourceServiceIsUp(webClient),
         new IsEqual(HttpStatus.NOT_FOUND)  // NOT_FOUND is a sign that the customer registry service is there
       );

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/tracing/TracingIntegratonTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/tracing/TracingIntegratonTest.java
@@ -55,7 +55,7 @@ public class TracingIntegratonTest extends DockerIntegrationTest {
         String counterId = "some-counter";
         callTCounter(counterId, 10);
 
-        await().ignoreExceptions().atMost(20, TimeUnit.of(SECONDS)).untilAsserted(() -> {
+        await().ignoreExceptions().atMost(60, TimeUnit.of(SECONDS)).untilAsserted(() -> {
            Traces traces = selectTraces();
            assertThat(traces.traces().isEmpty()).isFalse();
            Batches batches = selectBatches(traces.traces().get(0).traceID());


### PR DESCRIPTION
Updating the timing for some tests that failed in #1810, with the switch to H2 and some longer delays for projections. There may be others that need adjusting. Separate from the bump PR, but will also test there.