### PR TITLE
chore: bump scala tooling version 2.12.15 -> 2.12.18

### DIFF
--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <encoding>UTF-8</encoding>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.18</scala.version>
     <scala.compat.version>2.12</scala.compat.version>
   </properties>
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
 
   // changing the Scala version of the Java SDK affects end users
   val ScalaVersion = "2.13.12"
-  val ScalaVersionForTooling = "2.12.15"
+  val ScalaVersionForTooling = "2.12.18"
 
   val ProtobufVersion = // akka.grpc.gen.BuildInfo.googleProtobufVersion
     "3.21.12" // explicitly overriding the 3.21.1 version from Akka gRPC 2.1.6 (even though its build says 3.20.1)


### PR DESCRIPTION
I've noticed the issue when using `./publishLocally.sh`:
```
[info] scalafmt: Formatting 5 Scala sources (/Users/andrzej/projects/kalix/kalix-jvm-sdk/codegen/core)...
[info] scalafmt: Formatting 8 Scala sources (/Users/andrzej/projects/kalix/kalix-jvm-sdk/codegen/core)...
[info] Compiling 14 protobuf files to /Users/andrzej/projects/kalix/kalix-jvm-sdk/codegen/core/target/scala-2.12/akka-grpc/main
[info] Main Scala API documentation to /Users/andrzej/projects/kalix/kalix-jvm-sdk/codegen/core/target/scala-2.12/api...
[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.15. Compiling...
error:
  bad constant pool index: 0 at pos: 48445ate 2s
     while compiling: <no file>
        during phase: globalPhase=<no phase>, enteringPhase=<some phase>
     library version: version 2.12.15
    compiler version: version 2.12.15
  reconstructed args: -bootclasspath /Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15.jar -nowarn -classpath /Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.9.2/compiler-interface-1.9.2.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.9.1/util-interface-1.9.1.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.9.2/compiler-bridge_2.12-1.9.2-sources.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.15/scala-compiler-2.12.15.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.15/scala-reflect-2.12.15.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar -d /var/folders/ng/gr9v1p2n7ml56xrgwb9j_vh40000gn/T/sbt_c74b20c9 -Xmaxwarns 0

  last tree to typer: EmptyTree
       tree position: <unknown>
            tree tpe: <notype>
              symbol: null
           call site: <none> in <none>

== Source file context for tree position ==

error: scala.reflect.internal.FatalError:
  bad constant pool index: 0 at pos: 48445
     while compiling: <no file>
        during phase: globalPhase=<no phase>, enteringPhase=<some phase>
     library version: version 2.12.15
    compiler version: version 2.12.15
  reconstructed args: -bootclasspath /Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15.jar -nowarn -classpath /Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.9.2/compiler-interface-1.9.2.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.9.1/util-interface-1.9.1.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-bridge_2.12/1.9.2/compiler-bridge_2.12-1.9.2-sources.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.15/scala-compiler-2.12.15.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.15/scala-reflect-2.12.15.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar:/Users/andrzej/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar -d /var/folders/ng/gr9v1p2n7ml56xrgwb9j_vh40000gn/T/sbt_c74b20c9 -Xmaxwarns 0

  last tree to typer: EmptyTree
       tree position: <unknown>
            tree tpe: <notype>
              symbol: null
           call site: <none> in <none>

== Source file context for tree position ==


	at scala.reflect.internal.Reporting.abort(Reporting.scala:69)
	at scala.reflect.internal.Reporting.abort$(Reporting.scala:65)
	at scala.reflect.internal.SymbolTable.abort(SymbolTable.scala:28)
```