### PR TITLE
feat: provide http status code API

### DIFF
--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
@@ -239,6 +239,15 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    */
   Principals principals();
 
+  /**
+   * Add an HTTP response code to this metadata.
+   * This will only take effect when HTTP transcoding is in use. It will be ignored for gRPC requests.
+   *
+   * @param code The status code to add.
+   * @return a copy of this metadata with the HTTP response code set.
+   */
+  Metadata withHttpResponseCode(StatusCode code);
+
   /** A metadata entry. */
   interface MetadataEntry {
     /**

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
@@ -243,19 +243,19 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    * Add an HTTP response code to this metadata.
    * This will only take effect when HTTP transcoding is in use. It will be ignored for gRPC requests.
    *
-   * @param code The success status code to add.
+   * @param httpStatusCode The success status code to add.
    * @return a copy of this metadata with the HTTP response code set.
    */
-  Metadata withHttpResponseCode(StatusCode.Success code);
+  Metadata withStatusCode(StatusCode.Success httpStatusCode);
 
   /**
    * Add an HTTP response code to this metadata.
    * This will only take effect when HTTP transcoding is in use. It will be ignored for gRPC requests.
    *
-   * @param code The redirect status code to add.
+   * @param httpStatusCode The redirect status code to add.
    * @return a copy of this metadata with the HTTP response code set.
    */
-  Metadata withHttpResponseCode(StatusCode.Redirect code);
+  Metadata withStatusCode(StatusCode.Redirect httpStatusCode);
 
   /** A metadata entry. */
   interface MetadataEntry {

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
@@ -243,10 +243,19 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    * Add an HTTP response code to this metadata.
    * This will only take effect when HTTP transcoding is in use. It will be ignored for gRPC requests.
    *
-   * @param code The status code to add.
+   * @param code The success status code to add.
    * @return a copy of this metadata with the HTTP response code set.
    */
-  Metadata withHttpResponseCode(StatusCode code);
+  Metadata withHttpResponseCode(StatusCode.Success code);
+
+  /**
+   * Add an HTTP response code to this metadata.
+   * This will only take effect when HTTP transcoding is in use. It will be ignored for gRPC requests.
+   *
+   * @param code The redirect status code to add.
+   * @return a copy of this metadata with the HTTP response code set.
+   */
+  Metadata withHttpResponseCode(StatusCode.Redirect code);
 
   /** A metadata entry. */
   interface MetadataEntry {

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/StatusCode.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/StatusCode.java
@@ -17,8 +17,7 @@
 package kalix.javasdk;
 
 /**
- * Interface used to represent a status code, typically used when replying with an error. **NOT**
- * for user extension.
+ * Interface used to represent HTTP status code. **NOT** for user extension.
  */
 public interface StatusCode {
 
@@ -55,6 +54,8 @@ public interface StatusCode {
     FOUND(302),
     SEE_OTHER(303),
     NOT_MODIFIED(304),
+    USE_PROXY(305),
+
     TEMPORARY_REDIRECT(307),
     PERMANENT_REDIRECT(308);
 

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/StatusCode.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/StatusCode.java
@@ -21,16 +21,77 @@ package kalix.javasdk;
  * for user extension.
  */
 public interface StatusCode {
+
+  // return the value of the status code
+  int value();
+
+  enum Success implements StatusCode {
+    OK(200),
+    CREATED(201),
+    ACCEPTED(202),
+    NON_AUTHORITATIVE_INFORMATION(203),
+    NO_CONTENT(204),
+    RESET_CONTENT(205),
+    PARTIAL_CONTENT(206),
+    MULTI_STATUS(207),
+    ALREADY_REPORTED(208),
+    IM_USED(226);
+
+    private final int value;
+
+    Success(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int value() {
+      return value;
+    }
+  }
+
+  enum Redirect implements StatusCode {
+    MULTIPLE_CHOICES(300),
+    MOVED_PERMANENTLY(301),
+    FOUND(302),
+    SEE_OTHER(303),
+    NOT_MODIFIED(304),
+    TEMPORARY_REDIRECT(307),
+    PERMANENT_REDIRECT(308);
+
+    private final int value;
+
+    Redirect(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int value() {
+      return value;
+    }
+  }
+
+
   /** The supported HTTP error codes that can be used when replying from the Kalix user function. */
   enum ErrorCode implements StatusCode {
-    BAD_REQUEST,
-    UNAUTHORIZED,
-    FORBIDDEN,
-    NOT_FOUND,
-    CONFLICT,
-    TOO_MANY_REQUESTS,
-    INTERNAL_SERVER_ERROR,
-    SERVICE_UNAVAILABLE,
-    GATEWAY_TIMEOUT
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    FORBIDDEN(403),
+    NOT_FOUND(404),
+    CONFLICT(409),
+    TOO_MANY_REQUESTS(429),
+    INTERNAL_SERVER_ERROR(500),
+    SERVICE_UNAVAILABLE(503),
+    GATEWAY_TIMEOUT(504);
+
+    private final int value;
+
+    ErrorCode(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int value() {
+      return value;
+    }
   }
 }

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/StatusCode.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/StatusCode.java
@@ -55,7 +55,6 @@ public interface StatusCode {
     SEE_OTHER(303),
     NOT_MODIFIED(304),
     USE_PROXY(305),
-
     TEMPORARY_REDIRECT(307),
     PERMANENT_REDIRECT(308);
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
@@ -22,6 +22,8 @@ import kalix.javasdk.JwtClaims
 import kalix.javasdk.Metadata
 import kalix.javasdk.Principal
 import kalix.javasdk.Principals
+import kalix.javasdk.StatusCode
+import kalix.javasdk.StatusCode.ErrorCode
 import kalix.javasdk.impl.MetadataImpl.JwtClaimPrefix
 import kalix.protocol.component
 import kalix.protocol.component.MetadataEntry
@@ -193,6 +195,13 @@ private[kalix] class MetadataImpl(val entries: Seq[MetadataEntry]) extends Metad
     set(MetadataImpl.CeTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(time))
 
   override def clearTime(): MetadataImpl = remove(MetadataImpl.CeTime)
+
+  override def withHttpResponseCode(code: StatusCode): MetadataImpl = {
+    if (code.isInstanceOf[ErrorCode])
+      throw new RuntimeException("Invalid HTTP status code: " + code + ". Use .error method for replying with errors.")
+
+    set("_kalix-http-code", code.value.toString)
+  }
 
   override def asMetadata(): Metadata = this
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
@@ -196,10 +196,10 @@ private[kalix] class MetadataImpl(val entries: Seq[MetadataEntry]) extends Metad
 
   override def clearTime(): MetadataImpl = remove(MetadataImpl.CeTime)
 
-  override def withHttpResponseCode(code: StatusCode.Redirect): MetadataImpl =
+  override def withStatusCode(code: StatusCode.Redirect): MetadataImpl =
     set("_kalix-http-code", code.value.toString)
 
-  override def withHttpResponseCode(code: StatusCode.Success): MetadataImpl =
+  override def withStatusCode(code: StatusCode.Success): MetadataImpl =
     set("_kalix-http-code", code.value.toString)
 
   override def asMetadata(): Metadata = this

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
@@ -196,12 +196,11 @@ private[kalix] class MetadataImpl(val entries: Seq[MetadataEntry]) extends Metad
 
   override def clearTime(): MetadataImpl = remove(MetadataImpl.CeTime)
 
-  override def withHttpResponseCode(code: StatusCode): MetadataImpl = {
-    if (code.isInstanceOf[ErrorCode])
-      throw new RuntimeException("Invalid HTTP status code: " + code + ". Use .error method for replying with errors.")
-
+  override def withHttpResponseCode(code: StatusCode.Redirect): MetadataImpl =
     set("_kalix-http-code", code.value.toString)
-  }
+
+  override def withHttpResponseCode(code: StatusCode.Success): MetadataImpl =
+    set("_kalix-http-code", code.value.toString)
 
   override def asMetadata(): Metadata = this
 

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/MetadataImplSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/MetadataImplSpec.scala
@@ -153,10 +153,10 @@ class MetadataImplSpec extends AnyWordSpec with Matchers with OptionValues {
     }
 
     "support setting a HTTP status code" in {
-      val md = Metadata.EMPTY.withHttpResponseCode(Success.CREATED)
+      val md = Metadata.EMPTY.withStatusCode(Success.CREATED)
       md.get("_kalix-http-code").toScala.value shouldBe "201"
 
-      val mdRedirect = md.withHttpResponseCode(Redirect.MOVED_PERMANENTLY)
+      val mdRedirect = md.withStatusCode(Redirect.MOVED_PERMANENTLY)
       mdRedirect.get("_kalix-http-code").toScala.value shouldBe "301"
     }
   }

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/MetadataImplSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/MetadataImplSpec.scala
@@ -16,6 +16,9 @@
 
 package kalix.javasdk.impl
 
+import kalix.javasdk.StatusCode.Redirect
+import kalix.javasdk.StatusCode.Success
+
 import java.time.Instant
 import java.util.Optional
 import kalix.javasdk.{ Metadata, Principal }
@@ -147,6 +150,14 @@ class MetadataImplSpec extends AnyWordSpec with Matchers with OptionValues {
         meta.principals().isAnyLocalService shouldBe false
         meta.principals().get().asScala should have size 0
       }
+    }
+
+    "support setting a HTTP status code" in {
+      val md = Metadata.EMPTY.withHttpResponseCode(Success.CREATED)
+      md.get("_kalix-http-code").toScala.value shouldBe "201"
+
+      val mdRedirect = md.withHttpResponseCode(Redirect.MOVED_PERMANENTLY)
+      mdRedirect.get("_kalix-http-code").toScala.value shouldBe "301"
     }
   }
 

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
@@ -44,6 +44,7 @@ import com.example.wiring.views.UsersByEmailAndName;
 import com.google.protobuf.any.Any;
 import kalix.javasdk.DeferredCall;
 import kalix.javasdk.Metadata;
+import kalix.javasdk.StatusCode;
 import kalix.javasdk.client.ComponentClient;
 import kalix.javasdk.client.EventSourcedEntityCallBuilder;
 import kalix.spring.KalixConfigurationTest;
@@ -51,6 +52,7 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,6 +60,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -218,6 +221,17 @@ public class SpringSdkIntegrationTest {
     );
 
     assertThat(response.text).isEqualTo("foo/bar");
+  }
+
+  @Test
+  public void verifyEchoActionWithCustomCode() {
+    ClientResponse response =
+        webClient
+            .post()
+            .uri("/echo/message/customCode/hello")
+            .exchangeToMono(Mono::just)
+            .block(timeout);
+    Assertions.assertEquals(StatusCode.Success.ACCEPTED.value(), response.statusCode().value());
   }
 
   @Test

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/ValueEntityIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/ValueEntityIntegrationTest.java
@@ -111,7 +111,6 @@ public class ValueEntityIntegrationTest {
             .uri("/user/" + user.id + "/" + user.email + "/" + user.name)
             .exchangeToMono(Mono::just)
             .block(timeout);
-    Assertions.assertEquals("\"Ok\"", response.bodyToMono(String.class));
     Assertions.assertEquals(201, response.statusCode().value());
   }
 

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/ValueEntityIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/ValueEntityIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -104,14 +105,14 @@ public class ValueEntityIntegrationTest {
   }
 
   private void createUser(TestUser user) {
-    String userCreation =
+    ClientResponse response =
         webClient
             .post()
             .uri("/user/" + user.id + "/" + user.email + "/" + user.name)
-            .retrieve()
-            .bodyToMono(String.class)
+            .exchangeToMono(Mono::just)
             .block(timeout);
-    Assertions.assertEquals("\"Ok\"", userCreation);
+    Assertions.assertEquals("\"Ok\"", response.bodyToMono(String.class));
+    Assertions.assertEquals(201, response.statusCode().value());
   }
 
   private void changeEmail(TestUser user) {

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/actions/echo/EchoAction.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/actions/echo/EchoAction.java
@@ -16,6 +16,8 @@
 
 package com.example.wiring.actions.echo;
 
+import kalix.javasdk.Metadata;
+import kalix.javasdk.StatusCode;
 import kalix.javasdk.action.Action;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.javasdk.client.ComponentClient;
@@ -91,5 +93,12 @@ public class EchoAction extends Action {
         .flatMap(
             i -> Mono.fromCompletionStage(CompletableFuture.supplyAsync(() -> parrot.repeat(msg))))
         .map(m -> effects().reply(new Message(m)));
+  }
+
+  @PostMapping("/echo/message/customCode/{msg}")
+  public Effect<Message> stringMessageCustomCode(@PathVariable String msg) {
+    String response = this.parrot.repeat(msg);
+    return effects().reply(new Message(response),
+        Metadata.EMPTY.withHttpResponseCode(StatusCode.Success.ACCEPTED));
   }
 }

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/actions/echo/EchoAction.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/actions/echo/EchoAction.java
@@ -99,6 +99,6 @@ public class EchoAction extends Action {
   public Effect<Message> stringMessageCustomCode(@PathVariable String msg) {
     String response = this.parrot.repeat(msg);
     return effects().reply(new Message(response),
-        Metadata.EMPTY.withHttpResponseCode(StatusCode.Success.ACCEPTED));
+        Metadata.EMPTY.withStatusCode(StatusCode.Success.ACCEPTED));
   }
 }

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/customer/CustomerEntity.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/customer/CustomerEntity.java
@@ -16,8 +16,6 @@
 
 package com.example.wiring.valueentities.customer;
 
-import kalix.javasdk.Metadata;
-import kalix.javasdk.StatusCode;
 import kalix.javasdk.valueentity.ValueEntity;
 import kalix.javasdk.annotations.Id;
 import kalix.javasdk.annotations.TypeId;
@@ -38,8 +36,7 @@ public class CustomerEntity extends ValueEntity<CustomerEntity.Customer> {
 
   @PutMapping
   public Effect<String> create(@RequestBody Customer customer) {
-    return effects().updateState(customer).thenReply("Ok",
-        Metadata.EMPTY.withHttpResponseCode(StatusCode.Success.CREATED));
+    return effects().updateState(customer).thenReply("Ok");
   }
 
   @GetMapping

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/customer/CustomerEntity.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/customer/CustomerEntity.java
@@ -16,6 +16,8 @@
 
 package com.example.wiring.valueentities.customer;
 
+import kalix.javasdk.Metadata;
+import kalix.javasdk.StatusCode;
 import kalix.javasdk.valueentity.ValueEntity;
 import kalix.javasdk.annotations.Id;
 import kalix.javasdk.annotations.TypeId;
@@ -36,7 +38,8 @@ public class CustomerEntity extends ValueEntity<CustomerEntity.Customer> {
 
   @PutMapping
   public Effect<String> create(@RequestBody Customer customer) {
-    return effects().updateState(customer).thenReply("Ok");
+    return effects().updateState(customer).thenReply("Ok",
+        Metadata.EMPTY.withHttpResponseCode(StatusCode.Success.CREATED));
   }
 
   @GetMapping

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
@@ -16,6 +16,7 @@
 
 package com.example.wiring.valueentities.user;
 
+import kalix.javasdk.Metadata;
 import kalix.javasdk.StatusCode;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.valueentity.ValueEntity;
@@ -49,7 +50,8 @@ public class UserEntity extends ValueEntity<User> {
 
   @PostMapping("/{email}/{name}")
   public Effect<String> createOrUpdateUser(@PathVariable String email, @PathVariable String name) {
-    return effects().updateState(new User(email, name)).thenReply("Ok");
+    return effects().updateState(new User(email, name)).thenReply("Ok",
+        Metadata.EMPTY.withHttpResponseCode(StatusCode.Success.CREATED));
   }
 
   @PutMapping("/{email}/{name}")

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/valueentities/user/UserEntity.java
@@ -51,7 +51,7 @@ public class UserEntity extends ValueEntity<User> {
   @PostMapping("/{email}/{name}")
   public Effect<String> createOrUpdateUser(@PathVariable String email, @PathVariable String name) {
     return effects().updateState(new User(email, name)).thenReply("Ok",
-        Metadata.EMPTY.withHttpResponseCode(StatusCode.Success.CREATED));
+        Metadata.EMPTY.withStatusCode(StatusCode.Success.CREATED));
   }
 
   @PutMapping("/{email}/{name}")

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/Metadata.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/Metadata.scala
@@ -269,23 +269,23 @@ trait Metadata extends Iterable[MetadataEntry] {
    * Add an HTTP response code to this metadata. This will only take effect when HTTP transcoding is in use. It will be
    * ignored for gRPC requests.
    *
-   * @param code
+   * @param httpStatusCode
    *   The success status code to add.
    * @return
    *   a copy of this metadata with the HTTP response code set.
    */
-  def withHttpResponseCode(code: StatusCode.Success): Metadata
+  def withStatusCode(httpStatusCode: StatusCode.Success): Metadata
 
   /**
    * Add an HTTP response code to this metadata. This will only take effect when HTTP transcoding is in use. It will be
    * ignored for gRPC requests.
    *
-   * @param code
+   * @param httpStatusCode
    *   The redirect status code to add.
    * @return
    *   a copy of this metadata with the HTTP response code set.
    */
-  def withHttpResponseCode(code: StatusCode.Redirect): Metadata
+  def withStatusCode(httpStatusCode: StatusCode.Redirect): Metadata
 }
 
 object Metadata {

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/Metadata.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/Metadata.scala
@@ -264,6 +264,28 @@ trait Metadata extends Iterable[MetadataEntry] {
    * Get the Principals associated with this request.
    */
   def principals: Principals
+
+  /**
+   * Add an HTTP response code to this metadata. This will only take effect when HTTP transcoding is in use. It will be
+   * ignored for gRPC requests.
+   *
+   * @param code
+   *   The success status code to add.
+   * @return
+   *   a copy of this metadata with the HTTP response code set.
+   */
+  def withHttpResponseCode(code: StatusCode.Success): Metadata
+
+  /**
+   * Add an HTTP response code to this metadata. This will only take effect when HTTP transcoding is in use. It will be
+   * ignored for gRPC requests.
+   *
+   * @param code
+   *   The redirect status code to add.
+   * @return
+   *   a copy of this metadata with the HTTP response code set.
+   */
+  def withHttpResponseCode(code: StatusCode.Redirect): Metadata
 }
 
 object Metadata {

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kalix.scalasdk
+
+/**
+ * A sealed trait representing HTTP status codes.
+ */
+sealed trait StatusCode
+
+/**
+ * Companion object for the `StatusCode` trait, containing various HTTP status code definitions.
+ */
+object StatusCode {
+  sealed abstract class Success(val value: Int) extends StatusCode
+
+  case object Ok extends Success(200)
+
+  case object Created extends Success(201)
+
+  case object Accepted extends Success(202)
+
+  case object NonAuthoritativeInformation extends Success(203)
+
+  case object NoContent extends Success(204)
+
+  case object ResetContent extends Success(205)
+
+  case object PartialContent extends Success(206)
+
+  case object MultiStatus extends Success(207)
+
+  case object AlreadyReported extends Success(208)
+
+  case object IMUsed extends Success(226)
+
+  sealed abstract class Redirect(val value: Int) extends StatusCode
+
+  case object MultipleChoices extends Redirect(300)
+
+  case object MovedPermanently extends Redirect(301)
+
+  case object Found extends Redirect(302)
+
+  case object SeeOther extends Redirect(303)
+
+  case object NotModified extends Redirect(304)
+
+  case object UseProxy extends Redirect(305)
+
+  case object TemporaryRedirect extends Redirect(307)
+
+  case object PermanentRedirect extends Redirect(308)
+}

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
@@ -47,7 +47,6 @@ object StatusCode {
 
   case object IMUsed extends Success(226)
 
-
   sealed abstract class Redirect(val value: Int) extends StatusCode
 
   case object MultipleChoices extends Redirect(300)

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
@@ -47,6 +47,7 @@ object StatusCode {
 
   case object IMUsed extends Success(226)
 
+
   sealed abstract class Redirect(val value: Int) extends StatusCode
 
   case object MultipleChoices extends Redirect(300)

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/MetadataImpl.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/MetadataImpl.scala
@@ -95,9 +95,9 @@ private[kalix] class MetadataImpl(val impl: kalix.javasdk.impl.MetadataImpl) ext
     override def localService: Option[String] = impl.principals.getLocalService.toScala
     override def apply: Seq[Principal] = impl.principals.get.asScala.map(Principal.toScala).toSeq
   }
-  override def withHttpResponseCode(code: StatusCode.Success): Metadata =
+  override def withStatusCode(code: StatusCode.Success): Metadata =
     set("_kalix-http-code", code.value.toString)
 
-  override def withHttpResponseCode(code: StatusCode.Redirect): Metadata =
+  override def withStatusCode(code: StatusCode.Redirect): Metadata =
     set("_kalix-http-code", code.value.toString)
 }

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/MetadataImpl.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/MetadataImpl.scala
@@ -16,10 +16,10 @@
 
 package kalix.scalasdk.impl
 import java.nio.ByteBuffer
-
 import scala.collection.immutable.Seq
 import kalix.scalasdk.{ CloudEvent, JwtClaims, Metadata, MetadataEntry, Principal, Principals }
 import kalix.protocol.component.{ MetadataEntry => ProtocolMetadataEntry }
+import kalix.scalasdk.StatusCode
 
 import scala.jdk.OptionConverters._
 import scala.jdk.CollectionConverters._
@@ -95,4 +95,9 @@ private[kalix] class MetadataImpl(val impl: kalix.javasdk.impl.MetadataImpl) ext
     override def localService: Option[String] = impl.principals.getLocalService.toScala
     override def apply: Seq[Principal] = impl.principals.get.asScala.map(Principal.toScala).toSeq
   }
+  override def withHttpResponseCode(code: StatusCode.Success): Metadata =
+    set("_kalix-http-code", code.value.toString)
+
+  override def withHttpResponseCode(code: StatusCode.Redirect): Metadata =
+    set("_kalix-http-code", code.value.toString)
 }


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-jvm-sdk/issues/1851

This is still very early draft version. I still have some questions to revisit:
- Should this go directly into Metadata or into something like ResponseCode (similar to CloudEvents and JwtClaims)?
- It could also go directly on the `reply` method (similar to the `error` that receives an error code), but maybe this way is better
- scala API
