### PR TITLE
bump: kalix runtime to 1.1.29

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: ]]#${artifactId}#[[
     ports:
       - "9000:9000"

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: ]]#${artifactId}#[[
     ports:
       - "9000:9000"

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: ]]#${artifactId}#[[
     ports:
       - "9000:9000"

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/docker-compose.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: ]]#${artifactId}#[[
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-customer-registry-kafka-quickstart
     # uncomment volumes when persistence is enabled
 #    volumes:

--- a/samples/java-protobuf-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-quickstart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-customer-registry-quickstart
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-customer-registry-views-quickstart
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-eventsourced-counter/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-eventsourced-counter
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-eventsourced-customer-registry-subscriber
     depends_on:
       - kalix-runtime-customer-registry
@@ -21,7 +21,7 @@ services:
       USER_SERVICE_PORT: "8081"
 
   kalix-runtime-customer-registry:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-eventsourced-customer-registry
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # on the same local machine as the java-protobuf-eventsourced-customer-registry
 #tag::customer-registry-subscriber[]  
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-eventsourced-customer-registry-subscriber
     ports:
       - "9001:9001"

--- a/samples/java-protobuf-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-customer-registry/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-eventsourced-customer-registry
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-eventsourced-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-fibonacci-action/docker-compose.yml
+++ b/samples/java-protobuf-fibonacci-action/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-fibonacci-action
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-first-service/docker-compose.yml
+++ b/samples/java-protobuf-first-service/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-first-service
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-reliable-timers/docker-compose.yml
+++ b/samples/java-protobuf-reliable-timers/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-reliable-timers
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-replicatedentity-examples/docker-compose.yml
+++ b/samples/java-protobuf-replicatedentity-examples/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-replicatedentity-examples
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-replicatedentity-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-protobuf-shopping-cart-quickstart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-shopping-cart-quickstart
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-valueentity-counter/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-counter/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-valueentity-counter
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-customer-registry/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-valueentity-customer-registry
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-protobuf-valueentity-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-valueentity-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-view-store/docker-compose.yml
+++ b/samples/java-protobuf-view-store/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-view-store
     ports:
       - "9000:9000"

--- a/samples/java-protobuf-web-resources/docker-compose.yml
+++ b/samples/java-protobuf-web-resources/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-protobuf-web-resources
     ports:
       - "9000:9000"

--- a/samples/java-spring-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-spring-customer-registry-quickstart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-customer-registry-quickstart
     ports:
       - "9000:9000"

--- a/samples/java-spring-customer-registry-views-quickstart/docker-compose.yml
+++ b/samples/java-spring-customer-registry-views-quickstart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-customer-registry-views-quickstart
     ports:
       - "9000:9000"

--- a/samples/java-spring-doc-snippets/docker-compose.yml
+++ b/samples/java-spring-doc-snippets/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     # uncomment volumes when persistence is enabled
     volumes: # <1>
       - ./target/kalix:/var/kalix

--- a/samples/java-spring-eventsourced-counter/docker-compose.yml
+++ b/samples/java-spring-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-eventsourced-counter
     ports:
       - "9000:9000"

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-eventsourced-customer-registry-subscriber
     depends_on:
       - kalix-runtime-customer-registry
@@ -21,7 +21,7 @@ services:
       USER_SERVICE_PORT: "8081"
 
   kalix-runtime-customer-registry:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-eventsourced-customer-registry
     ports:
       - "9000:9000"

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-eventsourced-customer-registry-subscriber
     ports:
       - "9001:9001"

--- a/samples/java-spring-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/java-spring-eventsourced-customer-registry/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-eventsourced-customer-registry
     ports:
       - "9000:9000"

--- a/samples/java-spring-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-spring-eventsourced-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-eventsourced-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/java-spring-fibonacci-action/docker-compose.yml
+++ b/samples/java-spring-fibonacci-action/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-fibonacci-action
     ports:
       - "9000:9000"

--- a/samples/java-spring-reliable-timers/docker-compose.yml
+++ b/samples/java-spring-reliable-timers/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-reliable-timers
     ports:
       - "9000:9000"

--- a/samples/java-spring-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/java-spring-shopping-cart-quickstart/docker-compose.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-shopping-cart-quickstart
     ports:
       - "9000:9000"

--- a/samples/java-spring-transfer-workflow-compensation/docker-compose.yml
+++ b/samples/java-spring-transfer-workflow-compensation/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-transfer-workflow-compensation
     ports:
       - "9000:9000"

--- a/samples/java-spring-transfer-workflow/docker-compose.yml
+++ b/samples/java-spring-transfer-workflow/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-transfer-workflow
     ports:
       - "9000:9000"

--- a/samples/java-spring-valueentity-counter/docker-compose.yml
+++ b/samples/java-spring-valueentity-counter/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-valueentity-counter
     ports:
       - "9000:9000"

--- a/samples/java-spring-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-spring-valueentity-customer-registry/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-valueentity-customer-registry
     ports:
       - "9000:9000"

--- a/samples/java-spring-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-spring-valueentity-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-valueentity-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/java-spring-view-store/docker-compose.yml
+++ b/samples/java-spring-view-store/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-view-store
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-customer-registry-quickstart/docker-compose.yml
+++ b/samples/scala-protobuf-customer-registry-quickstart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-customer-registry-quickstart
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-doc-snippets/docker-compose.yml
+++ b/samples/scala-protobuf-doc-snippets/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     # uncomment volumes when persistence is enabled
     volumes: # <1>
       - ./target/kalix:/var/kalix

--- a/samples/scala-protobuf-eventsourced-counter/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-eventsourced-counter
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose-integration.yml
@@ -5,7 +5,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-eventsourced-customer-registry-subscriber
     depends_on:
       - kalix-runtime-customer-registry
@@ -20,7 +20,7 @@ services:
       USER_SERVICE_PORT: "8081"
 
   kalix-runtime-customer-registry:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-eventsourced-customer-registry
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # note the ports being different from other sample docker-compose files to allow this service to run
   # on the same local machine as the scala-protobuf-eventsourced-customer-registry
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-eventsourced-customer-registry-subscriber
     ports:
       - "9001:9000"

--- a/samples/scala-protobuf-eventsourced-customer-registry/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-customer-registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-eventsourced-customer-registry
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-eventsourced-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-fibonacci-action/docker-compose.yml
+++ b/samples/scala-protobuf-fibonacci-action/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-fibonacci-action
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-first-service/docker-compose.yml
+++ b/samples/scala-protobuf-first-service/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-first-service
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-reliable-timers/docker-compose.yml
+++ b/samples/scala-protobuf-reliable-timers/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-reliable-timers
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-replicatedentity-examples/docker-compose.yml
+++ b/samples/scala-protobuf-replicatedentity-examples/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-replicatedentity-examples
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-replicatedentity-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-valueentity-counter/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-counter/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-valueentity-counter
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-valueentity-customer-registry/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-customer-registry/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-valueentity-customer-registry
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/scala-protobuf-valueentity-shopping-cart/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-valueentity-shopping-cart
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-view-store/docker-compose.yml
+++ b/samples/scala-protobuf-view-store/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-view-store
     ports:
       - "9000:9000"

--- a/samples/scala-protobuf-web-resources/docker-compose.yml
+++ b/samples/scala-protobuf-web-resources/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: scala-protobuf-web-resources
     ports:
       - "9000:9000"

--- a/sdk/java-sdk-spring/docker-compose-integration.yml
+++ b/sdk/java-sdk-spring/docker-compose-integration.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     ports:
       - "9000:9000"
     extra_hosts:

--- a/updateProxyVersions.sh
+++ b/updateProxyVersions.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# delegating from the old script name
-
-${PWD}/updateRuntimeVersions.sh

--- a/updateRuntimeVersions.sh
+++ b/updateRuntimeVersions.sh
@@ -22,5 +22,5 @@ do
 done
 
 echo ">>> Updating Dependencies.scala"
-sed -i.bak "s/System.getProperty(\"kalix-runtime.version\", \"\(.*\)\")/System.getProperty(\"kalix-runtime.version\", \"$RUNTIME_VERSION\")/" ./project/Dependencies.scala
+sed -i.bak "s/System.getProperty(\"kalix-proxy.version\", \"\(.*\)\")/System.getProperty(\"kalix-proxy.version\", \"$RUNTIME_VERSION\")/" ./project/Dependencies.scala
 rm ./project/Dependencies.scala.bak


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-runtime/issues/2266

Auto PR not working (fixed in PR already) so opening manually.

As draft until 1.1.29 reaches prod.