### PR TITLE
feat: direct access to component client

### DIFF
--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionServiceSourceGenerator.scala
@@ -167,7 +167,7 @@ object ActionServiceSourceGenerator {
         |
         |$managedComment
         |
-        |public abstract class ${service.abstractActionName} extends kalix.javasdk.action.Action {
+        |public abstract class ${service.abstractActionName} extends kalix.javasdk.action.AbstractAction {
         |
         |  protected final Components components() {
         |    return new ComponentsImpl(contextForComponents());
@@ -236,7 +236,7 @@ object ActionServiceSourceGenerator {
       otherImports = Seq(
         "akka.NotUsed",
         "akka.stream.javadsl.Source",
-        "kalix.javasdk.action.Action.Effect",
+        "kalix.javasdk.action.AbstractAction.Effect",
         "kalix.javasdk.action.MessageEnvelope",
         "kalix.javasdk.impl.action.ActionRouter"))
 

--- a/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/kalix/codegen/java/ActionTestKitGenerator.scala
@@ -44,7 +44,7 @@ object ActionTestKitGenerator {
         "java.util.Optional",
         s"$packageName.$className",
         "kalix.javasdk.Metadata",
-        "kalix.javasdk.action.Action.Effect",
+        "kalix.javasdk.action.AbstractAction.Effect",
         "kalix.javasdk.action.ActionCreationContext",
         "kalix.javasdk.testkit.ActionResult",
         "kalix.javasdk.testkit.impl.ActionResultImpl",

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/AbstractMyServiceNamedAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/AbstractMyServiceNamedAction.java
@@ -10,7 +10,7 @@ import org.example.ComponentsImpl;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractMyServiceNamedAction extends kalix.javasdk.action.Action {
+public abstract class AbstractMyServiceNamedAction extends kalix.javasdk.action.AbstractAction {
 
   protected final Components components() {
     return new ComponentsImpl(contextForComponents());

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/MyServiceNamedActionRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-managed/org/example/service/MyServiceNamedActionRouter.java
@@ -3,7 +3,7 @@ package org.example.service;
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import com.google.protobuf.Empty;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.MessageEnvelope;
 import kalix.javasdk.impl.action.ActionRouter;
 

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
@@ -4,7 +4,7 @@ import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import com.google.protobuf.Empty;
 import kalix.javasdk.Metadata;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.javasdk.testkit.ActionResult;
 import kalix.javasdk.testkit.MockRegistry;

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/AbstractMyServiceAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/AbstractMyServiceAction.java
@@ -10,7 +10,7 @@ import org.external.ExternalDomain;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractMyServiceAction extends kalix.javasdk.action.Action {
+public abstract class AbstractMyServiceAction extends kalix.javasdk.action.AbstractAction {
 
   protected final Components components() {
     return new ComponentsImpl(contextForComponents());

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/MyServiceActionRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-managed/org/example/service/MyServiceActionRouter.java
@@ -2,7 +2,7 @@ package org.example.service;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.MessageEnvelope;
 import kalix.javasdk.impl.action.ActionRouter;
 import org.external.ExternalDomain;

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -3,7 +3,7 @@ package org.example.service;
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import kalix.javasdk.Metadata;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.javasdk.testkit.ActionResult;
 import kalix.javasdk.testkit.MockRegistry;

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/AbstractMyServiceAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/AbstractMyServiceAction.java
@@ -10,7 +10,7 @@ import org.external.ExternalDomain;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractMyServiceAction extends kalix.javasdk.action.Action {
+public abstract class AbstractMyServiceAction extends kalix.javasdk.action.AbstractAction {
 
   protected final Components components() {
     return new ComponentsImpl(contextForComponents());

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/MyServiceActionRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-managed/org/example/service/MyServiceActionRouter.java
@@ -2,7 +2,7 @@ package org.example.service;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.MessageEnvelope;
 import kalix.javasdk.impl.action.ActionRouter;
 import org.external.ExternalDomain;

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -3,7 +3,7 @@ package org.example.service;
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import kalix.javasdk.Metadata;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.javasdk.testkit.ActionResult;
 import kalix.javasdk.testkit.MockRegistry;

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/AbstractMyServiceAction.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/AbstractMyServiceAction.java
@@ -8,7 +8,7 @@ import org.example.ComponentsImpl;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractMyServiceAction extends kalix.javasdk.action.Action {
+public abstract class AbstractMyServiceAction extends kalix.javasdk.action.AbstractAction {
 
   protected final Components components() {
     return new ComponentsImpl(contextForComponents());

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/MyServiceActionRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-managed/org/example/service/MyServiceActionRouter.java
@@ -3,7 +3,7 @@ package org.example.service;
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import com.google.protobuf.Empty;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.MessageEnvelope;
 import kalix.javasdk.impl.action.ActionRouter;
 

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
@@ -2,7 +2,7 @@ package org.example.service;
 
 import com.google.protobuf.Empty;
 import kalix.javasdk.Metadata;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.javasdk.testkit.ActionResult;
 import kalix.javasdk.testkit.MockRegistry;

--- a/codegen/java-gen/src/test/resources/tests/workflow/generated-managed/org/example/service/AbstractSomeServiceAction.java
+++ b/codegen/java-gen/src/test/resources/tests/workflow/generated-managed/org/example/service/AbstractSomeServiceAction.java
@@ -8,7 +8,7 @@ import org.example.ComponentsImpl;
 // It will be re-generated to reflect any changes to your protobuf definitions.
 // DO NOT EDIT
 
-public abstract class AbstractSomeServiceAction extends kalix.javasdk.action.Action {
+public abstract class AbstractSomeServiceAction extends kalix.javasdk.action.AbstractAction {
 
   protected final Components components() {
     return new ComponentsImpl(contextForComponents());

--- a/codegen/java-gen/src/test/resources/tests/workflow/generated-managed/org/example/service/SomeServiceActionRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/workflow/generated-managed/org/example/service/SomeServiceActionRouter.java
@@ -3,7 +3,7 @@ package org.example.service;
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
 import com.google.protobuf.Empty;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.MessageEnvelope;
 import kalix.javasdk.impl.action.ActionRouter;
 

--- a/codegen/java-gen/src/test/resources/tests/workflow/generated-test-managed/org/example/service/SomeServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/workflow/generated-test-managed/org/example/service/SomeServiceActionTestKit.java
@@ -2,7 +2,7 @@ package org.example.service;
 
 import com.google.protobuf.Empty;
 import kalix.javasdk.Metadata;
-import kalix.javasdk.action.Action.Effect;
+import kalix.javasdk.action.AbstractAction.Effect;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.javasdk.testkit.ActionResult;
 import kalix.javasdk.testkit.MockRegistry;

--- a/samples/java-spring-transfer-workflow/src/main/java/com/example/transfer/TransferWorkflow.java
+++ b/samples/java-spring-transfer-workflow/src/main/java/com/example/transfer/TransferWorkflow.java
@@ -2,7 +2,6 @@ package com.example.transfer;
 
 import com.example.transfer.TransferState.Transfer;
 import com.example.wallet.WalletEntity;
-import kalix.javasdk.client.ComponentClient;
 import kalix.javasdk.workflow.Workflow;
 import kalix.javasdk.annotations.Id;
 import kalix.javasdk.annotations.TypeId;
@@ -37,19 +36,13 @@ public class TransferWorkflow extends Workflow<TransferState> { // <1>
 
   private static final Logger logger = LoggerFactory.getLogger(TransferWorkflow.class);
 
-  final private ComponentClient componentClient;
-
-  public TransferWorkflow(ComponentClient componentClient) {
-    this.componentClient = componentClient;
-  }
-
   // tag::definition[]
   @Override
   public WorkflowDef<TransferState> definition() {
     Step withdraw =
       step("withdraw") // <1>
         .call(Withdraw.class, cmd -> {
-          return componentClient.forValueEntity(cmd.from)
+          return componentClient().forValueEntity(cmd.from)
             .call(WalletEntity::withdraw)
             .params(cmd.amount);
         }) // <2>
@@ -63,7 +56,7 @@ public class TransferWorkflow extends Workflow<TransferState> { // <1>
     Step deposit =
       step("deposit") // <1>
         .call(Deposit.class, cmd -> {
-          return componentClient.forValueEntity(cmd.to)
+          return componentClient().forValueEntity(cmd.to)
             .call(WalletEntity::deposit)
             .params(cmd.amount);
         }) // <4>

--- a/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/ActionResultImpl.scala
+++ b/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/ActionResultImpl.scala
@@ -17,7 +17,6 @@
 package kalix.javasdk.testkit.impl
 
 import kalix.javasdk.SideEffect
-import kalix.javasdk.action.Action
 import kalix.javasdk.impl.GrpcDeferredCall
 import kalix.javasdk.impl.action.ActionEffectImpl
 import kalix.javasdk.testkit.ActionResult
@@ -30,6 +29,7 @@ import io.grpc.Status
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
+import kalix.javasdk.action.AbstractAction
 
 /**
  * INTERNAL API
@@ -48,7 +48,7 @@ private[kalix] object ActionResultImpl {
 final class ActionResultImpl[T](effect: ActionEffectImpl.PrimaryEffect[T]) extends ActionResult[T] {
   import ActionResultImpl._
 
-  def this(effect: Action.Effect[T]) = this(effect.asInstanceOf[ActionEffectImpl.PrimaryEffect[T]])
+  def this(effect: AbstractAction.Effect[T]) = this(effect.asInstanceOf[ActionEffectImpl.PrimaryEffect[T]])
 
   private implicit val ec = ExecutionContext.Implicits.global
 

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/DeferredCall.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/DeferredCall.java
@@ -16,6 +16,8 @@
 
 package kalix.javasdk;
 
+import kalix.javasdk.action.AbstractAction;
+
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -37,7 +39,7 @@ public interface DeferredCall<I, O> {
 
   /**
    * Execute this call right away and get the async result back for composition. Can be used to
-   * create an async reply in an {@link kalix.javasdk.action.Action} with {@code
+   * create an async reply in an {@link AbstractAction} with {@code
    * effects().asyncReply} and {@code effects().asyncEffect}
    */
   CompletionStage<O> execute();

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Kalix.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Kalix.java
@@ -49,12 +49,9 @@ import kalix.javasdk.valueentity.ValueEntityProvider;
 import kalix.javasdk.view.ViewOptions;
 import kalix.javasdk.view.ViewProvider;
 import kalix.javasdk.workflow.AbstractWorkflow;
-import kalix.javasdk.workflow.Workflow;
 import kalix.javasdk.workflow.WorkflowOptions;
 import kalix.javasdk.workflow.WorkflowProvider;
 import kalix.replicatedentity.ReplicatedData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import scala.jdk.javaapi.OptionConverters;
 
 import java.util.*;
@@ -67,7 +64,6 @@ import java.util.function.Function;
  */
 public final class Kalix {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
   private final Map<String, Function<ActorSystem, Service>> services = new HashMap<>();
   private ClassLoader classLoader = getClass().getClassLoader();
   private String typeUrlPrefix = AnySupport.DefaultTypeUrlPrefix();

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Kalix.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Kalix.java
@@ -22,7 +22,7 @@ import akka.annotation.InternalApi;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.typesafe.config.Config;
-import kalix.javasdk.action.Action;
+import kalix.javasdk.action.AbstractAction;
 import kalix.javasdk.action.ActionOptions;
 import kalix.javasdk.action.ActionProvider;
 import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
@@ -566,7 +566,7 @@ public final class Kalix {
    *
    * @return This stateful service builder.
    */
-  public <A extends Action> Kalix register(ActionProvider<A> provider) {
+  public <A extends AbstractAction> Kalix register(ActionProvider<A> provider) {
     return provider
       .alternativeCodec()
       .map(

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/AbstractAction.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/AbstractAction.java
@@ -59,7 +59,7 @@ import java.util.concurrent.CompletionStage;
  *
  * An Action method should return an {@link Effect} that describes what to do next.
  */
-public abstract class Action {
+public abstract class AbstractAction {
 
   private volatile Optional<ActionContext> actionContext = Optional.empty();
 

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/ActionCreationContext.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/ActionCreationContext.java
@@ -22,7 +22,7 @@ import kalix.javasdk.Context;
 import java.util.Optional;
 
 /**
- * Creation context for {@link Action} components.
+ * Creation context for {@link AbstractAction} components.
  *
  * <p>This may be accepted as an argument to the constructor of an Action.
  */

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/ActionProvider.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/ActionProvider.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * ActionProvider</code>. The concrete <code>ActionProvider</code> is generated for the specific
  * entities defined in Protobuf, for example <code>CustomerActionProvider</code>.
  */
-public interface ActionProvider<A extends Action> {
+public interface ActionProvider<A extends AbstractAction> {
 
   ActionOptions options();
 

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/valueentity/ValueEntity.java
@@ -21,8 +21,6 @@ import kalix.javasdk.DeferredCall;
 import kalix.javasdk.Metadata;
 import kalix.javasdk.SideEffect;
 import kalix.javasdk.StatusCode;
-import kalix.javasdk.action.Action;
-import kalix.javasdk.eventsourcedentity.EventSourcedEntity;
 import kalix.javasdk.impl.valueentity.ValueEntityEffectImpl;
 import io.grpc.Status;
 

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/workflow/ProtoStepBuilder.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/workflow/ProtoStepBuilder.java
@@ -133,7 +133,7 @@ public class ProtoStepBuilder {
      * Transition to the next step based on the result of the step call.
      * <p>
      * The {@link Function} passed to this method should receive the return type of the step call and return
-     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
+     * an {@link AbstractWorkflow.Effect.TransitionalEffect} describing the next step to transition to.
      * <p>
      * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
      * This can be another step, or a pause or end of the workflow.
@@ -141,12 +141,12 @@ public class ProtoStepBuilder {
      * When transition to another step, you can also pass an input parameter to the next step.
      *
      * @param transitionInputClass Input class for transition.
-     * @param transitionFunc       Function that transform the action result to a {@link Workflow.Effect.TransitionalEffect}
+     * @param transitionFunc       Function that transform the action result to a {@link AbstractWorkflow.Effect.TransitionalEffect}
      * @return CallStep
      */
     @ApiMayChange
-    public Workflow.CallStep<Input, DefCallInput, DefCallOutput, ?> andThen(Class<DefCallOutput> transitionInputClass, Function<DefCallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    public AbstractWorkflow.CallStep<Input, DefCallInput, DefCallOutput, ?> andThen(Class<DefCallOutput> transitionInputClass, Function<DefCallOutput, AbstractWorkflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new AbstractWorkflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
   }
 
@@ -167,7 +167,7 @@ public class ProtoStepBuilder {
      * Transition to the next step based on the result of the step call.
      * <p>
      * The {@link Function} passed to this method should receive the return type of the step call and return
-     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
+     * an {@link AbstractWorkflow.Effect.TransitionalEffect} describing the next step to transition to.
      * <p>
      * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
      * This can be another step, or a pause or end of the workflow.
@@ -175,12 +175,12 @@ public class ProtoStepBuilder {
      * When transition to another step, you can also pass an input parameter to the next step.
      *
      * @param transitionInputClass Input class for transition.
-     * @param transitionFunc       Function that transform the action result to a {@link Workflow.Effect.TransitionalEffect}
+     * @param transitionFunc       Function that transform the action result to a {@link AbstractWorkflow.Effect.TransitionalEffect}
      * @return AsyncCallStep
      */
     @ApiMayChange
-    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    public AbstractWorkflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, AbstractWorkflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new AbstractWorkflow.AsyncCallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
   }
 }

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/workflow/StepBuilder.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/workflow/StepBuilder.java
@@ -133,7 +133,7 @@ public class StepBuilder {
      * Transition to the next step based on the result of the step call.
      * <p>
      * The {@link Function} passed to this method should receive the return type of the step call and return
-     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
+     * an {@link AbstractWorkflow.Effect.TransitionalEffect} describing the next step to transition to.
      * <p>
      * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
      * This can be another step, or a pause or end of the workflow.
@@ -141,12 +141,12 @@ public class StepBuilder {
      * When transition to another step, you can also pass an input parameter to the next step.
      *
      * @param transitionInputClass Input class for transition.
-     * @param transitionFunc       Function that transform the action result to a {@link Workflow.Effect.TransitionalEffect}
+     * @param transitionFunc       Function that transform the action result to a {@link AbstractWorkflow.Effect.TransitionalEffect}
      * @return CallStep
      */
     @ApiMayChange
-    public Workflow.CallStep<Input, DefCallInput, DefCallOutput, ?> andThen(Class<DefCallOutput> transitionInputClass, Function<DefCallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    public AbstractWorkflow.CallStep<Input, DefCallInput, DefCallOutput, ?> andThen(Class<DefCallOutput> transitionInputClass, Function<DefCallOutput, AbstractWorkflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new AbstractWorkflow.CallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
   }
 
@@ -167,7 +167,7 @@ public class StepBuilder {
      * Transition to the next step based on the result of the step call.
      * <p>
      * The {@link Function} passed to this method should receive the return type of the step call and return
-     * an {@link Workflow.Effect.TransitionalEffect} describing the next step to transition to.
+     * an {@link AbstractWorkflow.Effect.TransitionalEffect} describing the next step to transition to.
      * <p>
      * When defining the Effect, you can update the workflow state and indicate the next step to transition to.
      * This can be another step, or a pause or end of the workflow.
@@ -175,12 +175,12 @@ public class StepBuilder {
      * When transition to another step, you can also pass an input parameter to the next step.
      *
      * @param transitionInputClass Input class for transition.
-     * @param transitionFunc       Function that transform the action result to a {@link Workflow.Effect.TransitionalEffect}
+     * @param transitionFunc       Function that transform the action result to a {@link AbstractWorkflow.Effect.TransitionalEffect}
      * @return AsyncCallStep
      */
     @ApiMayChange
-    public Workflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, Workflow.Effect.TransitionalEffect<Void>> transitionFunc) {
-      return new Workflow.AsyncCallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
+    public AbstractWorkflow.AsyncCallStep<CallInput, CallOutput, ?> andThen(Class<CallOutput> transitionInputClass, Function<CallOutput, AbstractWorkflow.Effect.TransitionalEffect<Void>> transitionFunc) {
+      return new AbstractWorkflow.AsyncCallStep<>(name, callInputClass, callFunc, transitionInputClass, transitionFunc);
     }
   }
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionRouter.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionRouter.scala
@@ -18,17 +18,17 @@ package kalix.javasdk.impl.action
 
 import akka.NotUsed
 import akka.stream.javadsl.Source
-import kalix.javasdk.action.Action
 import kalix.javasdk.action.ActionContext
 import kalix.javasdk.action.MessageEnvelope
 import kalix.javasdk.impl.action.ActionRouter.HandlerNotFound
 
 import java.util.Optional
+import kalix.javasdk.action.AbstractAction
 
 object ActionRouter {
   case class HandlerNotFound(commandName: String) extends RuntimeException
 }
-abstract class ActionRouter[A <: Action](protected val action: A) {
+abstract class ActionRouter[A <: AbstractAction](protected val action: A) {
 
   /**
    * Handle a unary call.
@@ -42,7 +42,10 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
    * @return
    *   A future of the message to return.
    */
-  final def handleUnary(commandName: String, message: MessageEnvelope[Any], context: ActionContext): Action.Effect[_] =
+  final def handleUnary(
+      commandName: String,
+      message: MessageEnvelope[Any],
+      context: ActionContext): AbstractAction.Effect[_] =
     callWithContext(context) { () =>
       handleUnary(commandName, message)
     }
@@ -57,7 +60,7 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
    * @return
    *   A future of the message to return.
    */
-  def handleUnary(commandName: String, message: MessageEnvelope[Any]): Action.Effect[_]
+  def handleUnary(commandName: String, message: MessageEnvelope[Any]): AbstractAction.Effect[_]
 
   /**
    * Handle a streamed out call call.
@@ -74,7 +77,7 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
   final def handleStreamedOut(
       commandName: String,
       message: MessageEnvelope[Any],
-      context: ActionContext): Source[Action.Effect[_], NotUsed] =
+      context: ActionContext): Source[AbstractAction.Effect[_], NotUsed] =
     callWithContext(context) { () =>
       handleStreamedOut(commandName, message)
     }
@@ -89,7 +92,7 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
    * @return
    *   The stream of messages to return.
    */
-  def handleStreamedOut(commandName: String, message: MessageEnvelope[Any]): Source[Action.Effect[_], NotUsed]
+  def handleStreamedOut(commandName: String, message: MessageEnvelope[Any]): Source[AbstractAction.Effect[_], NotUsed]
 
   /**
    * Handle a streamed in call.
@@ -106,7 +109,7 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
   final def handleStreamedIn(
       commandName: String,
       stream: Source[MessageEnvelope[Any], NotUsed],
-      context: ActionContext): Action.Effect[_] =
+      context: ActionContext): AbstractAction.Effect[_] =
     callWithContext(context) { () =>
       handleStreamedIn(commandName, stream)
     }
@@ -121,7 +124,7 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
    * @return
    *   A future of the message to return.
    */
-  def handleStreamedIn(commandName: String, stream: Source[MessageEnvelope[Any], NotUsed]): Action.Effect[_]
+  def handleStreamedIn(commandName: String, stream: Source[MessageEnvelope[Any], NotUsed]): AbstractAction.Effect[_]
 
   /**
    * Handle a full duplex streamed in call.
@@ -138,7 +141,7 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
   final def handleStreamed(
       commandName: String,
       stream: Source[MessageEnvelope[Any], NotUsed],
-      context: ActionContext): Source[Action.Effect[_], NotUsed] =
+      context: ActionContext): Source[AbstractAction.Effect[_], NotUsed] =
     callWithContext(context) { () =>
       handleStreamed(commandName, stream)
     }
@@ -155,7 +158,7 @@ abstract class ActionRouter[A <: Action](protected val action: A) {
    */
   def handleStreamed(
       commandName: String,
-      stream: Source[MessageEnvelope[Any], NotUsed]): Source[Action.Effect[_], NotUsed]
+      stream: Source[MessageEnvelope[Any], NotUsed]): Source[AbstractAction.Effect[_], NotUsed]
 
   private def callWithContext[T](context: ActionContext)(func: () => T) = {
     // only set, never cleared, to allow access from other threads in async callbacks in the action

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
@@ -136,7 +136,7 @@ private[javasdk] final class ActionsImpl(
   private def effectToResponse(
       service: ActionService,
       command: ActionCommand,
-      effect: Action.Effect[_],
+      effect: AbstractAction.Effect[_],
       messageCodec: MessageCodec): Future[ActionResponse] = {
     import ActionEffectImpl._
     effect match {

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/workflow/WorkflowImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/workflow/WorkflowImpl.scala
@@ -72,7 +72,6 @@ import java.util.Optional
 import scala.jdk.OptionConverters._
 
 import kalix.javasdk.workflow.AbstractWorkflow
-import kalix.javasdk.workflow.Workflow
 import kalix.javasdk.workflow.AbstractWorkflow.WorkflowDef
 import kalix.javasdk.workflow.WorkflowContext
 import kalix.javasdk.workflow.WorkflowOptions

--- a/sdk/java-sdk-protobuf/src/test/java/kalix/javasdk/workflow/TransferWorkflowRouter.java
+++ b/sdk/java-sdk-protobuf/src/test/java/kalix/javasdk/workflow/TransferWorkflowRouter.java
@@ -26,7 +26,7 @@ public class TransferWorkflowRouter extends WorkflowRouter<MoneyTransferApi.Stat
   }
 
   @Override
-  public Workflow.Effect handleCommand(String commandName, MoneyTransferApi.State state, Object command, CommandContext context) {
+  public AbstractWorkflow.Effect handleCommand(String commandName, MoneyTransferApi.State state, Object command, CommandContext context) {
     switch (commandName) {
       case "Start":
         return workflow().start((MoneyTransferApi.Transfer) command);

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/action/Action.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/action/Action.java
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package kalix.javasdk.impl;
+package kalix.javasdk.action;
 
-import kalix.javasdk.action.AbstractAction;
-import kalix.javasdk.action.ActionCreationContext;
-import kalix.javasdk.impl.action.ActionRouter;
+import kalix.javasdk.client.ComponentClient;
+import kalix.spring.KalixClient;
 
-/**
- * Low level interface to implement {@link AbstractAction} components.
- *
- * <p>Generally, this should not be needed, instead, a class extending a generated abstract {@link
- * AbstractAction} should be used.
- */
-public interface ActionFactory {
-  ActionRouter<?> create(ActionCreationContext context);
+public class Action extends AbstractAction {
+
+    private KalixClient kalixClient;
+
+    public ComponentClient componentClient() {
+        return new ComponentClient(kalixClient);
+    }
 }

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/workflow/Workflow.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/workflow/Workflow.java
@@ -17,6 +17,8 @@
 package kalix.javasdk.workflow;
 
 import akka.annotation.ApiMayChange;
+import kalix.javasdk.client.ComponentClient;
+import kalix.spring.KalixClient;
 
 /**
  * Workflows are stateful components and are defined by a set of steps and transitions between them.
@@ -38,6 +40,7 @@ import akka.annotation.ApiMayChange;
 @ApiMayChange
 public abstract class Workflow<S> extends AbstractWorkflow<S> {
 
+  private KalixClient kalixClient;
   /**
    * Start a step definition with a given step name.
    *
@@ -47,4 +50,9 @@ public abstract class Workflow<S> extends AbstractWorkflow<S> {
   public StepBuilder step(String name) {
     return new StepBuilder(name);
   }
+
+  public ComponentClient componentClient() {
+    return new ComponentClient(kalixClient);
+  }
+
 }

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/ComponentDescriptorFactory.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/ComponentDescriptorFactory.scala
@@ -19,6 +19,7 @@ package kalix.javasdk.impl
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Method
 import java.lang.reflect.ParameterizedType
+
 import kalix.DirectDestination
 import kalix.DirectSource
 import kalix.EventDestination
@@ -28,6 +29,7 @@ import kalix.MethodOptions
 import kalix.ServiceEventing
 import kalix.ServiceEventingOut
 import kalix.ServiceOptions
+import kalix.javasdk.action.AbstractAction
 import kalix.javasdk.action.Action
 import kalix.javasdk.annotations.Acl
 import kalix.javasdk.annotations.EntityType
@@ -96,7 +98,7 @@ private[impl] object ComponentDescriptorFactory {
   def hasActionOutput(javaMethod: Method): Boolean = {
     if (javaMethod.isPublic) {
       javaMethod.getGenericReturnType match {
-        case p: ParameterizedType => p.getRawType.equals(classOf[Action.Effect[_]])
+        case p: ParameterizedType => p.getRawType.equals(classOf[AbstractAction.Effect[_]])
         case _                    => false
       }
     } else {

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/action/ActionEffectImpl.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/action/ActionEffectImpl.scala
@@ -24,14 +24,14 @@ import kalix.scalasdk.{ DeferredCall, Metadata, SideEffect }
 import kalix.scalasdk.action.Action
 import kalix.scalasdk.impl.ScalaDeferredCallAdapter
 import kalix.scalasdk.impl.ScalaSideEffectAdapter
-
 import io.grpc.Status
+import kalix.javasdk.action.AbstractAction
 
 private[scalasdk] object ActionEffectImpl {
 
   sealed abstract class PrimaryEffect[T] extends Action.Effect[T] {
 
-    def toJavaSdk: javasdk.action.Action.Effect[T]
+    def toJavaSdk: AbstractAction.Effect[T]
 
     override def addSideEffect(sideEffects: SideEffect*): Action.Effect[T] =
       withSideEffects(internalSideEffects() ++ sideEffects)
@@ -65,7 +65,7 @@ private[scalasdk] object ActionEffectImpl {
     protected def withSideEffects(sideEffects: Seq[SideEffect]): AsyncEffect[T] =
       copy(internalSideEffects = sideEffects)
 
-    private def convertEffect(effect: Action.Effect[T]): Future[javasdk.action.Action.Effect[T]] = {
+    private def convertEffect(effect: Action.Effect[T]): Future[AbstractAction.Effect[T]] = {
       effect match {
         case eff: AsyncEffect[T] =>
           // FIXME? the Future may wrap another AsyncEffect.

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowAdapters.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowAdapters.scala
@@ -44,7 +44,7 @@ import kalix.scalasdk.workflow.WorkflowOptions
 import kalix.scalasdk.workflow.WorkflowProvider
 
 private[scalasdk] final class JavaWorkflowAdapter[S >: Null](scalaSdkWorkflow: AbstractWorkflow[S])
-    extends javasdk.workflow.Workflow[S] {
+    extends javasdk.workflow.AbstractWorkflow[S] {
 
   override def emptyState(): S = scalaSdkWorkflow.emptyState
 
@@ -160,7 +160,7 @@ private[scalasdk] final class JavaWorkflowProviderAdapter[S >: Null, E <: Abstra
 }
 
 private[scalasdk] final class JavaWorkflowRouterAdapter[S >: Null](
-    javaSdkWorkflow: javasdk.workflow.Workflow[S],
+    javaSdkWorkflow: javasdk.workflow.AbstractWorkflow[S],
     scalaSdkRouter: WorkflowRouter[S, AbstractWorkflow[S]])
     extends javasdk.impl.workflow.WorkflowRouter[S, javasdk.workflow.AbstractWorkflow[S]](javaSdkWorkflow) {
 

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/LocalPersistenceSubscriber.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/LocalPersistenceSubscriber.java
@@ -21,7 +21,7 @@ import akka.stream.javadsl.Source;
 import kalix.javasdk.DeferredCall;
 import kalix.javasdk.JsonSupport;
 import kalix.javasdk.Metadata;
-import kalix.javasdk.action.Action;
+import kalix.javasdk.action.AbstractAction;
 import kalix.javasdk.action.ActionContext;
 import kalix.javasdk.action.ActionCreationContext;
 import kalix.javasdk.impl.GrpcDeferredCall;
@@ -32,7 +32,7 @@ import com.example.Components;
 import com.example.ComponentsImpl;
 import com.google.protobuf.Any;
 
-public class LocalPersistenceSubscriber extends Action {
+public class LocalPersistenceSubscriber extends AbstractAction {
 
   // FIXME should come from generated Abstract base class
   protected final Components components() {
@@ -41,18 +41,18 @@ public class LocalPersistenceSubscriber extends Action {
 
   public LocalPersistenceSubscriber(ActionCreationContext creationContext) {}
 
-  public Action.Effect<LocalPersistenceEventing.Response> processEventOne(
+  public AbstractAction.Effect<LocalPersistenceEventing.Response> processEventOne(
       LocalPersistenceEventing.EventOne eventOne) {
     return convert(actionContext(), eventOne.getStep());
   }
 
-  public Source<Action.Effect<LocalPersistenceEventing.Response>, NotUsed> processEventTwo(
+  public Source<AbstractAction.Effect<LocalPersistenceEventing.Response>, NotUsed> processEventTwo(
       LocalPersistenceEventing.EventTwo eventTwo) {
     ActionContext context = actionContext();
     return Source.from(eventTwo.getStepList()).map(step -> convert(context, step));
   }
 
-  public Action.Effect<LocalPersistenceEventing.Response> processAnyEvent(Any any) {
+  public AbstractAction.Effect<LocalPersistenceEventing.Response> processAnyEvent(Any any) {
     JsonMessage jsonMessage = JsonSupport.decodeJson(JsonMessage.class, any);
     return effects()
         .reply(
@@ -62,13 +62,13 @@ public class LocalPersistenceSubscriber extends Action {
                 .build());
   }
 
-  public Action.Effect<LocalPersistenceEventing.Response> processValueOne(
+  public AbstractAction.Effect<LocalPersistenceEventing.Response> processValueOne(
       LocalPersistenceEventing.ValueOne valueOne) {
     ActionContext context = actionContext();
     return convert(context, valueOne.getStep());
   }
 
-  public Source<Action.Effect<LocalPersistenceEventing.Response>, NotUsed> processValueTwo(
+  public Source<AbstractAction.Effect<LocalPersistenceEventing.Response>, NotUsed> processValueTwo(
       LocalPersistenceEventing.ValueTwo valueTwo) {
     ActionContext context = actionContext();
     return Source.from(valueTwo.getStepList()).map(step -> convert(context, step));
@@ -94,7 +94,7 @@ public class LocalPersistenceSubscriber extends Action {
                 .build());
   }
 
-  private Action.Effect<LocalPersistenceEventing.Response> convert(
+  private AbstractAction.Effect<LocalPersistenceEventing.Response> convert(
       ActionContext context, LocalPersistenceEventing.ProcessStep step) {
     String id = context.eventSubject().orElse("");
     if (step.hasReply()) {

--- a/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/LocalPersistenceSubscriberRouter.java
+++ b/tck/java-tck/src/main/java/kalix/javasdk/tck/model/localpersistenceeventing/LocalPersistenceSubscriberRouter.java
@@ -18,7 +18,7 @@ package kalix.javasdk.tck.model.localpersistenceeventing;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
-import kalix.javasdk.action.Action;
+import kalix.javasdk.action.AbstractAction;
 import kalix.javasdk.action.MessageEnvelope;
 import kalix.javasdk.impl.action.ActionRouter;
 import kalix.tck.model.eventing.LocalPersistenceEventing;
@@ -31,7 +31,7 @@ public class LocalPersistenceSubscriberRouter extends ActionRouter<LocalPersiste
   }
 
   @Override
-  public Action.Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
+  public AbstractAction.Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
     switch (commandName) {
       case "ProcessEventOne":
         return action().processEventOne((LocalPersistenceEventing.EventOne) message.payload());
@@ -54,16 +54,16 @@ public class LocalPersistenceSubscriberRouter extends ActionRouter<LocalPersiste
   }
 
   @Override
-  public Source<Action.Effect<?>, NotUsed> handleStreamedOut(
+  public Source<AbstractAction.Effect<?>, NotUsed> handleStreamedOut(
       String commandName, MessageEnvelope<Object> message) {
     switch (commandName) {
       case "ProcessEventTwo":
-        return (Source<Action.Effect<?>, NotUsed>)
+        return (Source<AbstractAction.Effect<?>, NotUsed>)
             (Object)
                 action().processEventTwo((LocalPersistenceEventing.EventTwo) message.payload());
 
       case "ProcessValueTwo":
-        return (Source<Action.Effect<?>, NotUsed>)
+        return (Source<AbstractAction.Effect<?>, NotUsed>)
             (Object)
                 action().processValueTwo((LocalPersistenceEventing.ValueTwo) message.payload());
 
@@ -73,13 +73,13 @@ public class LocalPersistenceSubscriberRouter extends ActionRouter<LocalPersiste
   }
 
   @Override
-  public Action.Effect<?> handleStreamedIn(
+  public AbstractAction.Effect<?> handleStreamedIn(
       String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
     throw new ActionRouter.HandlerNotFound(commandName);
   }
 
   @Override
-  public Source<Action.Effect<?>, NotUsed> handleStreamed(
+  public Source<AbstractAction.Effect<?>, NotUsed> handleStreamed(
       String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
     throw new ActionRouter.HandlerNotFound(commandName);
   }


### PR DESCRIPTION
Still draft because running it as an experiment for now. 

Workflow is expected to be used only from the code-first SDK. Therefore it moves into that package. 

A field for the `kalixClient` is added to it and set via reflection when we construct the class.

The `componentClient()` method is then directly accessible to the Workflow and we can pass in that method a call context with the tracing much like we do in other places.

The same can be done for Actions.