### PR TITLE
docs: changing the file name

### DIFF
--- a/docs/src/modules/java/pages/access-control.adoc
+++ b/docs/src/modules/java/pages/access-control.adoc
@@ -175,7 +175,7 @@ When running integration tests, ACLs are disabled by default but can be explicit
 
 [source, java]
 ----
-include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfig.java[tags=class;acls]
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfiguration.java[tags=class;acls]
 ----
 <1> Using the DEFAULT `Settings` and enabling ACL.
 

--- a/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/actions-publishing-subscribing.adoc
@@ -219,8 +219,9 @@ TIP: In the example above we take advantage of the TestKit to serialize / deseri
 Before running your test, make sure to configure the TestKit correctly.
 
 [source, java]
+.src/it/java/com/example/TestKitConfiguration.java
 ----
-include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfig.java[tags=class;eventing-config]
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfiguration.java[tags=class;eventing-config]
 ----
 <1> Mock incoming messages from the `counter-commands` topic.
 <2> Mock outgoing messages from the `counter-events` topic.
@@ -267,7 +268,7 @@ NOTE: Despite the example, you are neither forced to clear all topics nor to do 
 To run an integration test against a real instance of Google PubSub (or its Emulator) or Kafka, use the TestKit settings to override the default eventing support, as shown below:
 
 [source,java]
-.src/it/java/com/example/TestkitConfig.java
+.src/it/java/com/example/TestKitConfiguration.java
 ----
-include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfig.java[tags=class;pubsub]
+include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfiguration.java[tags=class;pubsub]
 ----

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ActiveProfiles("with-mocked-eventing")
 // tag::class[]
 @SpringBootTest(classes = Main.class)
-@Import(TestKitConfig.class)
+@Import(TestKitConfiguration.class)
 public class CounterIntegrationTest extends KalixIntegrationTestKitSupport { // <1>
 
 // end::class[]

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationWithRealPubSubTest.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/CounterIntegrationWithRealPubSubTest.java
@@ -1,7 +1,6 @@
 package com.example;
 
 import com.example.actions.CounterCommandFromTopicAction;
-import kalix.javasdk.testkit.KalixTestKit;
 import kalix.spring.testkit.KalixIntegrationTestKitSupport;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // tag::class[]
 @SpringBootTest(classes = Main.class)
-@Import(TestKitConfig.class)
+@Import(TestKitConfiguration.class)
 @ActiveProfiles("with-pubsub")
 public class CounterIntegrationWithRealPubSubTest extends KalixIntegrationTestKitSupport { // <1>
 

--- a/samples/java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfiguration.java
+++ b/samples/java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Profile;
 
 // tag::class[]
 @Configuration
-public class TestKitConfig {
+public class TestKitConfiguration {
   // end::class[]
 
   @Profile("with-mocked-eventing")


### PR DESCRIPTION
changing the name from `TestkitConfig.java` to `TestKitConfig.java` results in:
```
Unresolved include directive in modules/java/pages/actions-publishing-subscribing.adoc - include::example$java-spring-eventsourced-counter/src/it/java/com/example/TestKitConfig.java[]
```
this could be related to the file system and how it manages the case changes in file names. I renamed the file to `TestkitConfiguration.java`