### PR TITLE
docs: fix deadlinks after setting-up page removal

### DIFF
--- a/docs/src/modules/developing/pages/development-process-proto.adoc
+++ b/docs/src/modules/developing/pages/development-process-proto.adoc
@@ -71,10 +71,9 @@ It is good practice to write unit tests as you implement your services. The kick
 [#_package_service]
 == Package service
 
-Use Docker to package your service and any of its dependencies. See the following pages for more information:
+Use Docker to package your service and any of its dependencies.
+See https://docs.kalix.io/projects/container-registries.html[Configuring registries] for more information.
 
-* https://docs.kalix.io/setting-up/#_containers[Setting up containers]
-* https://docs.kalix.io/projects/container-registries.html[Configuring registries]
 
 [#_run_locally]
 == Run locally

--- a/docs/src/modules/java-protobuf/pages/quickstart-template.adoc
+++ b/docs/src/modules/java-protobuf/pages/quickstart-template.adoc
@@ -26,7 +26,7 @@ Before running the code generation tools, make sure you have the following:
 
 To deploy the Kalix service, you need:
 
-* A https://docs.kalix.io/setting-up/index.html#_kalix_account[Kalix account]
+* A https://console.kalix.io[Kalix account]
 * A https://docs.kalix.io/projects/create-project.html[Kalix project]
 * The https://docs.kalix.io/kalix/install-kalix.html[Kalix CLI (kalix)]
 * A configured registry in which to publish the service container image. Refer to https://docs.kalix.io/projects/container-registries.html[Configuring registries] for more information on how to make your Docker registry available to Kalix.

--- a/docs/src/modules/java/pages/development-process.adoc
+++ b/docs/src/modules/java/pages/development-process.adoc
@@ -77,10 +77,8 @@ integration tests. Please consult the component specific pages to learn more abo
 [#_package_service]
 == Package service
 
-Use Docker to package your service and any of its dependencies. See the following pages for more information:
-
-* https://docs.kalix.io/setting-up/#_containers[Setting up containers]
-* https://docs.kalix.io/projects/container-registries.html[Configuring registries]
+Use Docker to package your service and any of its dependencies.
+See https://docs.kalix.io/projects/container-registries.html[Configuring registries] for more information.
 
 [#_run_locally]
 == Run locally

--- a/docs/src/modules/java/pages/getting-started.adoc
+++ b/docs/src/modules/java/pages/getting-started.adoc
@@ -22,7 +22,7 @@ Before you start, make sure you have the following:
 
 To deploy the Kalix service, you need:
 
-* A https://docs.kalix.io/setting-up/index.html#_kalix_account[Kalix account]
+* A https://console.kalix.io[Kalix account]
 * A https://docs.kalix.io/projects/create-project.html[Kalix project]
 * The https://docs.kalix.io/kalix/install-kalix.html[Kalix CLI (kalix)]
 * A configured registry in which to publish the service container image. Refer to https://docs.kalix.io/projects/container-registries.html[Configuring registries] for more information on how to make your Docker registry available to Kalix.

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -62,7 +62,7 @@ ERROR:
 ## Deploying
 ]]#
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
@@ -62,7 +62,7 @@ ERROR:
 ## Deploying
 ]]#
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-archetype/src/main/resources/archetype-resources/README.md
@@ -33,7 +33,7 @@ With both the Kalix Runtime and your service running, once you have defined endp
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/src/main/resources/archetype-resources/README.md
@@ -33,7 +33,7 @@ With both the Kalix Runtime and your service running, once you have defined endp
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/README.md
@@ -80,7 +80,7 @@ grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-customer-registry-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-quickstart/README.md
@@ -62,7 +62,7 @@ grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-customer-registry-views-quickstart/README.md
+++ b/samples/java-protobuf-customer-registry-views-quickstart/README.md
@@ -72,7 +72,7 @@ grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-eventsourced-counter/README.md
+++ b/samples/java-protobuf-eventsourced-counter/README.md
@@ -48,7 +48,7 @@ grpcurl -plaintext -d '{"counterId": "foo"}' localhost:9000 com.example.CounterS
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/java-protobuf-eventsourced-shopping-cart/README.md
@@ -73,7 +73,7 @@ mvn verify -Pit
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-fibonacci-action/README.md
+++ b/samples/java-protobuf-fibonacci-action/README.md
@@ -51,7 +51,7 @@ grpcurl -plaintext -d '{"value": 5 }' localhost:9000 com.example.fibonacci.Fibon
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-first-service/README.md
+++ b/samples/java-protobuf-first-service/README.md
@@ -53,7 +53,7 @@ ERROR:
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-reliable-timers/README.md
+++ b/samples/java-protobuf-reliable-timers/README.md
@@ -72,7 +72,7 @@ grpcurl -plaintext -d '{ "number" : "returned-order-number" }' localhost:9000 co
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/README.md
@@ -71,9 +71,9 @@ mvn verify -Pit
 
 ## Deploying
 
-To deploy your service, install the `kalix` CLI as documented in [Setting up a local development
-environment](https://docs.kalix.io/setting-up/) and
-configure a Docker Registry to upload your docker image to.
+To deploy your service, install the `kalix` CLI as documented in
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
+and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to [Configuring
 registries](https://docs.kalix.io/projects/container-registries.html) for more information on how

--- a/samples/java-protobuf-shopping-cart-quickstart/README.md
+++ b/samples/java-protobuf-shopping-cart-quickstart/README.md
@@ -65,7 +65,7 @@ curl -XPOST -H "Content-Type: application/json" localhost:9000/cart/cart1/items/
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-valueentity-counter/README.md
+++ b/samples/java-protobuf-valueentity-counter/README.md
@@ -64,7 +64,7 @@ grpcurl -plaintext -d '{"counterId": "foo"}' localhost:9000 com.example.CounterS
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/java-protobuf-valueentity-shopping-cart/README.md
@@ -79,7 +79,7 @@ mvn verify -Pit
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-view-store/README.md
+++ b/samples/java-protobuf-view-store/README.md
@@ -140,7 +140,7 @@ grpcurl -d '{"customerId": "C001"}' \
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-protobuf-web-resources/README.md
+++ b/samples/java-protobuf-web-resources/README.md
@@ -37,7 +37,7 @@ With both the Kalix Runtime and your service running, any defined endpoints shou
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-choreography-saga-quickstart/README.md
+++ b/samples/java-spring-choreography-saga-quickstart/README.md
@@ -177,7 +177,7 @@ The status of the email will be CONFIRMED or NOT_USED, depending on whether the 
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-customer-registry-quickstart/README.md
+++ b/samples/java-spring-customer-registry-quickstart/README.md
@@ -79,7 +79,7 @@ curl localhost:9000/customer/one/changeAddress \
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-customer-registry-views-quickstart/README.md
+++ b/samples/java-spring-customer-registry-views-quickstart/README.md
@@ -81,7 +81,7 @@ curl localhost:9000/customer/one/changeAddress \
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-eventsourced-counter/README.md
+++ b/samples/java-spring-eventsourced-counter/README.md
@@ -57,7 +57,7 @@ curl -XPOST localhost:9000/counter/hello/multiply/5
 ### Deploy
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-eventsourced-customer-registry/README.md
+++ b/samples/java-spring-eventsourced-customer-registry/README.md
@@ -79,7 +79,7 @@ curl localhost:9000/customer/one/changeAddress \
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-eventsourced-shopping-cart/README.md
+++ b/samples/java-spring-eventsourced-shopping-cart/README.md
@@ -56,7 +56,7 @@ curl -XPOST -H "Content-Type: application/json" localhost:9000/cart/123/items/ka
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-fibonacci-action/README.md
+++ b/samples/java-spring-fibonacci-action/README.md
@@ -49,7 +49,7 @@ curl -XPOST -H "Content-Type: application/json" localhost:9000/fibonacci/next -d
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-reliable-timers/README.md
+++ b/samples/java-spring-reliable-timers/README.md
@@ -47,7 +47,7 @@ curl -XPOST -H "Content-Type: application/json" localhost:9000/orders/cancel/{re
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-shopping-cart-quickstart/README.md
+++ b/samples/java-spring-shopping-cart-quickstart/README.md
@@ -61,7 +61,7 @@ curl -XPOST localhost:9000/cart/123/checkout
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-transfer-workflow-compensation/README.md
+++ b/samples/java-spring-transfer-workflow-compensation/README.md
@@ -89,7 +89,7 @@ mvn verify -Pit
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-transfer-workflow/README.md
+++ b/samples/java-spring-transfer-workflow/README.md
@@ -89,7 +89,7 @@ mvn verify -Pit
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-valueentity-counter/README.md
+++ b/samples/java-spring-valueentity-counter/README.md
@@ -45,7 +45,7 @@ curl localhost:9000/counter/foo
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-valueentity-customer-registry/README.md
+++ b/samples/java-spring-valueentity-customer-registry/README.md
@@ -64,7 +64,7 @@ curl localhost:9000/summary/by_name/Test%20Testsson
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-valueentity-shopping-cart/README.md
+++ b/samples/java-spring-valueentity-shopping-cart/README.md
@@ -62,7 +62,7 @@ curl -XDELETE -H "UserRole: Admin" localhost:9000/carts/cart1
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/java-spring-view-store/README.md
+++ b/samples/java-spring-view-store/README.md
@@ -116,7 +116,7 @@ curl localhost:9000/structured-customer-orders/C001
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to

--- a/samples/scala-protobuf-customer-registry-quickstart/README.md
+++ b/samples/scala-protobuf-customer-registry-quickstart/README.md
@@ -69,7 +69,7 @@ grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-eventsourced-counter/README.md
+++ b/samples/scala-protobuf-eventsourced-counter/README.md
@@ -39,7 +39,7 @@ grpcurl -plaintext -d '{"counterId": "foo"}' localhost:9000 com.example.CounterS
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-eventsourced-customer-registry/README.md
+++ b/samples/scala-protobuf-eventsourced-customer-registry/README.md
@@ -84,7 +84,7 @@ grpcurl --plaintext -d '{"city":"Stockholm"}' localhost:9000 customer.view.Custo
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-eventsourced-shopping-cart/README.md
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/README.md
@@ -67,7 +67,7 @@ grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "kalix-tshirt" }' loc
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-fibonacci-action/README.md
+++ b/samples/scala-protobuf-fibonacci-action/README.md
@@ -39,7 +39,7 @@ grpcurl -plaintext -d '{"value": 5 }' localhost:9000 com.example.fibonacci.Fibon
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-first-service/README.md
+++ b/samples/scala-protobuf-first-service/README.md
@@ -57,7 +57,7 @@ ERROR:
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set your `docker.username` as a system property:

--- a/samples/scala-protobuf-reliable-timers/README.md
+++ b/samples/scala-protobuf-reliable-timers/README.md
@@ -47,7 +47,7 @@ grpcurl -plaintext -d '{ "number" : "returned-order-number" }' localhost:9000 co
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/README.md
@@ -68,7 +68,7 @@ grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "kalix-tshirt", "name
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set your `docker.username` as a system property:

--- a/samples/scala-protobuf-valueentity-counter/README.md
+++ b/samples/scala-protobuf-valueentity-counter/README.md
@@ -39,7 +39,7 @@ grpcurl -plaintext -d '{"counterId": "foo"}' localhost:9000 com.example.CounterS
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-valueentity-customer-registry/README.md
+++ b/samples/scala-protobuf-valueentity-customer-registry/README.md
@@ -59,7 +59,7 @@ grpcurl --plaintext -d '{"customer_id": "wip", "new_address": {"street": "Street
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.

--- a/samples/scala-protobuf-valueentity-shopping-cart/README.md
+++ b/samples/scala-protobuf-valueentity-shopping-cart/README.md
@@ -74,7 +74,7 @@ grpcurl --plaintext -d '{"cart_id": "cart1"}' -H 'UserRole: Admin' localhost:900
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set your `docker.username` as a system property:

--- a/samples/scala-protobuf-view-store/README.md
+++ b/samples/scala-protobuf-view-store/README.md
@@ -142,8 +142,8 @@ grpcurl -d '{"customerId": "C001"}' \
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
-and configure a Docker Registry to upload your Docker image to.
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
+and configure a Docker Registry to upload your docker image to.
 
 You will need to set your `docker.username` as a system property:
 

--- a/samples/scala-protobuf-web-resources/README.md
+++ b/samples/scala-protobuf-web-resources/README.md
@@ -33,7 +33,7 @@ With both the Kalix Runtime and your service running, any defined endpoints shou
 ## Deploying
 
 To deploy your service, install the `kalix` CLI as documented in
-[Setting up a local development environment](https://docs.kalix.io/setting-up/)
+[Instal Kalix](https://docs.kalix.io/kalix/install-kalix.html)
 and configure a Docker Registry to upload your docker image to.
 
 You will need to set the `docker.username` system property when starting sbt to be able to publish the image, for example `sbt -Ddocker.username=myuser Docker/publish`.


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-docs/pull/2018

With the above change, there is not a direct replacement page for the setting-up page, so we need to send for more specific pages. I think the replacements here make the most sense, maybe even better than before.