### PR TITLE
ci: pin version of vale to 2.30.0

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,6 +48,7 @@ jobs:
         # v2.0.1
         uses: errata-ai/vale-action@c4213d4de3d5f718b8497bd86161531c78992084
         with:
+          version: 2.30.0
           files: docs
           fail_on_error: true
           filter_mode: nofilter


### PR DESCRIPTION
Failures in CI due to non-backwards compatible change in `3.0.0` and us using latest by default.