### PR TITLE
fix: remove bogus plugin re-declaration

### DIFF
--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -112,10 +112,6 @@
             <artifactId>maven-resources-plugin</artifactId>
             <version>3.2.0</version>
           </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-          </plugin>  
         </plugins>
       </build>
     </profile>

--- a/publishLocally.sh
+++ b/publishLocally.sh
@@ -25,17 +25,17 @@ sbt 'publishM2; publishLocal'
     rm pom.xml.bak
   )
 
-  
-
   mvn clean install
 
   # cleanup
   rm pom.xml.versionsBackup
   rm */pom.xml.versionsBackup
 
-  # revert
-  git checkout pom.xml
-  git checkout */pom.xml
+  # revert, but only we didn't request to keep the modified files
+  if [ "$1" != "--keep" ]; then
+    git checkout pom.xml
+    git checkout */pom.xml
+  fi
 )
 
 


### PR DESCRIPTION
Release didn't work because we were adding the plugin twice and the second addition was overwriting the settings we needed. 

