### PR TITLE
feat: ease build for multi-platform images

### DIFF
--- a/maven-java/kalix-java-protobuf-parent/pom.xml
+++ b/maven-java/kalix-java-protobuf-parent/pom.xml
@@ -32,6 +32,7 @@
         <dockerTag>${project.version}-${build.timestamp}</dockerTag>
 
         <docker.base.image>docker.io/library/eclipse-temurin:21.0.2_13-jre-jammy</docker.base.image>
+        <docker.platform>linux/amd64</docker.platform>
 
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <java.version>21</java.version>
@@ -172,7 +173,7 @@
                             <!-- Base Docker image which contains jre-->
                             <from>${docker.base.image}</from>
                             <createImageOptions>
-                            <platform>linux/amd64</platform>
+                                <platform>${docker.platform}</platform>
                             </createImageOptions>
                             <tags>
                             <!-- tag for generated image -->

--- a/maven-java/kalix-spring-boot-parent/pom.xml
+++ b/maven-java/kalix-spring-boot-parent/pom.xml
@@ -32,6 +32,7 @@
         <dockerTag>${project.version}-${build.timestamp}</dockerTag>
 
         <docker.base.image>docker.io/library/eclipse-temurin:21.0.2_13-jre-jammy</docker.base.image>
+        <docker.platform>linux/amd64</docker.platform>
 
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <java.version>21</java.version>
@@ -133,7 +134,7 @@
                                     <!-- Base Docker image which contains jre-->
                                     <from>${docker.base.image}</from>
                                     <createImageOptions>
-                                        <platform>linux/amd64</platform>
+                                        <platform>${docker.platform}</platform>
                                     </createImageOptions>
                                     <tags>
                                         <!-- tag for generated image -->


### PR DESCRIPTION
On top of #2122 

Make it easy to build arm64 images. 

This will become more common when using multi-service tests with user service containers. 
Not yet documenting it, because my main goal for now is to have it in place to ease my own debugging.