### PR TITLE
fix(java-sdk): enforce entity id presence on http calls

### DIFF
--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/SpringSdkIntegrationTest.java
@@ -108,6 +108,38 @@ public class SpringSdkIntegrationTest {
   }
 
   @Test
+  public void acceptRequestWithMissingPathParamIfNotEntityId() {
+
+    ResponseEntity<String> response =
+        webClient
+            .get()
+            .uri("/echo/message/") // missing param
+            .retrieve()
+            .toEntity(String.class)
+            .onErrorResume(WebClientResponseException.class, error -> Mono.just(ResponseEntity.status(error.getStatusCode()).body(error.getResponseBodyAsString())))
+            .block(timeout);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void failRequestWithMissingRequiredIntPathParam() {
+
+    ResponseEntity<String> response =
+        webClient
+            .get()
+            .uri("/echo/int/") // missing param
+            .retrieve()
+            .toEntity(String.class)
+            .onErrorResume(WebClientResponseException.class, error -> Mono.just(ResponseEntity.status(error.getStatusCode()).body(error.getResponseBodyAsString())))
+            .block(timeout);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).isEqualTo("Path contains value of wrong type! Expected field of type INT32.");
+  }
+
+
+  @Test
   public void verifyRequestWithOptionalQueryParams() {
 
     Message response =
@@ -399,6 +431,22 @@ public class SpringSdkIntegrationTest {
             .collect(Collectors.toList())
             .size(),
         new IsEqual<>(2));
+  }
+
+  @Test
+  public void failRequestWithMissingEntityId() {
+
+    ResponseEntity<String> response =
+        webClient
+            .get()
+            .uri("/user/") // missing id path param
+            .retrieve()
+            .toEntity(String.class)
+            .onErrorResume(WebClientResponseException.class, error -> Mono.just(ResponseEntity.status(error.getStatusCode()).body(error.getResponseBodyAsString())))
+            .block(timeout);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).isEqualTo("INVALID_ARGUMENT: Entity key field(s) List(id) must not be empty.");
   }
 
   @Test

--- a/sdk/java-sdk-spring/src/it/java/com/example/wiring/actions/echo/EchoAction.java
+++ b/sdk/java-sdk-spring/src/it/java/com/example/wiring/actions/echo/EchoAction.java
@@ -56,6 +56,13 @@ public class EchoAction extends Action {
     return effects().reply(new Message(response));
   }
 
+  @GetMapping("/echo/int/{int_value}")
+  public Effect<Message> intMessage(@PathVariable("int_value") Integer i) {
+    String response = this.parrot.repeat(i+"");
+    return effects().reply(new Message(response));
+  }
+
+
   @GetMapping("/echo/message")
   public Effect<Message> stringMessageFromParam(@RequestParam String msg) {
     return stringMessage(msg);


### PR DESCRIPTION
Fix https://github.com/lightbend/kalix-runtime/issues/1848

With this PR:

- Instead of this (timeout + 500):
```shell
➜ curl -i -XGET -H "Content-Type: application/json" localhost:9000/cart/
HTTP/1.1 500 Internal Server Error
Access-Control-Allow-Origin: *
Server: akka-http/10.6.0
Date: Tue, 16 Jan 2024 16:29:27 GMT
Content-Length: 0
```

- We get:
```shell
➜ curl -i -XGET -H "Content-Type: application/json" localhost:9000/cart/
HTTP/1.1 400 Bad Request
Access-Control-Allow-Origin: *
Server: akka-http/10.6.0
Date: Tue, 16 Jan 2024 16:28:37 GMT
Content-Type: text/plain; charset=UTF-8
Content-Length: 69

INVALID_ARGUMENT: Entity key field(s) List(cartId) must not be empty.% 
```

Note that, this does NOT change current behavior where for non-entity id fields, one is able to do calls without providing all path variables. E.g for path defined as `"cart/{cart_id}/str/{msg}"`:

```
➜ curl -i -XGET -H "Content-Type: application/json" localhost:9000/cart/cart1/str/
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Server: akka-http/10.6.0
Date: Tue, 16 Jan 2024 16:32:32 GMT
Content-Type: application/json
Content-Length: 2

""%
```

This means `{msg}` is considered to be `""`.
