### PR TITLE
chore: move container class to impl package

### DIFF
--- a/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/impl/KalixRuntimeContainer.java
+++ b/sdk/java-sdk-protobuf-testkit/src/main/java/kalix/javasdk/testkit/impl/KalixRuntimeContainer.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package kalix.javasdk.testkit;
+package kalix.javasdk.testkit.impl;
 
+import kalix.javasdk.testkit.BuildInfo;
 import kalix.javasdk.testkit.KalixTestKit.Settings.EventingSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,16 +30,16 @@ import static kalix.javasdk.testkit.KalixTestKit.Settings.EventingSupport.GOOGLE
 import static kalix.javasdk.testkit.KalixTestKit.Settings.EventingSupport.KAFKA;
 
 /** Docker test container of Kalix Runtime for local development and testing. */
-public class KalixProxyContainer extends GenericContainer<KalixProxyContainer> {
+public class KalixRuntimeContainer extends GenericContainer<KalixRuntimeContainer> {
 
   /** Default Testcontainers DockerImageName for the Kalix Runtime. */
-  public static final DockerImageName DEFAULT_PROXY_IMAGE_NAME;
+  public static final DockerImageName DEFAULT_RUNTIME_IMAGE_NAME;
 
-  /** Default proxy port (9000). */
-  public static final int DEFAULT_PROXY_PORT = 9000;
+  /** Default runtime port (9000). */
+  public static final int DEFAULT_RUNTIME_PORT = 9000;
 
-  /** Default user function port (8080). */
-  public static final int DEFAULT_USER_FUNCTION_PORT = 8080;
+  /** Default user service port (8080). */
+  public static final int DEFAULT_USER_SERVICE_PORT = 8080;
 
   /** Default local port where the Google Pub/Sub emulator is available (8085). */
   public static final int DEFAULT_GOOGLE_PUBSUB_PORT = 8085;
@@ -48,10 +49,10 @@ public class KalixProxyContainer extends GenericContainer<KalixProxyContainer> {
   static {
     String customImage = System.getenv("KALIX_TESTKIT_PROXY_IMAGE");
     if (customImage == null) {
-      DEFAULT_PROXY_IMAGE_NAME = DockerImageName.parse(BuildInfo.runtimeImage()).withTag(BuildInfo.runtimeVersion());
+      DEFAULT_RUNTIME_IMAGE_NAME = DockerImageName.parse(BuildInfo.runtimeImage()).withTag(BuildInfo.runtimeVersion());
     } else {
-      Logger logger = LoggerFactory.getLogger(KalixProxyContainer.class);
-      DEFAULT_PROXY_IMAGE_NAME = DockerImageName.parse(customImage);
+      Logger logger = LoggerFactory.getLogger(KalixRuntimeContainer.class);
+      DEFAULT_RUNTIME_IMAGE_NAME = DockerImageName.parse(customImage);
       logger.info("Using custom runtime image [{}]", customImage);
     }
   }
@@ -60,31 +61,31 @@ public class KalixProxyContainer extends GenericContainer<KalixProxyContainer> {
   private final int eventingPort;
   private final EventingSupport eventingSupport;
 
-  public KalixProxyContainer() {
-    this(DEFAULT_USER_FUNCTION_PORT);
+  public KalixRuntimeContainer() {
+    this(DEFAULT_USER_SERVICE_PORT);
   }
 
-  public KalixProxyContainer(final int userFunctionPort) {
-    this(DEFAULT_PROXY_IMAGE_NAME, EventingSupport.TEST_BROKER, userFunctionPort, DEFAULT_GOOGLE_PUBSUB_PORT);
+  public KalixRuntimeContainer(final int userFunctionPort) {
+    this(DEFAULT_RUNTIME_IMAGE_NAME, EventingSupport.TEST_BROKER, userFunctionPort, DEFAULT_GOOGLE_PUBSUB_PORT);
   }
 
-  public KalixProxyContainer(EventingSupport eventingSupport, final int userFunctionPort, int eventingPort) {
-    this(DEFAULT_PROXY_IMAGE_NAME, eventingSupport, userFunctionPort, eventingPort);
+  public KalixRuntimeContainer(EventingSupport eventingSupport, final int userFunctionPort, int eventingPort) {
+    this(DEFAULT_RUNTIME_IMAGE_NAME, eventingSupport, userFunctionPort, eventingPort);
   }
 
-  public KalixProxyContainer(
+  public KalixRuntimeContainer(
       final DockerImageName dockerImageName,
       EventingSupport eventingSupport,
-      final int userFunctionPort,
+      final int userServicePort,
       final int eventingPort) {
     super(dockerImageName);
-    this.userFunctionPort = userFunctionPort;
+    this.userFunctionPort = userServicePort;
     this.eventingPort = eventingPort;
     this.eventingSupport = eventingSupport;
-    withExposedPorts(DEFAULT_PROXY_PORT);
+    withExposedPorts(DEFAULT_RUNTIME_PORT);
     withEnv("USER_SERVICE_HOST", "host.testcontainers.internal");
-    withEnv("USER_SERVICE_PORT", String.valueOf(userFunctionPort));
-    withEnv("HTTP_PORT", String.valueOf(DEFAULT_PROXY_PORT));
+    withEnv("USER_SERVICE_PORT", String.valueOf(userServicePort));
+    withEnv("HTTP_PORT", String.valueOf(DEFAULT_RUNTIME_PORT));
     if ("false".equals(System.getenv("VERSION_CHECK_ON_STARTUP"))) {
       withEnv("VERSION_CHECK_ON_STARTUP", "false");
     }
@@ -114,6 +115,6 @@ public class KalixProxyContainer extends GenericContainer<KalixProxyContainer> {
    * @return port for the local Kalix service
    */
   public int getProxyPort() {
-    return getMappedPort(DEFAULT_PROXY_PORT);
+    return getMappedPort(DEFAULT_RUNTIME_PORT);
   }
 }


### PR DESCRIPTION
Build on top of https://github.com/lightbend/kalix-jvm-sdk/pull/1933

This is a little more complicated. We have a KalixProxyContainer class that is public, but should have been in impl package. 

It is instantiated inside the testkit and kept private. So, from that perspective it is effectively private.

Leaving it as draft until we merge #1933 and decide what to do with this class. From my part, we can simply move it to the impl package and consider it private.
