### PR TITLE
chore: Create a sample with extra docker containers (Tempo and Jaeger UI) to store (and show) traces.

### DIFF
--- a/samples/java-spring-view-store/README.md
+++ b/samples/java-spring-view-store/README.md
@@ -14,6 +14,11 @@ mvn kalix:runAll
 
 This command will start your Kalix service and a companion Kalix Runtime as configured in [docker-compose.yml](./docker-compose.yml) file.
 
+To start your service locally with tracing, run:
+```shell
+mvn kalix:runAll -Dkalix.telemetry.tracing.collector-endpoint="http://localhost:4317"
+```
+
 ## Exercising the services
 
 With both the Kalix Runtime and your service running, once you have defined endpoints they should be available at `http://localhost:9000`.

--- a/samples/java-spring-view-store/docker-compose.yml
+++ b/samples/java-spring-view-store/docker-compose.yml
@@ -31,8 +31,9 @@ services:
       - ./tempo-config/tempo.yaml:/etc/tempo.yaml
       - ./tempo-data/:/tmp/tempo
     ports:
-      - "14268"  # jaeger ingest
-      - "3200"   # tempo
+      - "14268:14268"  # jaeger ingest
+      - "3200:3200"   # tempo
+      - "4317:4317" 
 
   tempo-query:
     image: grafana/tempo-query:latest

--- a/samples/java-spring-view-store/docker-compose.yml
+++ b/samples/java-spring-view-store/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.27
+    image: gcr.io/kalix-public/kalix-runtime:1.1.29
     container_name: java-spring-view-store
     ports:
       - "9000:9000"
@@ -12,8 +12,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       JAVA_TOOL_OPTIONS: >
-      # jvm -D properties can be added under this environment map (note: remove this comment when adding properties)
-
+        -Dkalix.proxy.telemetry.tracing.enabled=true
+        -Dkalix.proxy.telemetry.tracing.collector-endpoint=http://tempo:4317
       USER_SERVICE_HOST: ${USER_SERVICE_HOST:-host.docker.internal}
       USER_SERVICE_PORT: ${USER_SERVICE_PORT:-8080}
       # Enable advanced view features locally (note: disabled in deployed services by default)
@@ -24,3 +24,22 @@ services:
   #  command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085
   #  ports:
   #    - 8085:8085
+  tempo:
+    image: grafana/tempo:latest
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./tempo-config/tempo.yaml:/etc/tempo.yaml
+      - ./tempo-data/:/tmp/tempo
+    ports:
+      - "14268"  # jaeger ingest
+      - "3200"   # tempo
+
+  tempo-query:
+    image: grafana/tempo-query:latest
+    command: [ "--grpc-storage-plugin.configuration-file=/etc/tempo-query.yaml" ]
+    volumes:
+      - ./tempo-config/tempo-query.yaml:/etc/tempo-query.yaml
+    ports:
+      - "16686:16686"  # jaeger-ui
+    depends_on:
+      - tempo

--- a/samples/java-spring-view-store/tempo-config/tempo-query.yaml
+++ b/samples/java-spring-view-store/tempo-config/tempo-query.yaml
@@ -1,0 +1,1 @@
+backend: "tempo:3200"

--- a/samples/java-spring-view-store/tempo-config/tempo.yaml
+++ b/samples/java-spring-view-store/tempo-config/tempo.yaml
@@ -1,0 +1,55 @@
+server:
+  http_listen_port: 3200
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /tmp/tempo/generator/wal
+    # remote_write:
+    #   - url: http://prometheus:9090/api/v1/write
+    #     send_exemplars: true
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+    local:
+      path: /tmp/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics] # enables metrics generator


### PR DESCRIPTION
References https://github.com/lightbend/kalix/issues/10288

