### PR TITLE
Correct GetCustomer to return non-null Address.

### DIFF
--- a/samples/scala-protobuf-customer-registry-quickstart/src/main/scala/customer/domain/Customer.scala
+++ b/samples/scala-protobuf-customer-registry-quickstart/src/main/scala/customer/domain/Customer.scala
@@ -49,7 +49,8 @@ class Customer(context: ValueEntityContext) extends AbstractCustomer {
     api.Customer(
       customerId = customer.customerId,
       email = customer.email,
-      name = customer.name
+      name = customer.name,
+      address = customer.address.map(address => api.Address(address.street, address.city))
     )
   // end::getCustomer[]
 


### PR DESCRIPTION
If you follow the quickstart tutorial and [run it](https://docs.kalix.io/java-protobuf/quickstart/cr-value-entity-scala.html#_invoke_your_service), by issuing `grpcurl` commands, `Address` will always come back as `null`, even when setting it, which may be perceived as a bug by the user experimenting with this.

References
- [docs](https://docs.kalix.io/java-protobuf/quickstart/cr-value-entity-scala.html)
