### PR TITLE
ci: mark changes to samples as docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,21 +8,19 @@ java-sdk-protobuf:
   - sdk/java-sdk-protobuf-testkit/**/*
   - maven-java/**/*
   - codegen/java-gen/**/*
-  - samples/java-protobuf-*/**/*
 
 scala-sdk-protobuf:
   - sdk/scala-sdk-protobuf/**/*
   - sdk/scala-sdk-protobuf-testkit/**/*
   - sbt-plugin/**/*
   - codegen/scala-gen/**/*
-  - samples/scala-protobuf-*/**/*
 
 java-sdk:
   - sdk/java-sdk-spring/**/*
   - sdk/java-sdk-spring-testkit/**/*
   - sdk/spring-boot-starter/**/*
   - sdk/spring-boot-starter-test/**/*
-  - samples/java-spring-*/**/*
 
 Documentation:
   - docs/**/*
+  - samples/**/*


### PR DESCRIPTION
Our automatic release notes are a bit confusing at the moment (see below)... mostly, I think this is due to the fact that all changes to samples go under a specific sdk section. I think marking sample changes as documentation changes will help in this regard. (maybe it was like this previously actually)

<img width="748" alt="Screenshot 2024-01-10 at 14 31 53" src="https://github.com/lightbend/kalix-jvm-sdk/assets/1105359/7a620541-fb70-4d8f-b4e0-846cdb6a4c16">
