### PR TITLE
Maven publishing (Take 7)

### DIFF
--- a/.github/publish-maven.sh
+++ b/.github/publish-maven.sh
@@ -28,7 +28,10 @@ cat <<EOF >~/.m2/settings.xml
   </servers>
   <profiles>
     <profile>
-      <id>release</id>
+      <id>ossrh</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <gpg.passphrase>${PGP_PASSPHRASE}</gpg.passphrase>
       </properties>


### PR DESCRIPTION
I'm not convinced this is the right path, but the profile name and the repository IDs were the same before. Also, this enables the `ossrh` profile as default additionally to `release`, enabled from the command line.