### PR TITLE
fix: reverting maven-surefire-plugin and maven-failsafe-plugin versions bump

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -205,7 +205,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -255,7 +255,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -205,7 +205,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>2.22.2</version>
         <configuration>
           <excludes>
             <!-- ignore integration test classes -->
@@ -255,7 +255,7 @@
             <!-- run *IntegrationTest with failsafe -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>2.22.2</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
Alleging version with samples, otherwise, integration tests are failing.