### PR TITLE
feat: single event handler for sealed interface

### DIFF
--- a/sdk/java-sdk-spring-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedTestKit.java
+++ b/sdk/java-sdk-spring-testkit/src/main/java/kalix/javasdk/testkit/EventSourcedTestKit.java
@@ -19,11 +19,12 @@ package kalix.javasdk.testkit;
 import kalix.javasdk.Metadata;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import kalix.javasdk.impl.MethodInvoker;
 import kalix.javasdk.testkit.impl.EventSourcedEntityEffectsRunner;
 import kalix.javasdk.testkit.impl.TestKitEventSourcedEntityContext;
 import kalix.javasdk.impl.JsonMessageCodec;
-import kalix.javasdk.impl.eventsourcedentity.EventSourceEntityHandlers;
 import kalix.javasdk.impl.eventsourcedentity.EventSourcedHandlersExtractor;
+import scala.collection.immutable.Map;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -44,7 +45,7 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
     extends EventSourcedEntityEffectsRunner<S, E> {
 
   private final ES entity;
-  private final EventSourceEntityHandlers eventHandlers;
+  private final Map<String, MethodInvoker> eventHandlers;
 
   private final JsonMessageCodec messageCodec;
 
@@ -124,7 +125,7 @@ public class EventSourcedTestKit<S, E, ES extends EventSourcedEntity<S, E>>
   @Override
   protected final S handleEvent(S state, E event) {
     try {
-      Method method = eventHandlers.handlers().apply(messageCodec.removeVersion(messageCodec.typeUrlFor(event.getClass()))).method();
+      Method method = eventHandlers.apply(messageCodec.removeVersion(messageCodec.typeUrlFor(event.getClass()))).method();
       return (S) method.invoke(entity, event);
     } catch (NoSuchElementException e) {
       throw new RuntimeException(

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/eventsourcedentities/counter/Counter.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/eventsourcedentities/counter/Counter.java
@@ -29,4 +29,16 @@ public record Counter(Integer value) {
   public Counter onValueMultiplied(CounterEvent.ValueMultiplied evt) {
     return new Counter(this.value * evt.value());
   }
+
+  public Counter apply(CounterEvent counterEvent) {
+    if (counterEvent instanceof CounterEvent.ValueIncreased increased) {
+      return onValueIncreased(increased);
+    } else if (counterEvent instanceof CounterEvent.ValueSet set) {
+      return onValueSet(set);
+    } else if (counterEvent instanceof CounterEvent.ValueMultiplied multiplied) {
+      return onValueMultiplied(multiplied);
+    } else {
+      throw new RuntimeException("Unknown event type: " + counterEvent);
+    }
+  }
 }

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/eventsourcedentities/counter/CounterEntity.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/eventsourcedentities/counter/CounterEntity.java
@@ -94,17 +94,7 @@ public class CounterEntity extends EventSourcedEntity<Counter, CounterEvent> {
   }
 
   @EventHandler
-  public Counter handleIncrease(CounterEvent.ValueIncreased increased) {
-    return currentState().onValueIncreased(increased);
-  }
-
-  @EventHandler
-  public Counter handleSet(CounterEvent.ValueSet set) {
-    return currentState().onValueSet(set);
-  }
-
-  @EventHandler
-  public Counter handleMultiply(CounterEvent.ValueMultiplied multiplied) {
-    return currentState().onValueMultiplied(multiplied);
+  public Counter handle(CounterEvent counterEvent) {
+    return currentState().apply(counterEvent);
   }
 }

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/eventsourcedentities/counter/CounterEvent.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/eventsourcedentities/counter/CounterEvent.java
@@ -18,7 +18,7 @@ package com.example.wiring.eventsourcedentities.counter;
 
 import kalix.javasdk.annotations.TypeName;
 
-public interface CounterEvent {
+public sealed interface CounterEvent {
 
   @TypeName("increased")
   record ValueIncreased(int value) implements CounterEvent {

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/Validations.scala
@@ -18,11 +18,13 @@ package kalix.javasdk.impl
 
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
 
 import scala.reflect.ClassTag
 
 import kalix.javasdk.action.Action
+import kalix.javasdk.annotations.EventHandler
 import kalix.javasdk.annotations.Publish
 import kalix.javasdk.annotations.Query
 import kalix.javasdk.annotations.Subscribe
@@ -148,6 +150,39 @@ object Validations {
     validateEventSourcedEntity(component) ++
     validateWorkflow(component)
 
+  private def validateEventHandlers(entityClass: Class[_]): Validation = {
+
+    val annotatedHandlers = entityClass.getDeclaredMethods
+      .filter(_.getAnnotation(classOf[EventHandler]) != null)
+      .toList
+
+    val genericTypeArguments = entityClass.getGenericSuperclass
+      .asInstanceOf[ParameterizedType]
+      .getActualTypeArguments
+
+    // the state type parameter from the ES entity defines the return type of each event handler
+    val stateType = genericTypeArguments.head
+      .asInstanceOf[Class[_]]
+
+    val eventType = genericTypeArguments(1).asInstanceOf[Class[_]]
+
+    val (invalidHandlers, validSignatureHandlers) = annotatedHandlers.partition((m: Method) =>
+      m.getParameterCount != 1 || !Modifier.isPublic(m.getModifiers) || (stateType != m.getReturnType))
+
+    val signatureValidation = Validation(
+      invalidHandlers
+        .sortBy(_.getName) //for tests
+        .map(method =>
+          errorMessage(
+            entityClass,
+            s"event handler [${method.getName}] must be public, with exactly one parameter and return type '${stateType.getTypeName}'.")))
+
+    val missingHandlerInputParams = validSignatureHandlers.sortBy(_.getName).map(_.getParameterTypes.head)
+
+    signatureValidation ++ ambiguousHandlersErrors(validSignatureHandlers, entityClass) ++
+    missingEventHandler(missingHandlerInputParams, eventType, entityClass)
+  }
+
   private def validateCompoundIdsOrder(component: Class[_]): Validation = {
     val restService = RestServiceIntrospector.inspectService(component)
     component.getMethods.toIndexedSeq
@@ -187,7 +222,8 @@ object Validations {
 
   private def validateEventSourcedEntity(component: Class[_]): Validation = {
     when[EventSourcedEntity[_, _]](component) {
-      validateCompoundIdsOrder(component)
+      validateCompoundIdsOrder(component) ++
+      validateEventHandlers(component)
     }
   }
 
@@ -255,7 +291,7 @@ object Validations {
       hasStreamSubscription(component),
       hasTopicSubscription(component))
 
-    when(typeLevelSubs.filter(identity).size > 1) {
+    when(typeLevelSubs.count(identity) > 1) {
       Validation(errorMessage(component, "Only one subscription type is allowed on a type level."))
     }
   }
@@ -287,12 +323,9 @@ object Validations {
     val methods = component.getMethods.toIndexedSeq
 
     if (hasSubscription(component)) {
-      val effectMethodsByInputParams: Map[Option[Class[_]], IndexedSeq[Method]] = methods
+      val effectMethods = methods
         .filter(updateMethodPredicate)
-        .groupBy(_.getParameterTypes.lastOption)
-
-      Validation(ambiguousHandlersErrors(effectMethodsByInputParams, component))
-
+      ambiguousHandlersErrors(effectMethods, component)
     } else {
       val effectOutputMethodsGrouped = methods
         .filter(hasSubscription)
@@ -301,30 +334,40 @@ object Validations {
 
       effectOutputMethodsGrouped
         .map { case (_, methods) =>
-          val effectMethodsByInputParams: Map[Option[Class[_]], IndexedSeq[Method]] =
-            methods.groupBy(_.getParameterTypes.lastOption)
-          Validation(ambiguousHandlersErrors(effectMethodsByInputParams, component))
+          ambiguousHandlersErrors(methods, component)
         }
         .fold(Valid)(_ ++ _)
     }
 
   }
 
-  private def ambiguousHandlersErrors(
-      effectMethodsInputParams: Map[Option[Class[_]], IndexedSeq[Method]],
-      component: Class[_]) = {
-    val errors = effectMethodsInputParams
+  private def ambiguousHandlersErrors(handlers: Seq[Method], component: Class[_]): Validation = {
+    val ambiguousHandlers = handlers
+      .groupBy(_.getParameterTypes.lastOption)
       .filter(_._2.size > 1)
       .map {
         case (Some(inputType), methods) =>
-          errorMessage(
+          Validation(errorMessage(
             component,
-            s"Ambiguous handlers for ${inputType.getCanonicalName}, methods: [${methods.sorted.map(_.getName).mkString(", ")}] consume the same type.")
+            s"Ambiguous handlers for ${inputType.getCanonicalName}, methods: [${methods.sorted.map(_.getName).mkString(", ")}] consume the same type."))
         case (None, methods) => //only delete handlers
-          errorMessage(component, s"Ambiguous delete handlers: [${methods.sorted.map(_.getName).mkString(", ")}].")
+          Validation(
+            errorMessage(component, s"Ambiguous delete handlers: [${methods.sorted.map(_.getName).mkString(", ")}]."))
       }
-      .toSeq
-    errors
+
+    val sealedHandler = handlers.find(_.getParameterTypes.lastOption.exists(_.isSealed))
+    val sealedHandlerMixedUsage = if (sealedHandler.nonEmpty && handlers.size > 1) {
+      val unexpectedHandlerNames = handlers.filterNot(m => m == sealedHandler.get).map(_.getName)
+      Validation(
+        errorMessage(
+          component,
+          s"Event handler accepting a sealed interface [${sealedHandler.get.getName}] cannot be mixed with handlers for specific events. Please remove following handlers: [${unexpectedHandlerNames
+            .mkString(", ")}]."))
+    } else {
+      Valid
+    }
+
+    ambiguousHandlers.fold(sealedHandlerMixedUsage)(_ ++ _)
   }
 
   private def missingEventHandlerValidations(
@@ -339,7 +382,7 @@ object Validations {
           val effectMethodsInputParams: Seq[Class[_]] = methods
             .filter(updateMethodPredicate)
             .map(_.getParameterTypes.last) //last because it could be a view update methods with 2 params
-          Validation(missingErrors(effectMethodsInputParams, eventType, component))
+          missingEventHandler(effectMethodsInputParams, eventType, component)
         } else {
           Valid
         }
@@ -350,23 +393,38 @@ object Validations {
           .filter(updateMethodPredicate)
           .groupBy(findEventSourcedEntityClass)
 
-        val errors = effectOutputMethodsGrouped.flatMap { case (entityClass, methods) =>
-          val eventType = getEventType(entityClass)
-          if (eventType.isSealed) {
-            missingErrors(methods.map(_.getParameterTypes.last), eventType, component)
-          } else {
-            List.empty
+        effectOutputMethodsGrouped
+          .map { case (entityClass, methods) =>
+            val eventType = getEventType(entityClass)
+            if (eventType.isSealed) {
+              missingEventHandler(methods.map(_.getParameterTypes.last), eventType, component)
+            } else {
+              Valid
+            }
           }
-        }
-        Validation(errors.toSeq)
+          .fold(Valid)(_ ++ _)
     }
   }
 
-  private def missingErrors(effectOutputInputParams: Seq[Class[_]], eventType: Class[_], component: Class[_]) = {
-    eventType.getPermittedSubclasses
-      .filterNot(effectOutputInputParams.contains)
-      .map(clazz => s"Component '${component.getSimpleName}' is missing an event handler for '${clazz.getName}'")
-      .toList
+  private def missingEventHandler(
+      inputEventParams: Seq[Class[_]],
+      eventType: Class[_],
+      component: Class[_]): Validation = {
+    if (inputEventParams.exists(param => param.isSealed && param == eventType)) {
+      //single sealed interface handler
+      Valid
+    } else {
+      if (eventType.isSealed) {
+        //checking possible only for sealed interfaces
+        Validation(
+          eventType.getPermittedSubclasses
+            .filterNot(inputEventParams.contains)
+            .map(clazz => errorMessage(component, s"missing an event handler for '${clazz.getName}'."))
+            .toList)
+      } else {
+        Valid
+      }
+    }
   }
 
   private def topicSubscriptionValidations(component: Class[_]): Validation = {
@@ -662,7 +720,7 @@ object Validations {
           val numParams = method.getParameters.length
           errorMessage(
             method,
-            s"Method annotated with '@Subscribe.ValueEntity' and handleDeletes=true must not have parameters. Found ${numParams} method parameters.")
+            s"Method annotated with '@Subscribe.ValueEntity' and handleDeletes=true must not have parameters. Found $numParams method parameters.")
         }
 
       Validation(messages)

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedHandlersExtractor.scala
@@ -16,86 +16,33 @@
 
 package kalix.javasdk.impl.eventsourcedentity
 
-import java.lang.reflect.Method
-import java.lang.reflect.Modifier
-import java.lang.reflect.ParameterizedType
 import kalix.javasdk.annotations.EventHandler
-import kalix.javasdk.impl.MethodInvoker
 import kalix.javasdk.impl.JsonMessageCodec
+import kalix.javasdk.impl.MethodInvoker
 import kalix.javasdk.impl.reflection.ParameterExtractors
 
 object EventSourcedHandlersExtractor {
-  def handlersFrom(entityClass: Class[_], messageCodec: JsonMessageCodec): EventSourceEntityHandlers = {
+  def handlersFrom(entityClass: Class[_], messageCodec: JsonMessageCodec): Map[String, MethodInvoker] = {
 
     val annotatedHandlers = entityClass.getDeclaredMethods
       .filter(_.getAnnotation(classOf[EventHandler]) != null)
       .toList
 
-    val genericTypeArguments = entityClass.getGenericSuperclass
-      .asInstanceOf[ParameterizedType]
-      .getActualTypeArguments
-    // the type parameter from the entity defines the return type of each event handler
-    val returnType = genericTypeArguments.head
-      .asInstanceOf[Class[_]]
-
-    val eventType = genericTypeArguments(1).asInstanceOf[Class[_]]
-
-    val (invalidHandlers, validSignatureHandlers) = annotatedHandlers.partition((m: Method) =>
-      m.getParameterCount != 1 || !Modifier.isPublic(m.getModifiers) || (returnType != m.getReturnType))
-
-    def eventTypeExtractor: Method => Class[_] = (mt: Method) => mt.getParameterTypes.head
-    val eventTypeGrouped = validSignatureHandlers
-      .groupBy(eventTypeExtractor)
-
-    val (duplicatedEventTypes, validHandlers) = eventTypeGrouped.partition(_._2.length > 1)
-
-    val errorsForSignatures =
-      if (invalidHandlers.isEmpty) List.empty
-      else
-        List(
-          HandlerValidationError(
-            invalidHandlers,
-            "must be public, with exactly one parameter and return type '" + returnType.getTypeName + "'"))
-
-    val errorsForDuplicates =
-      for (elem <- duplicatedEventTypes)
-        yield HandlerValidationError(
-          elem._2,
-          "cannot have duplicate event handlers for the same event type: '" + elem._1.getName + "'")
-
-    val missingEventHandler =
-      if (eventType.isSealed) {
-        val missingHandlerClasses = eventType.getPermittedSubclasses
-          .filterNot(validHandlers.contains)
-          .toList
-        if (missingHandlerClasses.isEmpty) {
-          List.empty
-        } else {
-          List(HandlerValidationError(List.empty, "missing event handler", missingHandlerClasses))
-        }
-      } else {
-        List.empty
-      }
-
-    EventSourceEntityHandlers(
-      handlers = validHandlers.flatMap { case (classType, methods) =>
-        val invoker = MethodInvoker(methods.head, ParameterExtractors.AnyBodyExtractor[AnyRef](classType))
+    if (annotatedHandlers.size == 1 && annotatedHandlers.head.getParameterTypes.head.isSealed) {
+      val singleHandler = annotatedHandlers.head
+      val eventClass = singleHandler.getParameterTypes.head
+      eventClass.getPermittedSubclasses.toList.flatMap { subClass =>
+        val invoker = MethodInvoker(singleHandler, ParameterExtractors.AnyBodyExtractor[AnyRef](subClass))
         //in case of schema evolution more types can point to the same invoker
-        messageCodec.typeUrlsFor(classType).map(typeUrl => typeUrl -> invoker)
-      },
-      errors = errorsForSignatures ++ errorsForDuplicates.toList ++ missingEventHandler)
+        messageCodec.typeUrlsFor(subClass).map(typeUrl => typeUrl -> invoker)
+      }.toMap
+    } else {
+      annotatedHandlers.flatMap { method =>
+        val eventClass = method.getParameterTypes.head
+        val invoker = MethodInvoker(method, ParameterExtractors.AnyBodyExtractor[AnyRef](eventClass))
+        //in case of schema evolution more types can point to the same invoker
+        messageCodec.typeUrlsFor(eventClass).map(typeUrl => typeUrl -> invoker)
+      }.toMap
+    }
   }
-}
-
-private[kalix] final case class EventSourceEntityHandlers private (
-    handlers: Map[String, MethodInvoker],
-    errors: List[HandlerValidationError])
-
-private[kalix] final case class HandlerValidationError(
-    methods: List[Method],
-    description: String,
-    missingHandlersFor: List[Class[_]] = List.empty) {
-  override def toString: String =
-    s"ValidationError(reason='$description', offendingMethods=${methods.map(
-      _.getName)}, missingHandlersFor=${missingHandlersFor.map(_.getName)}"
 }

--- a/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
+++ b/sdk/java-sdk-spring/src/test/java/kalix/spring/testmodels/eventsourcedentity/EventSourcedEntitiesTestModels.java
@@ -258,6 +258,34 @@ public class EventSourcedEntitiesTestModels {
   }
 
   @Id("id")
+  @TypeId("employee")
+  @RequestMapping("/employee/{id}")
+  public static class EmployeeEntityWithMixedHandlers extends EventSourcedEntity<Employee, EmployeeEvent> {
+
+    @PostMapping
+    public Effect<String> createUser(@RequestBody CreateEmployee create) {
+      return effects()
+          .emitEvent(new EmployeeEvent.EmployeeCreated(create.firstName, create.lastName, create.email))
+          .thenReply(__ -> "ok");
+    }
+
+    @EventHandler
+    public Employee onEvent(EmployeeEvent event) {
+      if (event instanceof EmployeeEvent.EmployeeCreated) {
+        EmployeeEvent.EmployeeCreated created = (EmployeeEvent.EmployeeCreated) event;
+        return new Employee(created.firstName, created.lastName, created.email);
+      } else {
+        return currentState();
+      }
+    }
+
+    @EventHandler
+    public Employee onEmployeeCreated(EmployeeEvent.EmployeeCreated created) {
+      return new Employee(created.firstName, created.lastName, created.email);
+    }
+  }
+
+  @Id("id")
   @TypeId("counter")
   @Acl(allow = @Acl.Matcher(service = "test"))
   public static class EventSourcedEntityWithServiceLevelAcl extends EventSourcedEntity<Integer, Object> {

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ActionDescriptorFactorySpec.scala
@@ -760,15 +760,15 @@ class ActionDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSu
     "validates if there are missing event handlers for event sourced Entity Subscription at type level" in {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedEntityAction]).failIfInvalid
-      }.getMessage should include(
-        "Component 'MissingHandlersWhenSubscribeToEventSourcedEntityAction' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.subscriptions.PubSubTestModels$MissingHandlersWhenSubscribeToEventSourcedEntityAction': missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'."
     }
 
     "validates if there are missing event handlers for event sourced Entity Subscription at method level" in {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction]).failIfInvalid
-      }.getMessage should include(
-        "Component 'MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.subscriptions.PubSubTestModels$MissingHandlersWhenSubscribeToEventSourcedOnMethodLevelEntityAction': missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'."
     }
 
     "validates it is forbidden Topic Subscription at annotation type level and method level at the same time" in {

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/EventSourcedEntityDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/EventSourcedEntityDescriptorFactorySpec.scala
@@ -16,6 +16,8 @@
 
 package kalix.javasdk.impl
 
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import kalix.JwtMethodOptions.JwtMethodMode
 import kalix.JwtServiceOptions.JwtServiceMode
@@ -28,13 +30,15 @@ import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithMethodLevelJWT
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.CounterEventSourcedEntityWithServiceLevelJWT
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ESEntityCompoundIdIncorrectOrder
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EmployeeEntityWithMissingHandler
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EmployeeEntityWithMixedHandlers
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ErrorDuplicatedEventsEntity
+import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.ErrorWrongSignaturesEntity
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EventSourcedEntityWithMethodLevelAcl
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.EventSourcedEntityWithServiceLevelAcl
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.IllDefinedEntityWithIdGeneratorAndId
 import kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels.IllDefinedEntityWithoutIdGeneratorNorId
 import org.scalatest.wordspec.AnyWordSpec
-
-import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuite {
 
@@ -161,6 +165,35 @@ class EventSourcedEntityDescriptorFactorySpec extends AnyWordSpec with Component
         Validations.validate(classOf[ESEntityCompoundIdIncorrectOrder]).failIfInvalid
       }.getMessage should include(
         "Ids in the path '/{id2}/eventsourced/{id}/int/{number}' are in a different order than specified in the @Id annotation [id, id2]. This could lead to unexpected bugs when calling the component.")
+    }
+
+    "not allow handlers with duplicates signatures (receiving the same event type)" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[ErrorDuplicatedEventsEntity]).failIfInvalid
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels$ErrorDuplicatedEventsEntity': Ambiguous handlers for java.lang.Integer, methods: [receivedIntegerEvent, receivedIntegerEventDup] consume the same type."
+
+    }
+
+    "report error on missing event handler for sealed event interface" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[EmployeeEntityWithMissingHandler]).failIfInvalid
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels$EmployeeEntityWithMissingHandler': missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'."
+    }
+
+    "report error sealed interface event handler is mixed with specific event handlers" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[EmployeeEntityWithMixedHandlers]).failIfInvalid
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels$EmployeeEntityWithMixedHandlers': Event handler accepting a sealed interface [onEvent] cannot be mixed with handlers for specific events. Please remove following handlers: [onEmployeeCreated]."
+    }
+
+    "report error on annotated handlers with wrong return type or number of params" in {
+      intercept[InvalidComponentException] {
+        Validations.validate(classOf[ErrorWrongSignaturesEntity]).failIfInvalid
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels$ErrorWrongSignaturesEntity': event handler [receivedIntegerEvent] must be public, with exactly one parameter and return type 'java.lang.Integer'., On 'kalix.spring.testmodels.eventsourcedentity.EventSourcedEntitiesTestModels$ErrorWrongSignaturesEntity': event handler [receivedIntegerEventAndString] must be public, with exactly one parameter and return type 'java.lang.Integer'."
     }
   }
 

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ViewDescriptorFactorySpec.scala
@@ -552,15 +552,15 @@ class ViewDescriptorFactorySpec extends AnyWordSpec with ComponentDescriptorSuit
     "validate missing handlers for method level subscription" in {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[SubscribeToEventSourcedWithMissingHandlerState]).failIfInvalid
-      }.getMessage should include(
-        "Component 'SubscribeToEventSourcedWithMissingHandlerState' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.view.ViewTestModels$SubscribeToEventSourcedWithMissingHandlerState': missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'."
     }
 
     "validate missing handlers for type level subscription" in {
       intercept[InvalidComponentException] {
         Validations.validate(classOf[TypeLevelSubscribeToEventSourcedEventsWithState]).failIfInvalid
-      }.getMessage should include(
-        "Component 'TypeLevelSubscribeToEventSourcedEventsWithState' is missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'")
+      }.getMessage shouldBe
+      "On 'kalix.spring.testmodels.view.ViewTestModels$TypeLevelSubscribeToEventSourcedEventsWithState': missing an event handler for 'kalix.spring.testmodels.eventsourcedentity.EmployeeEvent$EmployeeEmailUpdated'."
     }
 
     "not allow duplicated ES subscriptions methods" in {


### PR DESCRIPTION
My main motivation is that we want to migrate java sdk sample to Java 21, where we can fully embrace a sealed interface pattern-matching. Although is only about ES entity event handlers, we should promote this approach not only for ES but also for Views or any subscription that consumes all events because then the compiler will check if all cases are handled.