### PR TITLE
chore: update docs links on errors

### DIFF
--- a/docs/src/modules/java-protobuf/pages/publishing-subscribing.adoc
+++ b/docs/src/modules/java-protobuf/pages/publishing-subscribing.adoc
@@ -2,7 +2,7 @@ include::ROOT:partial$include.adoc[]
 
 = Publishing and Subscribing
 :page-supergroup-java-scala: Language
-:page-aliases: java-protobuf:service-to-service.adoc, java-protobuf:serialization.adoc
+:page-aliases: java-protobuf:service-to-service.adoc, java-protobuf:serialization.adoc, java-protobuf:actions-publishing-subscribing.adoc
 
 
 A very common use case when building Microservices is to publish and subscribe to a stream of events. The source of events can be the journal of an event sourced entity, the value entity state changes, a https://cloud.google.com/pubsub/docs/overview[Google Cloud Pub/Sub] or Apache Kafka topic for asynchronous messaging between services.

--- a/docs/src/modules/java/pages/publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/publishing-subscribing.adoc
@@ -1,5 +1,5 @@
 = Publishing and Subscribing
-:page-aliases: spring:actions-publishing-subscribing.adoc, spring:service-to-service.adoc, java:service-to-service.adoc
+:page-aliases: spring:actions-publishing-subscribing.adoc, spring:service-to-service.adoc, java:service-to-service.adoc, java:actions-publishing-subscribing.adoc
 
 include::ROOT:partial$include.adoc[]
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
@@ -196,7 +196,7 @@ class DiscoveryImpl(
     val severityString = in.severity.name.take(1) + in.severity.name.drop(1).toLowerCase
     val message = s"$severityString reported from Kalix system: ${in.code} ${in.message}"
     val detail = if (in.detail.isEmpty) Nil else List(in.detail)
-    val seeDocs = DocLinks.forErrorCode(in.code).map(link => s"See documentation: $link").toList
+    val seeDocs = DocLinks(sdkName).forErrorCode(in.code).map(link => s"See documentation: $link").toList
     val messages = message :: detail ::: seeDocs ::: sourceMsgs
     val logMessage = messages.mkString("\n\n")
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DocLinks.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DocLinks.scala
@@ -16,34 +16,37 @@
 
 package kalix.javasdk.impl
 
-object DocLinks {
-
+case class DocLinks(sdkName: String) {
   private val baseUrl = "https://docs.kalix.io"
 
-  private val errorCodes = Map(
-    "KLX-00112" -> s"$baseUrl/java/views.html#changing",
-    "KLX-00402" -> s"$baseUrl/java/topic-eventing.html",
-    "KLX-00406" -> s"$baseUrl/java/topic-eventing.html",
-    "KLX-00414" -> s"$baseUrl/java/entity-eventing.html"
-    // TODO: docs for value entity eventing (https://github.com/lightbend/kalix-jvm-sdk/issues/121)
-    // "KLX-00415" -> s"$baseUrl/java/entity-eventing.html"
+  // sdkName is of format e.g. kalix-java-sdk-protobuf
+  private val sdkPath = if (sdkName.endsWith("-protobuf")) "java-protobuf" else "java"
+
+  val errorCodes = Map(
+    "KLX-00112" -> "views.html#changing",
+    "KLX-00415" -> "publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity"
   )
 
   // fallback if not defined in errorCodes
-  private val errorCodeCategories = Map(
-    "KLX-001" -> s"$baseUrl/java/views.html",
-    "KLX-002" -> s"$baseUrl/java/value-entity.html",
-    "KLX-003" -> s"$baseUrl/java/eventsourced.html",
-    "KLX-004" -> s"$baseUrl/java/", // no single page for eventing
-    "KLX-005" -> s"$baseUrl/java/", // no docs yet for replicated entities
-    "KLX-006" -> s"$baseUrl/java/proto.html#_transcoding_http", // all HTTP API errors
-    "KLX-007" -> s"$baseUrl/services/using-jwts.html",
-    "KLX-008" -> s"$baseUrl/java/timers.html")
+  val errorCodeCategories = Map(
+    "KLX-001" -> "views.html",
+    "KLX-002" -> "value-entity.html",
+    "KLX-003" -> "event-sourced-entities.html",
+    "KLX-004" -> "publishing-subscribing.html",
+    "KLX-005" -> "replicated-entity-crdt.html", // only pb sdks
+    "KLX-006" -> "writing-grpc-descriptors-protobuf.html#_transcoding_http", // only pb sdks
+    "KLX-007" -> "using-jwts.html",
+    "KLX-008" -> "timers.html",
+    "KLX-009" -> "access-control.html",
+    "KLX-010" -> "workflows.html", // only java sdk currently
+    "KLX-011" -> "actions.html#_actions_as_life_cycle_hooks",
+  )
 
-  def forErrorCode(code: String): Option[String] =
-    errorCodes.get(code) match {
+  def forErrorCode(code: String): Option[String] = {
+    val page = errorCodes.get(code) match {
       case s @ Some(_) => s
-      case None        => errorCodeCategories.get(code.take(6))
+      case None        => errorCodeCategories.get(code.take(7))
     }
-
+    page.map(p => s"$baseUrl/$sdkPath/$p")
+  }
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DocLinks.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DocLinks.scala
@@ -24,8 +24,7 @@ case class DocLinks(sdkName: String) {
 
   val errorCodes = Map(
     "KLX-00112" -> "views.html#changing",
-    "KLX-00415" -> "publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity"
-  )
+    "KLX-00415" -> "publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
 
   // fallback if not defined in errorCodes
   val errorCodeCategories = Map(
@@ -39,8 +38,7 @@ case class DocLinks(sdkName: String) {
     "KLX-008" -> "timers.html",
     "KLX-009" -> "access-control.html",
     "KLX-010" -> "workflows.html", // only java sdk currently
-    "KLX-011" -> "actions.html#_actions_as_life_cycle_hooks",
-  )
+    "KLX-011" -> "actions.html#_actions_as_life_cycle_hooks")
 
   def forErrorCode(code: String): Option[String] = {
     val page = errorCodes.get(code) match {

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/DocLinksSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/DocLinksSpec.scala
@@ -1,0 +1,40 @@
+package kalix.javasdk.impl
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+
+class DocLinksSpec extends AnyWordSpec with Matchers {
+
+  "DocLinks" should {
+
+    "specific error codes should be mapped to sdk specific urls" in {
+      val javaPbDocLinks = new DocLinks("kalix-java-sdk-protobuf")
+      javaPbDocLinks.forErrorCode("KLX-00112") shouldBe Some("https://docs.kalix.io/java-protobuf/views.html#changing")
+      javaPbDocLinks.forErrorCode("KLX-00402") shouldBe Some("https://docs.kalix.io/java-protobuf/publishing-subscribing.html")
+      javaPbDocLinks.forErrorCode("KLX-00415") shouldBe Some("https://docs.kalix.io/java-protobuf/publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
+
+      val javaDocLinks = new DocLinks("kalix-java-sdk-spring")
+      javaDocLinks.forErrorCode("KLX-00112") shouldBe Some("https://docs.kalix.io/java/views.html#changing")
+      javaDocLinks.forErrorCode("KLX-00402") shouldBe Some("https://docs.kalix.io/java/publishing-subscribing.html")
+      javaDocLinks.forErrorCode("KLX-00415") shouldBe Some("https://docs.kalix.io/java/publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
+    }
+
+    "fallback to general codes when no code matches" in {
+      val javaDocLinks = new DocLinks("kalix-java-sdk-spring")
+
+      javaDocLinks.forErrorCode("KLX-00100") shouldBe Some("https://docs.kalix.io/java/views.html")
+      javaDocLinks.forErrorCode("KLX-00200") shouldBe Some("https://docs.kalix.io/java/value-entity.html")
+    }
+
+  }
+}

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/DocLinksSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/DocLinksSpec.scala
@@ -1,17 +1,23 @@
+/*
+ * Copyright 2024 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kalix.javasdk.impl
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.StatusCodes
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatest.wordspec.AnyWordSpec
-
-import scala.concurrent.Await
-import scala.concurrent.Future
 
 class DocLinksSpec extends AnyWordSpec with Matchers {
 
@@ -20,13 +26,16 @@ class DocLinksSpec extends AnyWordSpec with Matchers {
     "specific error codes should be mapped to sdk specific urls" in {
       val javaPbDocLinks = new DocLinks("kalix-java-sdk-protobuf")
       javaPbDocLinks.forErrorCode("KLX-00112") shouldBe Some("https://docs.kalix.io/java-protobuf/views.html#changing")
-      javaPbDocLinks.forErrorCode("KLX-00402") shouldBe Some("https://docs.kalix.io/java-protobuf/publishing-subscribing.html")
-      javaPbDocLinks.forErrorCode("KLX-00415") shouldBe Some("https://docs.kalix.io/java-protobuf/publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
+      javaPbDocLinks.forErrorCode("KLX-00402") shouldBe Some(
+        "https://docs.kalix.io/java-protobuf/publishing-subscribing.html")
+      javaPbDocLinks.forErrorCode("KLX-00415") shouldBe Some(
+        "https://docs.kalix.io/java-protobuf/publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
 
       val javaDocLinks = new DocLinks("kalix-java-sdk-spring")
       javaDocLinks.forErrorCode("KLX-00112") shouldBe Some("https://docs.kalix.io/java/views.html#changing")
       javaDocLinks.forErrorCode("KLX-00402") shouldBe Some("https://docs.kalix.io/java/publishing-subscribing.html")
-      javaDocLinks.forErrorCode("KLX-00415") shouldBe Some("https://docs.kalix.io/java/publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
+      javaDocLinks.forErrorCode("KLX-00415") shouldBe Some(
+        "https://docs.kalix.io/java/publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
     }
 
     "fallback to general codes when no code matches" in {


### PR DESCRIPTION
Close https://github.com/lightbend/kalix-jvm-sdk/issues/1907
Close https://github.com/lightbend/kalix-jvm-sdk/issues/1313

This PR:
- updates lists for error code and categories with updated doc links
- introduces different URLs depending on which sdk is in use
