### PR TITLE
docs: add note on how to configure brokers

### DIFF
--- a/docs/src/modules/java/pages/publishing-subscribing.adoc
+++ b/docs/src/modules/java/pages/publishing-subscribing.adoc
@@ -24,6 +24,8 @@ You can subscribe an Action to events from an Event Source Entity by annotating 
 
 To publish the events you need to add the annotation `@Publish.Topic` to the method subscribed to the events and add the name of the topic. 
 
+include::partial$pubsub-note.adoc[]
+
 [source,java,indent=0]
 .src/main/java/com/example/actions/CounterJournalToTopicAction.java
 ----
@@ -129,7 +131,9 @@ Check xref:serialization.adoc[serialization] documentation for more details.
 
 == Subscribing to a Topic
 
-To receive messages from a Google Cloud Pub/Sub or Apache Kafka topic, annotate the service method `@Subscribe.Topic` and specify the topic name.
+To receive messages from a Google Cloud Pub/Sub or Apache Kafka topic, annotate the service method `@Subscribe.Topic` and specify the topic name. 
+
+include::partial$pubsub-note.adoc[]
 
 In the following example the events from the topic are delivered to the Action and logged.
 

--- a/docs/src/modules/java/partials/pubsub-note.adoc
+++ b/docs/src/modules/java/partials/pubsub-note.adoc
@@ -1,4 +1,4 @@
 [NOTE]
 ====
-In the Protobuf descriptors, only topic names are referenced and no additional details about how to connect to the topics are needed. When deploying the application there must be a broker configuration in the Kalix project, with credentials and details on how connect to the broker. For details about configuring a broker see https://docs.kalix.io/projects/message-brokers.html[Configure message brokers]
+In the `Topic` annotation, only topic names are referenced and no additional details about how to connect to the topics are needed. When deploying the application there must be a broker configuration in the Kalix project, with credentials and details on how connect to the broker. For details about configuring a broker see https://docs.kalix.io/projects/message-brokers.html[Configure message brokers]
 ====


### PR DESCRIPTION
Adds note on how to configure brokers. 

This was missing only on the code-first SDK. Protobuf SDKs (jvm and js) have a similar note.