### PR TITLE
docs: add tracing sample for java sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,6 +559,7 @@ jobs:
 
           - { sample: java-spring-eventsourced-customer-registry, it: true }
           - { sample: java-spring-eventsourced-customer-registry-subscriber, it: true, pre_cmd: 'mvn -f ../java-spring-eventsourced-customer-registry/pom.xml package docker:build --no-transfer-progress' }
+          - { sample: java-spring-eventsourced-counter, pre_cmd: 'docker compose up gcloud-pubsub-emulator -d', it: true }
           - { sample: java-spring-eventsourced-shopping-cart, it: true }
 
           - { sample: java-protobuf-valueentity-counter, it: true }
@@ -569,12 +570,12 @@ jobs:
           - { sample: java-spring-valueentity-shopping-cart, it: true }
           - { sample: java-spring-valueentity-customer-registry, it: true }
 
-          - { sample: java-spring-eventsourced-counter, pre_cmd: 'docker compose up gcloud-pubsub-emulator -d', it: true }
 
           - { sample: java-protobuf-replicatedentity-shopping-cart, it: true }
           - { sample: java-protobuf-replicatedentity-examples, it: true }
 
           - { sample: java-protobuf-tracing, it: false }
+          - { sample: java-spring-tracing, it: false }
 
           - { sample: java-protobuf-web-resources, it: false }
 

--- a/samples/java-spring-tracing/.env
+++ b/samples/java-spring-tracing/.env
@@ -1,0 +1,11 @@
+# this is the port where the kalix runtime container will be exposed
+# when running multiple services on your local machine, make sure that this port is unique
+ADVERTISED_HTTP_PORT=9000
+
+# this is the port where the user services (your application) will open
+# when running multiple services on your local machine, make sure that this port is unique
+USER_SERVICE_PORT=8080
+
+# this variable defines the host where the kalix runtime (running in docker) 
+# will reach the user service in local development
+USER_SERVICE_HOST=host.docker.internal

--- a/samples/java-spring-tracing/README.md
+++ b/samples/java-spring-tracing/README.md
@@ -1,0 +1,61 @@
+# Tracing with OpenTelemetry in Java
+
+## Designing
+
+To understand the Kalix concepts that are the basis for this example, see [Designing services](https://docs.kalix.io/java/development-process.html) in the documentation.
+
+## Developing
+
+This project demonstrates how to use tracing in a Kalix Service using Java SDK.
+The service is based on a User entity that gets updated with a random name and random picture after created.
+Such updates are done after calling an external API to get a random name and picture.
+All the flow is traced (most of it automatically), and see the traces in Jaeger UI.
+
+
+## Building
+
+Use Maven to build your project:
+
+```shell
+mvn compile
+```
+
+## Running Locally
+
+When running a Kalix service locally, we need to have its companion Kalix Runtime running alongside it.
+To start your service locally, run:
+
+```shell
+mvn kalix:runAll
+```
+
+This command will start your Kalix service, a companion Kalix Runtime and Jaeger as configured in [docker-compose.yml](./docker-compose.yml) file.
+
+## Exercising the service
+
+With both the Kalix Runtime and your service running, any defined endpoints should be available at `http://localhost:9000`.
+
+- Add a new user
+
+```shell
+ curl -i -XPOST -H "Content-Type: application/json" localhost:9000/user/1/add -d '{"email":"john@doe.com"}'
+```
+
+- Now you can see the trace in Jaeger UI at http://localhost:16686
+  - select "Kalix endpoint" and "Find all traces" to explore the trace
+
+## Deploying
+
+To deploy your service, install the `kalix` CLI as documented in
+[Install Kalix](https://docs.kalix.io/kalix/install-kalix.html)
+and configure a Docker Registry to upload your docker image to.
+
+You will need to update the `dockerImage` property in the `pom.xml` and refer to
+[Configuring registries](https://docs.kalix.io/projects/container-registries.html)
+for more information on how to make your docker image available to Kalix.
+
+Finally, you can use the [Kalix Console](https://console.kalix.io)
+to create a project and then deploy your service into the project either by using `mvn deploy kalix:deploy` which
+will conveniently package, publish your docker image, and deploy your service to Kalix, or by first packaging and
+publishing the docker image through `mvn deploy` and then deploying the image
+through the `kalix` CLI.

--- a/samples/java-spring-tracing/docker-compose.yml
+++ b/samples/java-spring-tracing/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-runtime:
-    image: gcr.io/kalix-public/kalix-runtime:1.1.34
+    image: gcr.io/kalix-public/kalix-runtime:1.1.35
     container_name: tracing
     ports:
       - "${ADVERTISED_HTTP_PORT}:9000"

--- a/samples/java-spring-tracing/docker-compose.yml
+++ b/samples/java-spring-tracing/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+  kalix-runtime:
+    image: gcr.io/kalix-public/kalix-runtime:1.1.34
+    container_name: tracing
+    ports:
+      - "${ADVERTISED_HTTP_PORT}:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dkalix.proxy.telemetry.tracing.enabled=true
+        -Dkalix.proxy.telemetry.tracing.collector-endpoint=http://jaeger:4317
+      ADVERTISED_HTTP_PORT: ${ADVERTISED_HTTP_PORT}
+      USER_SERVICE_HOST: ${USER_SERVICE_HOST}
+      USER_SERVICE_PORT: ${USER_SERVICE_PORT}
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    ports:
+      - 4317:4317
+      - 16686:16686

--- a/samples/java-spring-tracing/pom.xml
+++ b/samples/java-spring-tracing/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.kalix</groupId>
+    <artifactId>kalix-spring-boot-parent</artifactId>
+    <version>1.4.1</version>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>java-spring-tracing</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>java-spring-tracing</name>
+  <properties>
+
+    <!-- For Docker setup see https://docs.kalix.io/projects/container-registries.html -->
+    <kalixContainerRegistry>kcr.us-east-1.kalix.io</kalixContainerRegistry>
+    <kalixOrganization>acme</kalixOrganization>
+    <mainClass>com.example.tracing.Main</mainClass>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.34.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.kalix</groupId>
+      <artifactId>kalix-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.kalix</groupId>
+      <artifactId>kalix-spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/samples/java-spring-tracing/src/it/java/com/example/IntegrationTest.java
+++ b/samples/java-spring-tracing/src/it/java/com/example/IntegrationTest.java
@@ -1,0 +1,37 @@
+package com.example;
+
+import com.example.tracing.Main;
+import kalix.spring.testkit.KalixIntegrationTestKitSupport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+
+/**
+ * This is a skeleton for implementing integration tests for a Kalix application built with the Java SDK.
+ * <p>
+ * This test will initiate a Kalix Runtime using testcontainers and therefore it's required to have Docker installed
+ * on your machine. This test will also start your Spring Boot application.
+ * <p>
+ * Since this is an integration tests, it interacts with the application using a WebClient
+ * (already configured and provided automatically through injection).
+ */
+@SpringBootTest(classes = Main.class)
+public class IntegrationTest extends KalixIntegrationTestKitSupport {
+
+  private Duration timeout = Duration.of(5, SECONDS);
+
+  @Test
+  public void testTracingPropagation() {
+    // TODO
+  }
+
+  @Test
+  public void testExternalTracingPropagation() {
+    // TODO
+  }
+}

--- a/samples/java-spring-tracing/src/it/resources/logback-test.xml
+++ b/samples/java-spring-tracing/src/it/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="INFO"/>
+    <logger name="kalix" level="INFO"/>
+    <logger name="com.github.dockerjava" level="INFO"/>
+    <logger name="io.grpc.netty" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/Main.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/Main.java
@@ -1,0 +1,23 @@
+package com.example.tracing;
+
+import kalix.javasdk.annotations.Acl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+// NOTE: This default ACL settings is very permissive as it allows any traffic from the internet.
+// Our samples default to this permissive configuration to allow users to easily try it out.
+// However, this configuration is not intended to be reproduced in production environments.
+// Documentation at https://docs.kalix.io/java/access-control.html
+@Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))
+public class Main {
+
+  private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+  public static void main(String[] args) {
+    logger.info("Starting Kalix Application");
+    SpringApplication.run(Main.class, args);
+  }
+}

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/api/GetRandomNameAction.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/api/GetRandomNameAction.java
@@ -1,0 +1,70 @@
+package com.example.tracing.api;
+
+import com.example.tracing.domain.UserEvent;
+import io.opentelemetry.api.trace.*;
+import io.opentelemetry.context.Scope;
+import kalix.javasdk.action.Action;
+import kalix.javasdk.annotations.Subscribe;
+import kalix.javasdk.client.ComponentClient;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.concurrent.CompletableFuture;
+
+
+@Subscribe.EventSourcedEntity(value = UserEntity.class, ignoreUnknown = true)
+public class GetRandomNameAction extends Action {
+
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(GetRandomNameAction.class);
+
+  private final ComponentClient componentClient;
+
+  private final WebClient webClient;
+
+  public GetRandomNameAction(ComponentClient componentClient) {
+    this.componentClient = componentClient;
+    this.webClient = WebClient.create("https://randomuser.me/api/?inc=name&noinfo");
+  }
+
+  public Effect<String> handleAdd(UserEvent.UserAdded userAdded) {
+    if (actionContext().eventSubject().isPresent()) {
+      var randomNameFut = getRandomNameAsync();
+
+      var updateNameCall = randomNameFut.thenCompose(name ->
+          componentClient
+            .forEventSourcedEntity(actionContext().eventSubject().get())
+            .call(UserEntity::updateName)
+            .params(new UserEntity.UserCmd.UpdateNameCmd(name))
+            .execute());
+
+      return effects().asyncReply(updateNameCall);
+    } else {
+      return effects().ignore();
+    }
+  }
+
+  // gets random name from external API using a synchronous call and traces that call
+  private CompletableFuture<String> getRandomNameAsync() {
+    var otelCurrentContext = actionContext().metadata().traceContext().asOpenTelemetryContext();
+    Span span = actionContext().getTracer()
+        .spanBuilder("random-name-async")
+        .setParent(otelCurrentContext)
+        .setSpanKind(SpanKind.CLIENT)
+        .startSpan();
+
+    try (Scope ignored = span.makeCurrent()) {
+      CompletableFuture<RandomUserApi.Name> result = webClient.get()
+          .retrieve()
+          .bodyToMono(RandomUserApi.Name.class)
+          .toFuture();
+
+      // set attrs on span
+      result.thenAccept(name -> {
+        span.setAttribute("user.id", actionContext().eventSubject().orElse("unknown"));
+        span.setAttribute("random.name", name.name());
+        span.end();
+      });
+
+      return result.thenApply(RandomUserApi.Name::name);
+    }
+  }
+}

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/api/GetRandomNameAction.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/api/GetRandomNameAction.java
@@ -2,10 +2,11 @@ package com.example.tracing.api;
 
 import com.example.tracing.domain.UserEvent;
 import io.opentelemetry.api.trace.*;
-import io.opentelemetry.context.Scope;
 import kalix.javasdk.action.Action;
 import kalix.javasdk.annotations.Subscribe;
 import kalix.javasdk.client.ComponentClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.concurrent.CompletableFuture;
@@ -14,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
 @Subscribe.EventSourcedEntity(value = UserEntity.class, ignoreUnknown = true)
 public class GetRandomNameAction extends Action {
 
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(GetRandomNameAction.class);
+  private static final Logger log = LoggerFactory.getLogger(GetRandomNameAction.class);
 
   private final ComponentClient componentClient;
 
@@ -27,44 +28,42 @@ public class GetRandomNameAction extends Action {
 
   public Effect<String> handleAdd(UserEvent.UserAdded userAdded) {
     if (actionContext().eventSubject().isPresent()) {
-      var randomNameFut = getRandomNameAsync();
-
-      var updateNameCall = randomNameFut.thenCompose(name ->
+      var randomNameFut = getRandomNameAsync().thenCompose(name ->
           componentClient
             .forEventSourcedEntity(actionContext().eventSubject().get())
             .call(UserEntity::updateName)
             .params(new UserEntity.UserCmd.UpdateNameCmd(name))
             .execute());
 
-      return effects().asyncReply(updateNameCall);
+      return effects().asyncReply(randomNameFut);
     } else {
       return effects().ignore();
     }
   }
 
-  // gets random name from external API using a synchronous call and traces that call
+  // gets random name from external API using an asynchronous call and traces that call
   private CompletableFuture<String> getRandomNameAsync() {
     var otelCurrentContext = actionContext().metadata().traceContext().asOpenTelemetryContext();
     Span span = actionContext().getTracer()
         .spanBuilder("random-name-async")
         .setParent(otelCurrentContext)
         .setSpanKind(SpanKind.CLIENT)
-        .startSpan();
+        .startSpan()
+        .setAttribute("user.id", actionContext().eventSubject().orElse("unknown"));
 
-    try (Scope ignored = span.makeCurrent()) {
-      CompletableFuture<RandomUserApi.Name> result = webClient.get()
-          .retrieve()
-          .bodyToMono(RandomUserApi.Name.class)
-          .toFuture();
+    CompletableFuture<RandomUserApi.Name> result = webClient.get()
+        .retrieve()
+        .bodyToMono(RandomUserApi.Name.class)
+        .toFuture()
+        .whenComplete((name, ex) -> {
+          if (ex != null) {
+            span.setStatus(StatusCode.ERROR, ex.getMessage());
+          } else {
+            span.setAttribute("random.name", name.name());
+          }
+          span.end();
+        });
 
-      // set attrs on span
-      result.thenAccept(name -> {
-        span.setAttribute("user.id", actionContext().eventSubject().orElse("unknown"));
-        span.setAttribute("random.name", name.name());
-        span.end();
-      });
-
-      return result.thenApply(RandomUserApi.Name::name);
-    }
+    return result.thenApply(RandomUserApi.Name::name);
   }
 }

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/api/GetRandomPhotoAction.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/api/GetRandomPhotoAction.java
@@ -1,0 +1,83 @@
+package com.example.tracing.api;
+
+import com.example.tracing.domain.UserEvent;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import kalix.javasdk.action.Action;
+import kalix.javasdk.annotations.Subscribe;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+
+@Subscribe.EventSourcedEntity(value = UserEntity.class, ignoreUnknown = true)
+public class GetRandomPhotoAction extends Action {
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(GetRandomPhotoAction.class);
+
+  private final Tracer tracer;
+  private final WebClient webClient;
+
+  public GetRandomPhotoAction(Tracer tracer) {
+    this.tracer = tracer;
+    this.webClient = WebClient.create("https://randomuser.me/api/?inc=picture&noinfo");
+  }
+
+  public Effect<String> handleAdd(UserEvent.UserAdded userAdded) {
+    var photoReply = getRandomPhotoAsync();
+    var updatePhoto = photoReply.thenCompose(randomPhotoUrl -> {
+      // Example for manually injecting headers for tracing context propagation
+      // NOTE: tracing context is automatically propagated when using component client, no need to manually inject headers
+      // in this case we are using WebClient directly instead, only for demonstration purposes but if you're doing a local call
+      // you should use the component client instead
+      var tracingMap = Map.of(
+          "traceparent", actionContext().metadata().traceContext().traceParent().orElse(""),
+          "tracestate", actionContext().metadata().traceContext().traceState().orElse("")
+      );
+
+      return WebClient.create("http://localhost:9000")
+          .put()
+          .uri(uriBuilder -> uriBuilder
+              .path("/user/{userId}/photo")
+              .queryParam("url", randomPhotoUrl)
+              .build(actionContext().eventSubject().get()))
+          .headers(h -> tracingMap.forEach(h::set))
+          .retrieve()
+          .bodyToMono(String.class)
+          .toFuture();
+    });
+
+    return effects().asyncReply(updatePhoto);
+  }
+
+  // gets random name from external API using an asynchronous call and traces that call
+  private CompletableFuture<String> getRandomPhotoAsync() {
+    var otelCurrentContext = actionContext().metadata().traceContext().asOpenTelemetryContext();
+    Span span = tracer
+        .spanBuilder("random-photo-async")
+        .setParent(otelCurrentContext)
+        .setSpanKind(SpanKind.CLIENT)
+        .startSpan();
+
+    try (Scope ignored = span.makeCurrent()) {
+
+      return webClient
+          .get()
+          .retrieve()
+          .bodyToMono(RandomUserApi.Photo.class)
+          .map(photoResult -> {
+            span.setAttribute("user.id", actionContext().eventSubject().orElse("unknown"));
+            span.setAttribute("random.photo", photoResult.url());
+            span.end();
+            return photoResult.url();
+          }).doOnError(throwable -> {
+            span.setStatus(StatusCode.ERROR, "Failed to fetch name: " + throwable.getMessage());
+            span.end();
+          }).toFuture();
+    }
+  }
+
+}

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/api/RandomUserApi.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/api/RandomUserApi.java
@@ -1,0 +1,30 @@
+package com.example.tracing.api;
+
+import java.util.List;
+
+public interface RandomUserApi {
+  record Name(List<Result> results) {
+    public record Result(ResultName name) {
+    }
+
+    public record ResultName(String title, String first, String last) {
+    }
+
+    public String name() {
+      // We always expect at least and only one result
+      return results.get(0).name().first() + " " + results.get(0).name().last();
+    }
+  }
+
+  record Photo(List<Result> results) {
+    public record Result(ResultPicture picture) { }
+    public record ResultPicture(String large) {}
+
+    public String url() {
+      // We only expect one result
+      return results.get(0).picture.large;
+    }
+  }
+
+
+}

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/api/UserEntity.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/api/UserEntity.java
@@ -1,0 +1,105 @@
+package com.example.tracing.api;
+
+import com.example.tracing.domain.User;
+import com.example.tracing.domain.UserEvent;
+import kalix.javasdk.StatusCode;
+import kalix.javasdk.annotations.EventHandler;
+import kalix.javasdk.annotations.ForwardHeaders;
+import kalix.javasdk.annotations.Id;
+import kalix.javasdk.annotations.TypeId;
+import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
+import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import org.springframework.web.bind.annotation.*;
+
+@Id("userId")
+@TypeId("user")
+@RequestMapping("/user/{userId}")
+@ForwardHeaders("traceparent")
+public class UserEntity extends EventSourcedEntity<User, UserEvent> {
+
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(UserEntity.class);
+
+  private final String entityId;
+
+  public sealed interface UserCmd {
+    record CreateCmd(String email) implements UserCmd { }
+    record UpdateNameCmd(String name) implements UserCmd { }
+    record UpdatePhotoCmd(String url) implements UserCmd { }
+  }
+
+
+  public UserEntity(EventSourcedEntityContext context) {
+    this.entityId = context.entityId();
+  }
+
+  @Override
+  public User emptyState() { // <2>
+    return new User(entityId, "", "", "");
+  }
+
+  @GetMapping
+  public Effect<User> get() {
+    if (currentState() == emptyState())
+      return effects().error("User does not exist", StatusCode.ErrorCode.NOT_FOUND);
+
+    return effects().reply(currentState());
+  }
+
+  @PostMapping("/add")
+  public Effect<String> add(@RequestBody UserCmd.CreateCmd create) {
+    log.info("Current context: {}, empty {}", currentState(), emptyState());
+    if (!currentState().equals(emptyState())) {
+      return effects().error("User already exists", StatusCode.ErrorCode.BAD_REQUEST);
+    }
+
+    var created = new UserEvent.UserAdded(create.email);
+
+    return effects()
+        .emitEvent(created)
+        .thenReply(newState -> "OK");
+  }
+
+  @PutMapping("/name")
+  public EventSourcedEntity.Effect<String> updateName(@RequestBody UserCmd.UpdateNameCmd updateNameCmd) {
+    if (currentState() == emptyState()){
+      return effects().error("User does not exist");
+    }
+
+    var updated = new UserEvent.UserNameUpdated(updateNameCmd.name);
+
+    return effects()
+        .emitEvent(updated)
+        .thenReply(newState -> "OK");
+  }
+
+  @PutMapping("/photo")
+  public EventSourcedEntity.Effect<String> updatePhoto(@RequestParam String url) {
+    if (currentState() == emptyState()){
+      return effects().error("User does not exist");
+    }
+
+    var updated = new UserEvent.UserPhotoUpdated(url);
+    return effects()
+        .emitEvent(updated)
+        .thenReply(newState -> "OK");
+  }
+
+  @EventHandler
+  public User handleEvent(UserEvent event) {
+      return switch (event) {
+          case UserEvent.UserAdded userAdded -> {
+              log.info("User added: {}", userAdded.email());
+              yield new User(entityId, "", userAdded.email(), "");
+          }
+          case UserEvent.UserNameUpdated nameUpdated -> {
+              log.info("User name updated: {}", nameUpdated.name());
+              yield currentState().withName(nameUpdated.name());
+          }
+          case UserEvent.UserPhotoUpdated photoUpdated -> {
+              log.info("User photo updated: {}", photoUpdated.url());
+              yield currentState().withPhoto(photoUpdated.url());
+          }
+      };
+  }
+
+}

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/api/UserEntity.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/api/UserEntity.java
@@ -9,6 +9,8 @@ import kalix.javasdk.annotations.Id;
 import kalix.javasdk.annotations.TypeId;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
 @Id("userId")
@@ -17,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @ForwardHeaders("traceparent")
 public class UserEntity extends EventSourcedEntity<User, UserEvent> {
 
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(UserEntity.class);
+  private static final Logger log = LoggerFactory.getLogger(UserEntity.class);
 
   private final String entityId;
 
@@ -39,7 +41,7 @@ public class UserEntity extends EventSourcedEntity<User, UserEvent> {
 
   @GetMapping
   public Effect<User> get() {
-    if (currentState() == emptyState())
+    if (currentState().equals(emptyState()))
       return effects().error("User does not exist", StatusCode.ErrorCode.NOT_FOUND);
 
     return effects().reply(currentState());
@@ -60,8 +62,8 @@ public class UserEntity extends EventSourcedEntity<User, UserEvent> {
   }
 
   @PutMapping("/name")
-  public EventSourcedEntity.Effect<String> updateName(@RequestBody UserCmd.UpdateNameCmd updateNameCmd) {
-    if (currentState() == emptyState()){
+  public Effect<String> updateName(@RequestBody UserCmd.UpdateNameCmd updateNameCmd) {
+    if (currentState().equals(emptyState())) {
       return effects().error("User does not exist");
     }
 
@@ -73,8 +75,8 @@ public class UserEntity extends EventSourcedEntity<User, UserEvent> {
   }
 
   @PutMapping("/photo")
-  public EventSourcedEntity.Effect<String> updatePhoto(@RequestParam String url) {
-    if (currentState() == emptyState()){
+  public Effect<String> updatePhoto(@RequestParam String url) {
+    if (currentState().equals(emptyState())) {
       return effects().error("User does not exist");
     }
 

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/domain/User.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/domain/User.java
@@ -1,0 +1,13 @@
+package com.example.tracing.domain;
+
+public record User(String userId, String name, String email, String photoUrl) {
+
+  public User withName(String name) {
+    return new User(userId, name, email, photoUrl);
+  }
+
+  public User withPhoto(String photoUrl) {
+    return new User(userId, name, email, photoUrl);
+  }
+}
+

--- a/samples/java-spring-tracing/src/main/java/com/example/tracing/domain/UserEvent.java
+++ b/samples/java-spring-tracing/src/main/java/com/example/tracing/domain/UserEvent.java
@@ -1,0 +1,15 @@
+package com.example.tracing.domain;
+
+
+import kalix.javasdk.annotations.TypeName;
+public sealed interface UserEvent {
+
+  @TypeName("user-added")
+  record UserAdded(String email) implements UserEvent {}
+
+  @TypeName("name-updated")
+  record UserNameUpdated(String name) implements UserEvent {}
+
+  @TypeName("photo-updated")
+  record UserPhotoUpdated(String url) implements UserEvent {}
+}

--- a/samples/java-spring-tracing/src/main/resources/application.conf
+++ b/samples/java-spring-tracing/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+
+# //tag::snapshot-every[]
+kalix.event-sourced-entity.snapshot-every = 100
+# //end::snapshot-every[]

--- a/samples/java-spring-tracing/src/main/resources/application.conf
+++ b/samples/java-spring-tracing/src/main/resources/application.conf
@@ -1,4 +1,1 @@
-
-# //tag::snapshot-every[]
 kalix.event-sourced-entity.snapshot-every = 100
-# //end::snapshot-every[]

--- a/samples/java-spring-tracing/src/main/resources/logback-dev-mode.xml
+++ b/samples/java-spring-tracing/src/main/resources/logback-dev-mode.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Non json config for Kalix user dev modes, note that for actual deploy
+     the default sample JSON logging output must be used or else production
+     does not work -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="WARN"/>
+    <logger name="kalix.javasdk.impl.telemetry" level="DEBUG" />
+    <logger name="com.example.tracing" level="DEBUG" />
+
+
+    <!-- Silence some details from Akka, should not be important to user/SDK dev mode -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/samples/java-spring-tracing/src/main/resources/logback.xml
+++ b/samples/java-spring-tracing/src/main/resources/logback.xml
@@ -1,0 +1,36 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="JSON-STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="kalix.javasdk.logging.LogbackJsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <!-- Don't use prettyPrint true in production, but can be useful for local development -->
+                    <prettyPrint>false</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC-JSON-STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="JSON-STDOUT"/>
+    </appender>
+
+    <logger name="akka" level="INFO"/>
+    <logger name="kalix" level="INFO"/>
+    <logger name="akka.http" level="INFO"/>
+    <logger name="io.grpc" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC-JSON-STDOUT"/>
+    </root>
+</configuration>

--- a/samples/java-spring-tracing/src/test/resources/logback-test.xml
+++ b/samples/java-spring-tracing/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="INFO"/>
+    <logger name="kalix" level="INFO"/>
+    <logger name="com.github.dockerjava" level="INFO"/>
+    <logger name="io.grpc.netty" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/ActionCallBuilder.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/ActionCallBuilder.java
@@ -49,8 +49,7 @@ public class ActionCallBuilder {
    * Pass in an Action method reference annotated as a REST endpoint, e.g. <code>MyAction::create</code>
    */
   public <T, R> DeferredCall<Any, R> call(Function<T, Action.Effect<R>> methodRef) {
-    DeferredCall<Any, R> result = ComponentCall.noParams(kalixClient, methodRef, List.of());
-    return result.withMetadata(ComponentCall.addTracing(result.metadata(), callMetadata));
+    return ComponentCall.noParams(kalixClient, methodRef, List.of(), callMetadata);
   }
 
   /**

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/EventSourcedEntityCallBuilder.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/EventSourcedEntityCallBuilder.java
@@ -61,8 +61,7 @@ public class EventSourcedEntityCallBuilder {
    * Pass in an Event Sourced Entity method reference annotated as a REST endpoint, e.g. <code>UserEntity::create</code>
    */
   public <T, R> DeferredCall<Any, R> call(Function<T, EventSourcedEntity.Effect<R>> methodRef) {
-    DeferredCall<Any, R> result = ComponentCall.noParams(kalixClient, methodRef, entityIds);
-    return result.withMetadata(ComponentCall.addTracing(result.metadata(), callMetadata));
+    return ComponentCall.noParams(kalixClient, methodRef, entityIds, callMetadata);
   }
 
   /**

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/ValueEntityCallBuilder.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/ValueEntityCallBuilder.java
@@ -61,8 +61,7 @@ public class ValueEntityCallBuilder {
    * Pass in a Value Entity method reference annotated as a REST endpoint, e.g. <code>UserEntity::create</code>
    */
   public <T, R> DeferredCall<Any, R> call(Function<T, ValueEntity.Effect<R>> methodRef) {
-    DeferredCall<Any, R> result = ComponentCall.noParams(kalixClient, methodRef, entityIds);
-    return result.withMetadata(ComponentCall.addTracing(result.metadata(), callMetadata));
+    return ComponentCall.noParams(kalixClient, methodRef, entityIds, callMetadata);
   }
 
   /**

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/ViewCallBuilder.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/ViewCallBuilder.java
@@ -56,8 +56,7 @@ public class ViewCallBuilder {
   public <T, R> DeferredCall<Any, R> call(Function<T, R> methodRef) {
     Method method = MethodRefResolver.resolveMethodRef(methodRef);
     ViewCallValidator.validate(method);
-    DeferredCall<Any, R> result =  ComponentCall.noParams(kalixClient, method, List.of());
-    return result.withMetadata(ComponentCall.addTracing(result.metadata(), callMetadata));
+    return ComponentCall.noParams(kalixClient, method, List.of(), callMetadata);
   }
 
   /**

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/WorkflowCallBuilder.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/client/WorkflowCallBuilder.java
@@ -32,6 +32,7 @@ import kalix.javasdk.workflow.Workflow;
 import kalix.spring.impl.KalixClient;
 
 import java.util.List;
+import java.util.Optional;
 
 public class WorkflowCallBuilder {
 
@@ -55,7 +56,7 @@ public class WorkflowCallBuilder {
    * Pass in a Workflow method reference annotated as a REST endpoint, e.g. <code>MyWorkflow::start</code>
    */
   public <T, R> DeferredCall<Any, R> call(Function<T, Workflow.Effect<R>> methodRef) {
-    return ComponentCall.noParams(kalixClient, methodRef, workflowIds);
+    return ComponentCall.noParams(kalixClient, methodRef, workflowIds, Optional.empty());
   }
 
   /**

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/action/ReflectiveActionRouter.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/action/ReflectiveActionRouter.scala
@@ -42,28 +42,24 @@ class ReflectiveActionRouter[A <: Action](
     // lookup ComponentClient
     val componentClients = Reflect.lookupComponentClientFields(action)
 
-    try {
-      componentClients.foreach(_.setCallMetadata(message.metadata()))
+    componentClients.foreach(_.setCallMetadata(message.metadata()))
 
-      methodInvoker match {
-        case Some(invoker) =>
-          inputTypeUrl match {
-            case ProtobufEmptyTypeUrl =>
-              invoker
-                .invoke(action)
-                .asInstanceOf[Action.Effect[_]]
-            case _ =>
-              invoker
-                .invoke(action, invocationContext)
-                .asInstanceOf[Action.Effect[_]]
-          }
-        case None if ignoreUnknown => ActionEffectImpl.Builder.ignore()
-        case None =>
-          throw new NoSuchElementException(
-            s"Couldn't find any method with input type [$inputTypeUrl] in Action [$action].")
-      }
-    } finally {
-      componentClients.foreach(_.clearCallMetadata())
+    methodInvoker match {
+      case Some(invoker) =>
+        inputTypeUrl match {
+          case ProtobufEmptyTypeUrl =>
+            invoker
+              .invoke(action)
+              .asInstanceOf[Action.Effect[_]]
+          case _ =>
+            invoker
+              .invoke(action, invocationContext)
+              .asInstanceOf[Action.Effect[_]]
+        }
+      case None if ignoreUnknown => ActionEffectImpl.Builder.ignore()
+      case None =>
+        throw new NoSuchElementException(
+          s"Couldn't find any method with input type [$inputTypeUrl] in Action [$action].")
     }
   }
 


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix/issues/9415

This PR:
- ~adds a new `TraceContext` type that can be derived from the metadata (similar to `JwtClaims`)~
- ~adds support for automatic injection of an opentelemetry `Tracer` (similar to the injection of the `ComponentClient`) for easier custom child spans (i.e. tracking an external call or a specific local computation)~
- adds a new tracing sample with java sdk for exemplifying all things related with tracing in Kalix
  - the sample uses a ESE for User management. A User is created with an email and then 2 actions generate a name and a photo respectively using an external API. 
  - the idea would be for this sample to show the different bits of tracing, events, component calls, external calls, etc.