### PR TITLE
bump: setup-java action 4.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,8 +284,8 @@ jobs:
 
       - name: Set up JDK 21
         # https://github.com/actions/setup-java/releases/
-        # v3.11.0
-        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+        # v4.2.1
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
Use a Node 20-based version.

References
- https://github.com/actions/setup-java/releases
