### PR TITLE
fix: kalix-spring-boot-parent publishing

### DIFF
--- a/.github/publish-maven.sh
+++ b/.github/publish-maven.sh
@@ -31,18 +31,14 @@ cd maven-java
 
 # update poms with the version extracted from sbt dynver
 mvn --quiet --batch-mode versions:set -DnewVersion=${SDK_VERSION}
-  (
+
+  ( # also needs to change kalix-sdk.version in parent pom
     cd kalix-java-protobuf-parent
-    # also needs to change kalix-sdk.version in parent pom
     sed -i.bak "s/<kalix-sdk.version>\(.*\)<\/kalix-sdk.version>/<kalix-sdk.version>$SDK_VERSION<\/kalix-sdk.version>/" pom.xml
   )
 
-  ( # special case for parent pom, version:set only changes project sharing the same parent
-    # kalix-spring-boot-parent is special because its parent is spring-boot-starter-parent
+  ( # also needs to change kalix-sdk.version in parent pom
     cd kalix-spring-boot-parent
-    mvn versions:set -DnewVersion=$SDK_VERSION
-
-    # also needs to change kalix-sdk.version in parent pom
     sed -i.bak "s/<kalix-sdk.version>\(.*\)<\/kalix-sdk.version>/<kalix-sdk.version>$SDK_VERSION<\/kalix-sdk.version>/" pom.xml
   )
 

--- a/maven-java/kalix-spring-boot-parent/pom.xml
+++ b/maven-java/kalix-spring-boot-parent/pom.xml
@@ -5,10 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.4</version>
-        <relativePath />
+        <groupId>io.kalix</groupId>
+        <artifactId>kalix-maven-java</artifactId>
+        <version>1.4.1</version>
     </parent>
     
     <!-- it has spring-boot-starter as parent, but groupId remains io.kalix -->
@@ -28,7 +27,6 @@
         <!-- archetype need to override kalixContainerRegistry and kalixOrganization -->
         <kalixContainerRegistry>kcr.us-east-1.kalix.io</kalixContainerRegistry>
         <kalixOrganization>acme</kalixOrganization>
-
 
         <dockerImage>${kalixContainerRegistry}/${kalixOrganization}/${project.artifactId}</dockerImage>
         <dockerTag>${project.version}-${build.timestamp}</dockerTag>
@@ -281,6 +279,19 @@
             </build>
         </profile>
     </profiles>
+
+    <dependencyManagement>
+        <dependencies>
+           <dependency>
+               <groupId>org.springframework.boot</groupId>
+               <artifactId>spring-boot-dependencies</artifactId>
+               <version>3.2.4</version>
+               <type>pom</type>
+               <scope>import</scope>
+           </dependency>
+       </dependencies>
+   </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.kalix</groupId>

--- a/publishLocally.sh
+++ b/publishLocally.sh
@@ -13,20 +13,14 @@ sbt 'publishM2; publishLocal'
   cd maven-java
   mvn versions:set -DnewVersion=$SDK_VERSION
   
-  (
+  ( # also needs to change kalix-sdk.version in parent pom
     cd kalix-java-protobuf-parent
-
-    # also needs to change kalix-sdk.version in parent pom
     sed -i.bak "s/<kalix-sdk.version>\(.*\)<\/kalix-sdk.version>/<kalix-sdk.version>$SDK_VERSION<\/kalix-sdk.version>/" pom.xml
     rm pom.xml.bak
   )
 
-  ( # special case for parent pom, version:set only changes project sharing the same parent
-    # kalix-spring-boot-parent is special because its parent is spring-boot-starter-parent
+  ( # also needs to change kalix-sdk.version in parent pom
     cd kalix-spring-boot-parent
-    mvn versions:set -DnewVersion=$SDK_VERSION
-
-    # also needs to change kalix-sdk.version in parent pom
     sed -i.bak "s/<kalix-sdk.version>\(.*\)<\/kalix-sdk.version>/<kalix-sdk.version>$SDK_VERSION<\/kalix-sdk.version>/" pom.xml
     rm pom.xml.bak
   )


### PR DESCRIPTION
kalix-spring-boot-parent was not being published and that was related to the fact that it was not sharing the same pom parent pom as the other maven project we have. 

This PR fix it by making full member of the Kalix maven projects and the Spring Boot Starter pom is removed and we only pull in the Spring BOM instead. 

Did some local tests and working as expected. In follow up PR I will change all the samples to use the new parent pom and then we will have more test running and building with it.