### PR TITLE
chore: fix typo

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-protobuf-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-quickstart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -28,7 +28,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: "8080"
 

--- a/samples/java-protobuf-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
 #end::customer-registry[]

--- a/samples/java-protobuf-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-fibonacci-action/docker-compose.yml
+++ b/samples/java-protobuf-fibonacci-action/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-first-service/docker-compose.yml
+++ b/samples/java-protobuf-first-service/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-reliable-timers/docker-compose.yml
+++ b/samples/java-protobuf-reliable-timers/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-replicatedentity-examples/docker-compose.yml
+++ b/samples/java-protobuf-replicatedentity-examples/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-shopping-cart-quickstart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-valueentity-counter/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-counter/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-customer-registry/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-protobuf-view-store/docker-compose.yml
+++ b/samples/java-protobuf-view-store/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Enable advanced view features locally (note: disabled in deployed services by default)

--- a/samples/java-protobuf-web-resources/docker-compose.yml
+++ b/samples/java-protobuf-web-resources/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}

--- a/samples/java-spring-choreography-saga-quickstart/docker-compose.yml
+++ b/samples/java-spring-choreography-saga-quickstart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-spring-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-spring-customer-registry-quickstart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-spring-customer-registry-views-quickstart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -28,7 +28,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: "8080"
 

--- a/samples/java-spring-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/java-spring-eventsourced-customer-registry/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
 #end::customer-registry[]

--- a/samples/java-spring-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-spring-eventsourced-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-fibonacci-action/docker-compose.yml
+++ b/samples/java-spring-fibonacci-action/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-reliable-timers/docker-compose.yml
+++ b/samples/java-spring-reliable-timers/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-spring-shopping-cart-quickstart/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-spring-transfer-workflow-compensation/docker-compose.yml
+++ b/samples/java-spring-transfer-workflow-compensation/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-transfer-workflow/docker-compose.yml
+++ b/samples/java-spring-transfer-workflow/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-valueentity-counter/docker-compose.yml
+++ b/samples/java-spring-valueentity-counter/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-spring-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-spring-valueentity-customer-registry/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Comment to enable ACL check in dev-mode (see https://docs.kalix.io/services/using-acls.html#_local_development_with_acls)

--- a/samples/java-spring-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-spring-valueentity-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/java-spring-view-store/docker-compose.yml
+++ b/samples/java-spring-view-store/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Enable advanced view features locally (note: disabled in deployed services by default)

--- a/samples/scala-protobuf-customer-registry-quickstart/docker-compose.yml
+++ b/samples/scala-protobuf-customer-registry-quickstart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -28,7 +28,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: "8080"
 

--- a/samples/scala-protobuf-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}

--- a/samples/scala-protobuf-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-fibonacci-action/docker-compose.yml
+++ b/samples/scala-protobuf-fibonacci-action/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-first-service/docker-compose.yml
+++ b/samples/scala-protobuf-first-service/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-reliable-timers/docker-compose.yml
+++ b/samples/scala-protobuf-reliable-timers/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-replicatedentity-examples/docker-compose.yml
+++ b/samples/scala-protobuf-replicatedentity-examples/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-valueentity-counter/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-counter/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-valueentity-customer-registry/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-customer-registry/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-shopping-cart/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       #PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator

--- a/samples/scala-protobuf-view-store/docker-compose.yml
+++ b/samples/scala-protobuf-view-store/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
       # Enable advanced view features locally (note: disabled in deployed services by default)

--- a/samples/scala-protobuf-web-resources/docker-compose.yml
+++ b/samples/scala-protobuf-web-resources/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be under this environment map (note: remove this comment when adding properties)
+      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
+
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}


### PR DESCRIPTION
Fix a typo in docker-compose file and added an extra line to split the JAVA_TOOL_OPTIONS and USER_FUNCTION_HOST to avoid confusion. 
