### PR TITLE
bump: remove direct dependency on commons-compress

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -125,9 +125,6 @@ object Dependencies {
 
   val javaSdkTestKit = deps ++= Seq(
     testContainers,
-    // Override for security vulnerabilities. Can be removed once testcontainers is updated:
-    // https://github.com/testcontainers/testcontainers-java/issues/4308
-    "org.apache.commons" % "commons-compress" % "1.21",
     junit4 % Provided,
     junit5 % Provided,
     scalaTest % Test,


### PR DESCRIPTION
Current TestContainers dependencies in the `kalix-java-sdk-protobuf-testkit`:

```
[info]   +-org.testcontainers:testcontainers:1.17.6
[info]     +-com.github.docker-java:docker-java-api:3.2.13
[info]     | +-com.fasterxml.jackson.core:jackson-annotations:2.10.3 (evicted by: 2.1..
[info]     | +-com.fasterxml.jackson.core:jackson-annotations:2.14.3
[info]     | +-org.slf4j:slf4j-api:1.7.30 (evicted by: 2.0.9)
[info]     | +-org.slf4j:slf4j-api:2.0.9
[info]     |
[info]     +-com.github.docker-java:docker-java-transport-zerodep:3.2.13
[info]     | +-com.github.docker-java:docker-java-transport:3.2.13
[info]     | +-net.java.dev.jna:jna:5.8.0
[info]     | +-org.slf4j:slf4j-api:1.7.25 (evicted by: 2.0.9)
[info]     | +-org.slf4j:slf4j-api:2.0.9
[info]     |
[info]     +-junit:junit:4.13.2
[info]     | +-org.hamcrest:hamcrest-core:1.3
[info]     |
[info]     +-org.apache.commons:commons-compress:1.22
[info]     +-org.rnorth.duct-tape:duct-tape:1.0.8
[info]     | +-org.jetbrains:annotations:17.0.0
[info]     |
[info]     +-org.slf4j:slf4j-api:1.7.36 (evicted by: 2.0.9)
[info]     +-org.slf4j:slf4j-api:2.0.9
```

References
- #555 
- https://github.com/testcontainers/testcontainers-java/issues/4308