### PR TITLE
chore: update javadoc to reflect implementation

### DIFF
--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/annotations/TypeName.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/annotations/TypeName.java
@@ -22,10 +22,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to assign a logical type name to persisted events.
+ * Annotation to assign a logical type name to events.
  *
  * Kalix needs to identify each event in order to deliver them to the right event handlers.
- * If a logical type name isn't specified, Kalix will use the non-qualified class name.
+ * If a logical type name isn't specified, Kalix will use the full-qualified class name.
  *
  * Once an event is persisted in Kalix, you won't be able to rename your class if no logical type name 
  * has been specified, as Kalix won't be able to recognize previously persisted events. 
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
 public @interface TypeName {
 
   /** Logical type name for the annotated type.
-   * If missing (or defined as Empty String), the non-qualified class name will be used.
+   * If missing (or defined as Empty String), the full-qualified class name will be used.
    */
   String value() default "";
 }

--- a/sdk/java-sdk-spring/src/main/java/kalix/javasdk/annotations/TypeName.java
+++ b/sdk/java-sdk-spring/src/main/java/kalix/javasdk/annotations/TypeName.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * Annotation to assign a logical type name to events.
  *
  * Kalix needs to identify each event in order to deliver them to the right event handlers.
- * If a logical type name isn't specified, Kalix will use the full-qualified class name.
+ * If a logical type name isn't specified, Kalix will use the fully qualified class name.
  *
  * Once an event is persisted in Kalix, you won't be able to rename your class if no logical type name 
  * has been specified, as Kalix won't be able to recognize previously persisted events. 
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
 public @interface TypeName {
 
   /** Logical type name for the annotated type.
-   * If missing (or defined as Empty String), the full-qualified class name will be used.
+   * If missing (or defined as Empty String), the fully qualified class name will be used.
    */
   String value() default "";
 }


### PR DESCRIPTION
Leftover from https://github.com/lightbend/kalix-jvm-sdk/pull/1562

We moved back to full-qualified class name but didn't change the javadoc for the TypeName annotation.

Also removed the word 'persisted' from the first line. It's not only about persisted events, but also events coming from a topic.