### PR TITLE
chore: refactor escaping of artifactId on templates

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -6,8 +6,8 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.23
-    container_name: ${artifactId}
-    #[[ports:
+    container_name: ]]#${artifactId}#[[
+    ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -6,8 +6,8 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.23
-    container_name: ${artifactId}
-    #[[ports:
+    container_name: ]]#${artifactId}#[[
+    ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -6,8 +6,8 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.23
-    container_name: ${artifactId}
-    #[[ports:
+    container_name: ]]#${artifactId}#[[
+    ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -6,8 +6,8 @@ version: "3"
 services:
   kalix-proxy:
     image: gcr.io/kalix-public/kalix-proxy:1.1.23
-    container_name: ${artifactId}
-    #[[ports:
+    container_name: ]]#${artifactId}#[[
+    ports:
       - "9000:9000"
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Follow-up of https://github.com/lightbend/kalix-jvm-sdk/pull/1859/files#r1394273904

Changing the escaping so it does not conflict with the Auto PR bot.