### PR TITLE
chore: GH built-in release notes formatting

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+changelog:
+  categories:
+    - title: 'Java SDK'
+      labels:
+        - 'java-sdk'
+    - title: 'Java/Protobuf SDK'
+      labels:
+        - 'java-sdk-protobuf'
+    - title: 'Scala/Protobuf SDK'
+      labels:
+        - 'scala-sdk-protobuf'
+    - title: 'Documentation'
+      labels:
+        - 'Documentation'
+    - title: 'Other'
+      labels:
+        - "*"


### PR DESCRIPTION
With this we should be able to remove the release-drafter workflow and still get the structured release notes.