### PR TITLE
Extracting the SDK version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2.1
+
+jobs:
+  checks:
+    description: "Checks"
+    docker:
+      - image: circleci/openjdk:11
+    steps:
+      - run:
+          command: echo "Dummy check as PR validation moved to the GH workflow"
+
+workflows:
+  CI:
+    jobs:
+      - checks

--- a/.github/determine-sdk-version.sh
+++ b/.github/determine-sdk-version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Extracting version from sbt build"
+sbt --client --no-colors "print coreSdk/version" > sdk-version-raw.txt
+# debugging help
+echo "----"
+cat sdk-version-raw.txt
+echo "----"
+cat sdk-version-raw.txt | tail -n 3 | head -n 1 | sed $'s/\033\[[0-9;]*m//g' > sdk-version.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,14 @@ jobs:
         with:
           jvm: temurin:1.17.0.5
 
+      - name: Determine SDK version
+        id: determine_sdk_version
+        run: |-
+          .github/determine-sdk-version.sh
+          SDK_VERSION="$(cat sdk-version.txt)"
+          echo "SDK version: '${SDK_VERSION}'"
+          echo "sdk_version=${SDK_VERSION}" >> $GITHUB_OUTPUT
+
       - name: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
@@ -50,6 +58,7 @@ jobs:
       - name: mvn deploy
         run: ./.github/publish-maven.sh
         env:
+          SDK_VERSION: ${{ steps.determine_sdk_version.outputs.sdk_version }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           PUBLISH_USER: ${{ secrets.PUBLISH_USER }}

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -32,13 +32,10 @@ jobs:
       - name: Determine SDK version
         id: determine_sdk_version
         run: |-
-          echo "Extracting version from sbt build"
-          sbt --client --no-colors "print coreSdk/version" > version.txt
-          # debugging help
-          echo "----"
-          cat version.txt
-          echo "----"
-          echo "sdk_version=$(cat version.txt | tail -n 3 | head -n 1 | tr -d '\n')" >> $GITHUB_OUTPUT
+          .github/determine-sdk-version.sh
+          SDK_VERSION="$(cat sdk-version.txt)"
+          echo "SDK version: '${SDK_VERSION}'"
+          echo "sdk_version=${SDK_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Create PR to update all sdk versions (samples, sbt and maven)
         env:


### PR DESCRIPTION
- Add an empty CircleCI workflow (until this becomes part of `main`)
- Yet another take on SDK version extraction (Maven publish still failed with an invisible escape character)