### PR TITLE
fix: wrong FQCN in workflow samples

### DIFF
--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -23,7 +23,7 @@
     <dockerImage>${kalixContainerRegistry}/${kalixOrganization}/${project.artifactId}</dockerImage>
     <dockerTag>${project.version}-${build.timestamp}</dockerTag>
     <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
-    <mainClass>store.Main</mainClass>
+    <mainClass>com.example.Main</mainClass>
 
     <jdk.target>17</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -23,7 +23,7 @@
     <dockerImage>${kalixContainerRegistry}/${kalixOrganization}/${project.artifactId}</dockerImage>
     <dockerTag>${project.version}-${build.timestamp}</dockerTag>
     <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
-    <mainClass>store.Main</mainClass>
+    <mainClass>com.example.Main</mainClass>
 
     <jdk.target>17</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Accidentally broken in https://github.com/lightbend/kalix-jvm-sdk/pull/1428

Probably some copy from other samples. 