### PR TITLE
chore: avoiding validation site.mockito while is down

### DIFF
--- a/docs/config/validate-links.json
+++ b/docs/config/validate-links.json
@@ -2,5 +2,6 @@
   "ignorePatterns": [
     { "pattern": "^https://mvnrepository\\.com" },
     { "pattern": "^http://127.0.0.1:8080" }
+    { "pattern": "^https://site\\.mockito\\.org/" }
   ]
 }

--- a/docs/config/validate-links.json
+++ b/docs/config/validate-links.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     { "pattern": "^https://mvnrepository\\.com" },
-    { "pattern": "^http://127.0.0.1:8080" }
+    { "pattern": "^http://127.0.0.1:8080" },
     { "pattern": "^https://site\\.mockito\\.org/" }
   ]
 }


### PR DESCRIPTION
https://typesafe.slack.com/archives/CQUASEUDV/p1707820966805069

CI PRs are failing because site.mockito is down.
