### PR TITLE
bumps: current Maven plugins

### DIFF
--- a/docs/src/modules/java-protobuf/pages/spring-client.adoc
+++ b/docs/src/modules/java-protobuf/pages/spring-client.adoc
@@ -26,7 +26,10 @@ To get started, do the following:
 
 - https://github.com/lightbend/kalix-jvm-sdk/archive/refs/heads/main.zip[Download] and unzip the source repository for this guide, or clone it using Git:
 
-`git clone https://github.com/lightbend/kalix-jvm-sdk.git`
+[source,command line]
+----
+git clone https://github.com/lightbend/kalix-jvm-sdk.git
+----
 
 - cd into `kalix-jvm-sdk/samples/java-protobuf-valueentity-counter`
 
@@ -36,15 +39,19 @@ With the source repository downloaded, you can build and run the Kalix Service l
 
 Run the Kalix Service using Maven:
 
-`mvn kalix:runAll`
+[source,command line]
+----
+mvn kalix:runAll
+----
 
 You should see output similar to the following:
 
-```
+[source,log]
+----
 [INFO] --- exec-maven-plugin:3.0.0:exec (default-cli) @ valueentity-counter ---
 {"timestamp":"2022-03-02T23:38:12.174Z","thread":"main","logger":"com.example.Main","message":"starting the Kalix service","context":"default","severity":"INFO"}
 {"timestamp":"2022-03-02T23:38:12.829Z","thread":"kalix-akka.actor.default-dispatcher-2","logger":"akka.event.slf4j.Slf4jLogger","message":"Slf4jLogger started","context":"default","severity":"INFO"}
-```
+----
 
 == Building Spring REST Client
 
@@ -139,10 +146,11 @@ Click Generate.
 Download the resulting ZIP file, which is an archive of a web application that is configured with your choices.
 
 
-* Add following Maven Dependencies to pom.xml
+Add following Maven Dependencies to `pom.xml`
 
+[source,xml,indent=4]
 ----
-  <properties>
+    <properties>
         <akka-grpc.version>2.1.6</akka-grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
@@ -182,7 +190,7 @@ Download the resulting ZIP file, which is an archive of a web application that i
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <version>1.7.1</version>
             </extension>
         </extensions>
         <plugins>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -202,7 +202,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -83,7 +83,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
   <groupId>${groupId}</groupId>
@@ -70,7 +70,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -221,7 +221,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -230,7 +230,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -126,7 +126,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -211,7 +211,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -43,7 +43,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   val JUnitJupiterVersion = "5.7.1"
   val SpringFrameworkVersion = "6.0.13"
   // make sure to sync spring-boot-starter-parent version in samples and archetype to this version
-  val SpringBootVersion = "3.1.4"
+  val SpringBootVersion = "3.1.5"
   val OpenTelemetryVersion = "1.28.0"
 
   val CommonsIoVersion = "2.11.0"

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -37,7 +37,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -37,7 +37,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -37,7 +37,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -231,7 +231,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.2</version>
                 <configuration>
                     <excludes>
                         <!-- ignore integration test classes -->
@@ -281,7 +281,7 @@
                         <!-- run *IntegrationTest with failsafe -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.22.2</version>
+                        <version>3.2.2</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.39.1</version>
+                <version>0.43.4</version>
                 <configuration>
                     <images>
                         <image>

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${jdk.target}</source>
                     <target>${jdk.target}</target>

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -39,7 +39,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <version>1.7.1</version>
             </extension>
         </extensions>
 

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -231,7 +231,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>2.22.2</version>
                 <configuration>
                     <excludes>
                         <!-- ignore integration test classes -->
@@ -281,7 +281,7 @@
                         <!-- run *IntegrationTest with failsafe -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.2.2</version>
+                        <version>2.22.2</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -262,7 +262,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -37,7 +37,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -212,7 +212,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -262,7 +262,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -243,7 +243,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -124,7 +124,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -212,7 +212,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -262,7 +262,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -251,7 +251,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -252,7 +252,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -37,7 +37,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -202,7 +202,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -252,7 +252,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -233,7 +233,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-valueentity-counter-spring-client/pom.xml
+++ b/samples/java-protobuf-valueentity-counter-spring-client/pom.xml
@@ -89,7 +89,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <version>1.7.1</version>
             </extension>
         </extensions>
         <plugins>

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -245,7 +245,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -126,7 +126,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -214,7 +214,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -264,7 +264,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -214,7 +214,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -264,7 +264,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -253,7 +253,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -235,7 +235,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -204,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -254,7 +254,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -204,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -254,7 +254,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -38,7 +38,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -202,7 +202,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -252,7 +252,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -202,7 +202,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -252,7 +252,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -233,7 +233,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-web-resources/pom.xml
+++ b/samples/java-protobuf-web-resources/pom.xml
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-protobuf-web-resources/pom.xml
+++ b/samples/java-protobuf-web-resources/pom.xml
@@ -187,7 +187,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-protobuf-web-resources/pom.xml
+++ b/samples/java-protobuf-web-resources/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-protobuf-web-resources/pom.xml
+++ b/samples/java-protobuf-web-resources/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -223,7 +223,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -204,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -223,7 +223,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -204,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -222,7 +222,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -222,7 +222,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -88,7 +88,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -227,7 +227,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -208,7 +208,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -75,7 +75,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -43,7 +43,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -72,7 +72,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -205,7 +205,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -224,7 +224,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -85,7 +85,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -222,7 +222,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -83,7 +83,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -222,7 +222,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -72,7 +72,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -223,7 +223,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -204,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -85,7 +85,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -222,7 +222,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/>
   </parent>
 
@@ -72,7 +72,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -205,7 +205,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -224,7 +224,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -85,7 +85,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -72,7 +72,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -205,7 +205,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -224,7 +224,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -85,7 +85,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -88,7 +88,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -227,7 +227,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -208,7 +208,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -75,7 +75,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -43,7 +43,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -203,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -39,7 +39,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -222,7 +222,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -88,7 +88,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -227,7 +227,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -208,7 +208,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -4,7 +4,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -75,7 +75,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -43,7 +43,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -40,7 +40,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
       </extension>
     </extensions>
 

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -223,7 +223,6 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.39.1</version>
+        <version>0.43.4</version>
         <configuration>
           <images>
             <image>

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -204,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -5,7 +5,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath/> 
   </parent>
 
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>


### PR DESCRIPTION
- Spring Boot 3.1.5 (was 3.1.4)
- ~~Maven Surefire/Failsafe 3.2.2 (was 2.22.2)~~ deferred
- Maven Deploy 3.1.1 (was 3.0.0-M1)
- Fabric8 Plugin 0.43.4 (was 0.39.1)
- OS Maven plugin 1.7.1 (was 1.7.0)

Removes the Maven Compiler Plugin and the Surefire/Failsafe plugins in the Spring poms as those inherit it from the Spring Boot pom.

Supersedes 
- #1865 