### PR TITLE
docs: add note to Value Entities not being Value Objects

### DIFF
--- a/docs/src/modules/java-protobuf/pages/value-entity.adoc
+++ b/docs/src/modules/java-protobuf/pages/value-entity.adoc
@@ -4,7 +4,7 @@ include::ROOT:partial$include.adoc[]
 
 https://docs.kalix.io/reference/glossary.html#value_entity[Value Entities] persist state on every change and Kalix needs to serialize that data to send it to the underlying data store, this is done with Protocol Buffers using `protobuf` types.
 
-NOTE: Kalix _Value Entities_ have nothing in common with the domain-driven design concept of _Value Objects_. The _Value_ in the name refers to directly modifying a value for the entity's state -- in contrast to https://docs.kalix.io/reference/glossary.html#event_sourced_entity[Event-sourced Entities] that persist events and the entity state is derived from them.
+NOTE: Kalix _Value Entities_ have nothing in common with the domain-driven design concept of _Value Objects_. The _Value_ in the name refers to directly modifying a value for the entity's state - in contrast to https://docs.kalix.io/reference/glossary.html#event_sourced_entity[Event-sourced Entities] that persist events and the entity state is derived from them.
 
 While Protocol Buffers are the recommended format for persisting state, we recommend that you do not persist your service's public `protobuf` messages. This may introduce some overhead to convert from one type to the other but allows the service public interface logic to evolve independently of the data storage format, which should be private.
 

--- a/docs/src/modules/java-protobuf/pages/value-entity.adoc
+++ b/docs/src/modules/java-protobuf/pages/value-entity.adoc
@@ -4,6 +4,8 @@ include::ROOT:partial$include.adoc[]
 
 https://docs.kalix.io/reference/glossary.html#value_entity[Value Entities] persist state on every change and Kalix needs to serialize that data to send it to the underlying data store, this is done with Protocol Buffers using `protobuf` types.
 
+NOTE: Kalix _Value Entities_ have nothing in common with the domain-driven design concept of _Value Objects_. The _Value_ in the name refers to directly modifying a value for the entity's state -- in contrast to https://docs.kalix.io/reference/glossary.html#event_sourced_entity[Event-sourced Entities] that persist events and the entity state is derived from them.
+
 While Protocol Buffers are the recommended format for persisting state, we recommend that you do not persist your service's public `protobuf` messages. This may introduce some overhead to convert from one type to the other but allows the service public interface logic to evolve independently of the data storage format, which should be private.
 
 The steps necessary to implement a Value Entity include:

--- a/docs/src/modules/java/pages/value-entity.adoc
+++ b/docs/src/modules/java/pages/value-entity.adoc
@@ -5,6 +5,8 @@ include::ROOT:partial$include.adoc[]
 
 https://docs.kalix.io/reference/glossary.html#value_entity[Value Entities] persist state on every change and thus Kalix needs to serialize that data to send it to the underlying data store. However, we recommend that you do not persist your service's public API messages. Persisting private API messages may introduce some overhead when converting from a public message to an internal one but it allows the logic of the service public interface to evolve independently of the data storage format, which should be private.
 
+NOTE: Kalix _Value Entities_ have nothing in common with the domain-driven design concept of _Value Objects_. The _Value_ in the name refers to directly modifying a value for the entity's state -- in contrast to https://docs.kalix.io/reference/glossary.html#event_sourced_entity[Event-sourced Entities] that persist events and the entity state is derived from them.
+
 The steps necessary to implement a Value Entity include:
 
 . Defining the API and model the entity's state.

--- a/docs/src/modules/java/pages/value-entity.adoc
+++ b/docs/src/modules/java/pages/value-entity.adoc
@@ -5,7 +5,7 @@ include::ROOT:partial$include.adoc[]
 
 https://docs.kalix.io/reference/glossary.html#value_entity[Value Entities] persist state on every change and thus Kalix needs to serialize that data to send it to the underlying data store. However, we recommend that you do not persist your service's public API messages. Persisting private API messages may introduce some overhead when converting from a public message to an internal one but it allows the logic of the service public interface to evolve independently of the data storage format, which should be private.
 
-NOTE: Kalix _Value Entities_ have nothing in common with the domain-driven design concept of _Value Objects_. The _Value_ in the name refers to directly modifying a value for the entity's state -- in contrast to https://docs.kalix.io/reference/glossary.html#event_sourced_entity[Event-sourced Entities] that persist events and the entity state is derived from them.
+NOTE: Kalix _Value Entities_ have nothing in common with the domain-driven design concept of _Value Objects_. The _Value_ in the name refers to directly modifying a value for the entity's state - in contrast to https://docs.kalix.io/reference/glossary.html#event_sourced_entity[Event-sourced Entities] that persist events and the entity state is derived from them.
 
 The steps necessary to implement a Value Entity include:
 


### PR DESCRIPTION
People with a DDD background get confused by the term Value Entity. Until we have a better solution I suggest adding this note to the docs.

Refs
- https://github.com/lightbend/kalix-docs/issues/1926