### PR TITLE
feat: reading the collector endpoint from the ProxyInfo

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Kalix {
     val ProtocolVersionMajor = 1
     val ProtocolVersionMinor = 1
-    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.1.24")
+    val ProxyVersion = System.getProperty("kalix-proxy.version", "1.1.26")
   }
 
   // changing the Scala version of the Java SDK affects end users

--- a/samples/scala-protobuf-eventsourced-counter/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.1.24
+    image: gcr.io/kalix-public/kalix-proxy:1.1.26
     container_name: scala-protobuf-eventsourced-counter
     ports:
       - "9000:9000"

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -611,7 +611,7 @@ public class KalixTestKit {
     ProxyInfoHolder holder = ProxyInfoHolder.get(runner.system());
     holder.overridePort(proxyPort);
     holder.overrideProxyHost(proxyHost);
-    holder.overrideTracingCollectorEndpoint("");
+    holder.overrideTracingCollectorEndpoint(""); //emulating ProxyInfo with disabled tracing.
   }
 
   private int userFunctionPort(Boolean useTestContainers) {

--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/KalixTestKit.java
@@ -611,6 +611,7 @@ public class KalixTestKit {
     ProxyInfoHolder holder = ProxyInfoHolder.get(runner.system());
     holder.overridePort(proxyPort);
     holder.overrideProxyHost(proxyHost);
+    holder.overrideTracingCollectorEndpoint("");
   }
 
   private int userFunctionPort(Boolean useTestContainers) {

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -115,4 +115,8 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
    */
   private[kalix] def overrideProxyHost(host: String): Unit =
     _proxyHostname.set(host)
+
+  private[kalix] def overrideTracingCollectorEndpoint(endpoint: String): Unit = {
+    _proxyTracingCollectorEndpoint = Some(endpoint)
+  }
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -45,6 +45,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
   private val _proxyHostname = new AtomicReference[String]()
   private val _proxyPort = new AtomicReference[Int](-1)
   @volatile private var _identificationInfo: Option[IdentificationInfo] = None
+  private val _proxyTracingCollectorEndpoint: Option[String] = None
 
   def setProxyInfo(proxyInfo: ProxyInfo): Unit = {
 
@@ -60,6 +61,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
     _proxyHostname.compareAndSet(null, chosenProxyName)
     _proxyPort.compareAndSet(-1, proxyInfo.proxyPort)
     _identificationInfo = proxyInfo.identificationInfo
+    _proxyTracingCollectorEndpoint = proxyInfo.tracingCollectorEndpoint
 
     log.debug("Proxy hostname: [{}]", chosenProxyName)
     log.debug("Proxy port to: [{}]", proxyInfo.proxyPort)
@@ -67,6 +69,8 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
   }
 
   def proxyHostname: Option[String] = Option(_proxyHostname.get())
+
+  def proxyTracingCollectorEndpoint: Option[String] = Option(_)
 
   def identificationInfo: Option[IdentificationInfo] = _identificationInfo
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -48,7 +48,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
   private val _proxyHostname = new AtomicReference[String]()
   private val _proxyPort = new AtomicReference[Int](-1)
   @volatile private var _identificationInfo: Option[IdentificationInfo] = None
-  @volatile private var _proxyTracingCollectorEndpoint: String = ""
+  @volatile private var _proxyTracingCollectorEndpoint: Option[String] = None
 
   def setProxyInfo(proxyInfo: ProxyInfo): Unit = {
 
@@ -64,7 +64,8 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
     _proxyHostname.compareAndSet(null, chosenProxyName)
     _proxyPort.compareAndSet(-1, proxyInfo.proxyPort)
     _identificationInfo = proxyInfo.identificationInfo
-    _proxyTracingCollectorEndpoint = proxyInfo.tracingCollectorEndpoint
+    if (proxyInfo.tracingCollectorEndpoint.nonEmpty)
+      _proxyTracingCollectorEndpoint = Some(proxyInfo.tracingCollectorEndpoint)
 
     log.debug("Proxy hostname: [{}]", chosenProxyName)
     log.debug("Proxy port to: [{}]", proxyInfo.proxyPort)
@@ -74,7 +75,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
 
   def proxyHostname: Option[String] = Option(_proxyHostname.get())
 
-  def proxyTracingCollectorEndpoint: String = _proxyTracingCollectorEndpoint
+  def proxyTracingCollectorEndpoint: Option[String] = _proxyTracingCollectorEndpoint
 
   def identificationInfo: Option[IdentificationInfo] = _identificationInfo
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -74,7 +74,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
 
   def proxyHostname: Option[String] = Option(_proxyHostname.get())
 
-  def proxyTracingCollectorEndpoint: Promise[String] = _proxyTracingCollectorEndpoint
+  def proxyTracingCollectorEndpoint: Future[String] = _proxyTracingCollectorEndpoint.future
 
   def identificationInfo: Option[IdentificationInfo] = _identificationInfo
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -27,9 +27,6 @@ import kalix.protocol.discovery.ProxyInfo
 import org.slf4j.LoggerFactory
 
 import java.util.concurrent.atomic.AtomicReference
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
 
 object ProxyInfoHolder extends ExtensionId[ProxyInfoHolder] with ExtensionIdProvider {
   override def get(system: ActorSystem): ProxyInfoHolder = super.get(system)

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -48,7 +48,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
   private val _proxyHostname = new AtomicReference[String]()
   private val _proxyPort = new AtomicReference[Int](-1)
   @volatile private var _identificationInfo: Option[IdentificationInfo] = None
-  var _proxyTracingCollectorEndpoint: Promise[String] = Promise()
+  @volatile private var _proxyTracingCollectorEndpoint: String = ""
 
   def setProxyInfo(proxyInfo: ProxyInfo): Unit = {
 
@@ -64,7 +64,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
     _proxyHostname.compareAndSet(null, chosenProxyName)
     _proxyPort.compareAndSet(-1, proxyInfo.proxyPort)
     _identificationInfo = proxyInfo.identificationInfo
-    _proxyTracingCollectorEndpoint.success(proxyInfo.tracingCollectorEndpoint)
+    _proxyTracingCollectorEndpoint = proxyInfo.tracingCollectorEndpoint
 
     log.debug("Proxy hostname: [{}]", chosenProxyName)
     log.debug("Proxy port to: [{}]", proxyInfo.proxyPort)
@@ -74,7 +74,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
 
   def proxyHostname: Option[String] = Option(_proxyHostname.get())
 
-  def proxyTracingCollectorEndpoint: Future[String] = _proxyTracingCollectorEndpoint.future
+  def proxyTracingCollectorEndpoint: String = _proxyTracingCollectorEndpoint
 
   def identificationInfo: Option[IdentificationInfo] = _identificationInfo
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ProxyInfoHolder.scala
@@ -64,8 +64,7 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
     _proxyHostname.compareAndSet(null, chosenProxyName)
     _proxyPort.compareAndSet(-1, proxyInfo.proxyPort)
     _identificationInfo = proxyInfo.identificationInfo
-    if (proxyInfo.tracingCollectorEndpoint.nonEmpty)
-      _proxyTracingCollectorEndpoint = Some(proxyInfo.tracingCollectorEndpoint)
+    _proxyTracingCollectorEndpoint = Some(proxyInfo.tracingCollectorEndpoint)
 
     log.debug("Proxy hostname: [{}]", chosenProxyName)
     log.debug("Proxy port to: [{}]", proxyInfo.proxyPort)
@@ -116,7 +115,6 @@ class ProxyInfoHolder(system: ExtendedActorSystem) extends Extension {
   private[kalix] def overrideProxyHost(host: String): Unit =
     _proxyHostname.set(host)
 
-  private[kalix] def overrideTracingCollectorEndpoint(endpoint: String): Unit = {
+  private[kalix] def overrideTracingCollectorEndpoint(endpoint: String): Unit =
     _proxyTracingCollectorEndpoint = Some(endpoint)
-  }
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
@@ -23,7 +23,6 @@ import akka.stream.scaladsl.Source
 import com.google.protobuf.Descriptors
 import com.google.protobuf.any.Any
 import io.grpc.Status
-import io.opentelemetry.api.trace.Span
 import kalix.javasdk._
 import kalix.javasdk.action._
 import kalix.javasdk.impl.ActionFactory
@@ -200,7 +199,7 @@ private[javasdk] final class ActionsImpl(
   override def handleUnary(in: ActionCommand): Future[ActionResponse] =
     services.get(in.serviceName) match {
       case Some(service) =>
-        val span: Option[Span] = telemetries(service.serviceName).buildSpan(service, in)
+        val span = telemetries(service.serviceName).buildSpan(service, in)
 
         val fut =
           try {
@@ -217,7 +216,7 @@ private[javasdk] final class ActionsImpl(
               Future.successful(handleUnexpectedException(service, in, ex))
           }
         fut.andThen { case _ =>
-          span.map(_.end())
+          span.foreach(_.end())
         }
       case None =>
         Future.successful(

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
@@ -200,8 +200,6 @@ private[javasdk] final class ActionsImpl(
   override def handleUnary(in: ActionCommand): Future[ActionResponse] =
     services.get(in.serviceName) match {
       case Some(service) =>
-        // This future is always completed before this method is called because that future completes right after the proxy discovery
-        // which always happens before any message can be processed by any component
         val span: Option[Span] = telemetries(service.serviceName).buildSpan(service, in)
 
         val fut =

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
@@ -203,7 +203,7 @@ private[javasdk] final class ActionsImpl(
         // This future is always completed before this method is called because that future completes right after the proxy discovery
         // which always happens before any message can be processed by any component
         val span: Future[Option[Span]] =
-          telemetries(service.serviceName).map { inst => inst.buildSpan(service, in) }
+          telemetries(service.serviceName).map { inst => inst.buildSpan(service, in) }.flatten
         val fut =
           try {
             val context = createContext(in, service.messageCodec)

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -48,7 +48,6 @@ import kalix.protocol.event_sourced_entity.EventSourcedStreamOut.Message.{ Snaps
 import kalix.protocol.event_sourced_entity._
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 final class EventSourcedEntityService(
@@ -113,7 +112,6 @@ final class EventSourcedEntitiesImpl(
   lazy val instrumentations: Map[String, Instrumentation] = services.values.map { s =>
     (s.serviceName, telemetry.traceInstrumentation(s.serviceName, EventSourcedEntityCategory))
   }.toMap
-  implicit val ec = ExecutionContext.Implicits.global //or system.dispatcher?
 
   private val pbCleanupDeletedEventSourcedEntityAfter =
     Some(com.google.protobuf.duration.Duration(configuration.cleanupDeletedEventSourcedEntityAfter))

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -188,7 +188,7 @@ final class EventSourcedEntitiesImpl(
           // This future is always completed before this method is called because that future completes right after the proxy discovery
           // which always happens before any message can be processed by any component
           val span: Future[Option[Span]] =
-            instrumentations(service.serviceName).map(inst => inst.buildSpan(service, command))
+            instrumentations(service.serviceName).map(inst => inst.buildSpan(service, command)).flatten
           try {
             val cmd =
               service.messageCodec.decodeMessage(

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -35,6 +35,7 @@ import kalix.javasdk.impl.effect.MessageReplyImpl
 import kalix.javasdk.impl.effect.SecondaryEffectImpl
 import kalix.javasdk.impl.eventsourcedentity.EventSourcedEntityRouter.CommandResult
 import kalix.javasdk.impl.telemetry.EventSourcedEntityCategory
+import kalix.javasdk.impl.telemetry.FastFuture
 import kalix.javasdk.impl.telemetry.Instrumentation
 import kalix.javasdk.impl.telemetry.Telemetry
 import kalix.protocol.component.Failure
@@ -112,7 +113,7 @@ final class EventSourcedEntitiesImpl(
     (name, if (service.snapshotEvery == 0) service.withSnapshotEvery(configuration.snapshotEvery) else service)
   }.toMap
   val telemetry = Telemetry(system)
-  val instrumentations: Map[String, Future[Instrumentation]] = services.values.map { s =>
+  lazy val instrumentations: Map[String, Instrumentation] = services.values.map { s =>
     (s.serviceName, telemetry.traceInstrumentation(s.serviceName, EventSourcedEntityCategory))
   }.toMap
   implicit val ec = ExecutionContext.Implicits.global //or system.dispatcher?

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -183,8 +183,6 @@ final class EventSourcedEntitiesImpl(
         case ((sequence, _), InCommand(command)) =>
           if (thisEntityId != command.entityId)
             throw ProtocolException(command, "Receiving entity is not the intended recipient of command")
-          // This future is always completed before this method is called because that future completes right after the proxy discovery
-          // which always happens before any message can be processed by any component
           val span = instrumentations(service.serviceName).buildSpan(service, command)
           try {
             val cmd =

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
@@ -93,7 +93,6 @@ final class Telemetry(system: ActorSystem) extends Extension {
           case None => throw new IllegalArgumentException("Tracing endpoint from the Proxy not yet received. Retry.")
         }
     }
-    logger.debug("collectorEndpoint [{}].", collectorEndpoint)
     if (collectorEndpoint.isEmpty) {
       logger.debug("Instrumentation disabled. Set to NoOp.")
       NoOpInstrumentation
@@ -106,10 +105,7 @@ final class Telemetry(system: ActorSystem) extends Extension {
 
 trait Instrumentation {
 
-  //private now?
-
   def buildSpan(service: Service, command: Command): Option[Span]
-  //private now?
 
   def buildSpan(service: Service, command: ActionCommand): Option[Span]
 
@@ -120,9 +116,9 @@ private object TraceInstrumentation {
   val TRACE_PARENT_KEY = "traceparent"
   val TRACING_ENDPOINT = "kalix.telemetry.tracing.collector-endpoint"
 
-  val logger: Logger = LoggerFactory.getLogger(getClass)
+  private val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  lazy val otelGetter = new TextMapGetter[Metadata]() {
+  private lazy val otelGetter = new TextMapGetter[Metadata]() {
     override def get(carrier: Metadata, key: String): String = {
       logger.debug("For the key [{}] the value is [{}]", key, carrier.get(key))
       carrier.get(key).toScala.getOrElse("")
@@ -131,7 +127,6 @@ private object TraceInstrumentation {
     override def keys(carrier: Metadata): java.lang.Iterable[String] =
       carrier.getAllKeys
   }
-
 }
 
 private final class TraceInstrumentation(
@@ -143,7 +138,7 @@ private final class TraceInstrumentation(
 
   import TraceInstrumentation._
 
-  val tracePrefix = componentCategory.name
+  private val tracePrefix = componentCategory.name
 
   private val openTelemetry: OpenTelemetry = {
     val resource =

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
@@ -87,7 +87,7 @@ final class Telemetry(system: ActorSystem) extends Extension {
   def traceInstrumentation(componentName: String, componentCategory: ComponentCategory): Instrumentation = {
     val collectorEndpoint = {
       if (collectorEndpointSDK.nonEmpty) collectorEndpointSDK
-      else if(proxyInfoHolder.proxyTracingCollectorEndpoint.nonEmpty) proxyInfoHolder.proxyTracingCollectorEndpoint
+      else if (proxyInfoHolder.proxyTracingCollectorEndpoint.nonEmpty) proxyInfoHolder.proxyTracingCollectorEndpoint
       else throw new IllegalArgumentException("Tracing endpoint from the Proxy not yet received. Retry.")
     }
     logger.debug("collectorEndpointSDK [{}].", collectorEndpointSDK)

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
@@ -87,8 +87,11 @@ final class Telemetry(system: ActorSystem) extends Extension {
   def traceInstrumentation(componentName: String, componentCategory: ComponentCategory): Instrumentation = {
     val collectorEndpoint = {
       if (collectorEndpointSDK.nonEmpty) collectorEndpointSDK
-      else if (proxyInfoHolder.proxyTracingCollectorEndpoint.nonEmpty) proxyInfoHolder.proxyTracingCollectorEndpoint
-      else throw new IllegalArgumentException("Tracing endpoint from the Proxy not yet received. Retry.")
+      else
+        proxyInfoHolder.proxyTracingCollectorEndpoint match {
+          case Some(endpoint) => endpoint
+          case None => throw new IllegalArgumentException("Tracing endpoint from the Proxy not yet received. Retry.")
+        }
     }
     logger.debug("collectorEndpointSDK [{}].", collectorEndpointSDK)
     if (collectorEndpoint.isEmpty) {

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
@@ -85,9 +85,11 @@ final class Telemetry(system: ActorSystem) extends Extension {
    * @return
    */
   def traceInstrumentation(componentName: String, componentCategory: ComponentCategory): Instrumentation = {
-    val collectorEndpoint =
-      if (!collectorEndpointSDK.isEmpty) collectorEndpointSDK
-      else proxyInfoHolder.proxyTracingCollectorEndpoint
+    val collectorEndpoint = {
+      if (collectorEndpointSDK.nonEmpty) collectorEndpointSDK
+      else if(proxyInfoHolder.proxyTracingCollectorEndpoint.nonEmpty) proxyInfoHolder.proxyTracingCollectorEndpoint
+      else throw new IllegalArgumentException("Tracing endpoint from the Proxy not yet received. Retry.")
+    }
     logger.debug("collectorEndpointSDK [{}].", collectorEndpointSDK)
     if (collectorEndpoint.isEmpty) {
       logger.debug("Instrumentation disabled. Set to NoOp.")

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
@@ -93,7 +93,7 @@ final class Telemetry(system: ActorSystem) extends Extension {
           case None => throw new IllegalArgumentException("Tracing endpoint from the Proxy not yet received. Retry.")
         }
     }
-    logger.debug("collectorEndpointSDK [{}].", collectorEndpointSDK)
+    logger.debug("collectorEndpoint [{}].", collectorEndpoint)
     if (collectorEndpoint.isEmpty) {
       logger.debug("Instrumentation disabled. Set to NoOp.")
       NoOpInstrumentation

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -164,8 +164,6 @@ final class ValueEntitiesImpl(
           val metadata = new MetadataImpl(command.metadata.map(_.entries.toVector).getOrElse(Nil))
 
           if (log.isTraceEnabled) log.trace("Metadata entries [{}].", metadata.entries)
-          // This future is always completed before this method is called because that future completes right after the proxy discovery
-          // which always happens before any message can be processed by any component
           val span: Option[Span] = instrumentations(service.serviceName).buildSpan(service, command)
 
           try {

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -21,7 +21,6 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import io.grpc.Status
-import io.opentelemetry.api.trace.Span
 import kalix.javasdk.KalixRunner.Configuration
 import kalix.javasdk.impl.ErrorHandling.BadRequestException
 import kalix.javasdk.impl.telemetry.Instrumentation
@@ -30,8 +29,6 @@ import kalix.javasdk.impl.telemetry.ValueEntityCategory
 import kalix.protocol.component.Failure
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 // FIXME these don't seem to be 'public API', more internals?
@@ -92,7 +89,6 @@ final class ValueEntitiesImpl(
 
   import EntityExceptions._
 
-  private implicit val ec: ExecutionContext = system.dispatcher
   private final val log = LoggerFactory.getLogger(this.getClass)
 
   val telemetry = Telemetry(system)
@@ -164,7 +160,7 @@ final class ValueEntitiesImpl(
           val metadata = new MetadataImpl(command.metadata.map(_.entries.toVector).getOrElse(Nil))
 
           if (log.isTraceEnabled) log.trace("Metadata entries [{}].", metadata.entries)
-          val span: Option[Span] = instrumentations(service.serviceName).buildSpan(service, command)
+          val span = instrumentations(service.serviceName).buildSpan(service, command)
 
           try {
             val cmd =

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -167,7 +167,8 @@ final class ValueEntitiesImpl(
           // This future is always completed before this method is called because that future completes right after the proxy discovery
           // which always happens before any message can be processed by any component
           val span: Future[Option[Span]] =
-            instrumentations(service.serviceName).map(inst => inst.buildSpan(service, command))
+            instrumentations(service.serviceName).map(inst => inst.buildSpan(service, command)).flatten
+
           try {
             val cmd =
               service.messageCodec.decodeMessage(

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/action/ActionHandlerSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/action/ActionHandlerSpec.scala
@@ -23,14 +23,15 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.scaladsl.adapter._
 import akka.stream.javadsl.Source
 import akka.stream.scaladsl.Sink
-import akka.testkit.EventFilter
 import kalix.javasdk.action.Action
 import kalix.javasdk.action.MessageEnvelope
 import kalix.javasdk.actionspec.ActionspecApi
+import kalix.javasdk.impl.ActionFactory
 import kalix.javasdk.impl.AbstractContext
 import kalix.javasdk.impl.AnySupport
 import kalix.javasdk.impl.GrpcDeferredCall
 import kalix.javasdk.impl.MetadataImpl
+import kalix.javasdk.impl.ProxyInfoHolder
 import kalix.javasdk.impl.ResolvedServiceMethod
 import kalix.javasdk.impl.effect.SideEffectImpl
 import kalix.protocol.action.ActionCommand
@@ -39,7 +40,6 @@ import kalix.protocol.action.Actions
 import kalix.protocol.component.Reply
 import com.google.protobuf
 import com.google.protobuf.any.{ Any => ScalaPbAny }
-import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Inside
 import org.scalatest.OptionValues
@@ -49,9 +49,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import kalix.javasdk.action.ActionOptions
-import kalix.javasdk.impl.ActionFactory
-import kalix.javasdk.impl.ProxyInfoHolder
 
 class ActionHandlerSpec
     extends ScalaTestWithActorTestKit

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/action/ActionHandlerSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/action/ActionHandlerSpec.scala
@@ -45,12 +45,13 @@ import org.scalatest.Inside
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
 import kalix.javasdk.action.ActionOptions
 import kalix.javasdk.impl.ActionFactory
+import kalix.javasdk.impl.ProxyInfoHolder
 
 class ActionHandlerSpec
     extends ScalaTestWithActorTestKit
@@ -74,6 +75,9 @@ class ActionHandlerSpec
     val service = new ActionService(actionFactory, serviceDescriptor, Array(), anySupport, None)
 
     val services = Map(serviceName -> service)
+
+    //setting tracing as disabled, emulating that is discovered from the proxy.
+    ProxyInfoHolder(system).overrideTracingCollectorEndpoint("")
 
     new ActionsImpl(classicSystem, services, new AbstractContext(classicSystem) {})
   }

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/eventsourcedentity/TestEventSourced.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/eventsourcedentity/TestEventSourced.scala
@@ -22,6 +22,7 @@ import akka.testkit.SocketUtil
 import kalix.javasdk.{ Kalix, KalixRunner }
 import com.typesafe.config.{ Config, ConfigFactory }
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityProvider
+import kalix.javasdk.impl.ProxyInfoHolder
 
 object TestEventSourced {
   def service(entityProvider: EventSourcedEntityProvider[_, _, _]): TestEventSourcedService =
@@ -46,6 +47,8 @@ class TestEventSourcedService(entityProvider: EventSourcedEntityProvider[_, _, _
     .createRunner(config)
 
   runner.run()
+  //setting tracing as disabled, emulating that is discovered from the proxy.
+  ProxyInfoHolder(runner.system).overrideTracingCollectorEndpoint("")
 
   def expectLogError[T](message: String)(block: => T): T =
     LoggingTestKit.error(message).expect(block)(runner.system.toTyped)

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/valueentity/TestValueEntity.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/valueentity/TestValueEntity.scala
@@ -23,6 +23,7 @@ import kalix.javasdk.{ Kalix, KalixRunner }
 import kalix.javasdk.valueentity.ValueEntityProvider
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import kalix.javasdk.impl.ProxyInfoHolder
 
 object TestValueEntity {
   def service(entityProvider: ValueEntityProvider[_, _]): TestValueService =
@@ -47,6 +48,8 @@ class TestValueService(entityProvider: ValueEntityProvider[_, _]) {
     .createRunner(config)
 
   runner.run()
+  //setting tracing as disabled, emulating that is discovered from the proxy.
+  ProxyInfoHolder(runner.system).overrideTracingCollectorEndpoint("")
 
   def expectLogError[T](message: String)(block: => T): T = {
     LoggingTestKit.error(message).expect(block)(runner.system.toTyped)

--- a/sdk/java-sdk-spring/docker-compose-integration.yml
+++ b/sdk/java-sdk-spring/docker-compose-integration.yml
@@ -10,7 +10,6 @@ services:
       JAVA_TOOL_OPTIONS: >
         -Dkalix.proxy.eventing.support=google-pubsub-emulator
         -Dkalix.proxy.telemetry.metrics.prometheus.use-default-registry=false
-        -Dkalix.proxy.telemetry.tracing.enabled=false
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/sdk/java-sdk-spring/docker-compose-integration.yml
+++ b/sdk/java-sdk-spring/docker-compose-integration.yml
@@ -10,12 +10,11 @@ services:
       JAVA_TOOL_OPTIONS: >
         -Dkalix.proxy.eventing.support=google-pubsub-emulator
         -Dkalix.proxy.telemetry.metrics.prometheus.use-default-registry=false
-        -Dkalix.proxy.telemetry.tracing.enabled=true
+        -Dkalix.proxy.telemetry.tracing.enabled=false
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
       VIEW_FEATURE_JOINS: "true"
-      COLLECTOR_ENDPOINT: "http://tempo:4317"
     depends_on:
       - gcloud-pubsub-emulator
       - tempo

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
@@ -46,7 +46,7 @@ public class PubSubIntegrationTest extends DockerIntegrationTest {
   static Config config = ConfigFactory.parseString("""
                 kalix.telemetry.tracing.collector-endpoint = "http://fake:1234"
                 """);
-  //FIXME there is not mechanism ATM in the integration tests to emulate the discovery call that disables tracing. More info in Telemetry.traceInstrumentation.
+  //FIXME there is not mechanism ATM in the integration tests to emulate the discovery call that disables tracing. More info in Telemetry.traceInstrumentation implementation.
 
   public PubSubIntegrationTest(ApplicationContext applicationContext) {
     super(applicationContext, config);

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
@@ -46,8 +46,7 @@ public class PubSubIntegrationTest extends DockerIntegrationTest {
   static Config config = ConfigFactory.parseString("""
                 kalix.telemetry.tracing.collector-endpoint = "http://fake:1234"
                 """);
-  //FIXME there is not mechanism ATM in the integration tests to emulate the discovery call, that disables tracing.
-  // This is only to avoid an exception when ProxyInfo is not set. More info in Telemetry.traceInstrumentation.
+  //FIXME there is not mechanism ATM in the integration tests to emulate the discovery call, that disables tracing. More info in Telemetry.traceInstrumentation.
 
   public PubSubIntegrationTest(ApplicationContext applicationContext) {
     super(applicationContext, config);

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
@@ -46,7 +46,7 @@ public class PubSubIntegrationTest extends DockerIntegrationTest {
   static Config config = ConfigFactory.parseString("""
                 kalix.telemetry.tracing.collector-endpoint = "http://fake:1234"
                 """);
-  //FIXME there is not mechanism ATM in the integration tests to emulate the discovery call, that disables tracing. More info in Telemetry.traceInstrumentation.
+  //FIXME there is not mechanism ATM in the integration tests to emulate the discovery call that disables tracing. More info in Telemetry.traceInstrumentation.
 
   public PubSubIntegrationTest(ApplicationContext applicationContext) {
     super(applicationContext, config);

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/pubsub/PubSubIntegrationTest.java
@@ -18,6 +18,8 @@ package com.example.wiring.pubsub;
 
 import com.example.Main;
 import com.example.wiring.valueentities.customer.CustomerEntity.Customer;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,9 +43,14 @@ import static org.awaitility.Awaitility.await;
 @ActiveProfiles("docker-it-test")
 public class PubSubIntegrationTest extends DockerIntegrationTest {
 
+  static Config config = ConfigFactory.parseString("""
+                kalix.telemetry.tracing.collector-endpoint = "http://fake:1234"
+                """);
+  //FIXME there is not mechanism ATM in the integration tests to emulate the discovery call, that disables tracing.
+  // This is only to avoid an exception when ProxyInfo is not set. More info in Telemetry.traceInstrumentation.
 
   public PubSubIntegrationTest(ApplicationContext applicationContext) {
-    super(applicationContext);
+    super(applicationContext, config);
   }
 
   @Test

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/tracing/TracingIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/tracing/TracingIntegrationTest.java
@@ -21,7 +21,6 @@ import com.example.wiring.pubsub.DockerIntegrationTest;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,15 +38,14 @@ import static org.awaitility.Awaitility.await;
 @SpringBootTest(classes = Main.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("docker-it-test")
-public class TracingIntegratonTest extends DockerIntegrationTest {
+public class TracingIntegrationTest extends DockerIntegrationTest {
 
-    Logger logger = LoggerFactory.getLogger(TracingIntegratonTest.class);
+    Logger logger = LoggerFactory.getLogger(TracingIntegrationTest.class);
     static Config config = ConfigFactory.parseString("""
-                kalix.proxy.telemetry.tracing.enabled = true
                 kalix.telemetry.tracing.collector-endpoint = "http://localhost:4317"
                 """);
 
-    public TracingIntegratonTest(ApplicationContext applicationContext) {
+    public TracingIntegrationTest(ApplicationContext applicationContext) {
         super(applicationContext, config);
     }
 

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionsImplSpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionsImplSpec.scala
@@ -59,6 +59,9 @@ class ActionsImplSpec
 
     val services = Map(provider.serviceDescriptor().getFullName -> service)
 
+    //setting tracing as disabled, emulating that is discovered from the proxy.
+    ProxyInfoHolder(system).overrideTracingCollectorEndpoint("")
+
     new ActionsImpl(classicSystem, services, new AbstractContext(classicSystem) {})
   }
 


### PR DESCRIPTION
Using the proxy info to set the tracing endpoint collector. See https://github.com/lightbend/kalix-runtime/pull/2196

