### PR TITLE
feat: expose underlying Akka version correctly

### DIFF
--- a/sbt-plugin/src/main/scala/kalix/sbt/KalixPlugin.scala
+++ b/sbt-plugin/src/main/scala/kalix/sbt/KalixPlugin.scala
@@ -34,8 +34,6 @@ object KalixPlugin extends AutoPlugin {
     val rootPackage = settingKey[Option[String]](
       "A root scala package to use for generated common classes such as Main, by default auto detected from protobuf files")
 
-    val akkaVersion = settingKey[String]("Akka core modules version")
-
     val runAll = inputKey[Unit]("Run all")
   }
 
@@ -44,6 +42,7 @@ object KalixPlugin extends AutoPlugin {
 
   val KalixSdkVersion = BuildInfo.version
   val KalixProtocolVersion = BuildInfo.protocolVersion
+  val AkkaVersion = BuildInfo.akkaVersion
 
   private val dockerComposeKey = "-Dkalix.dev-mode.docker-compose-file="
   private val disableDockerCompose = dockerComposeKey + "none"
@@ -62,10 +61,6 @@ object KalixPlugin extends AutoPlugin {
         "io.kalix" % "kalix-sdk-protocol" % KalixProtocolVersion % "protobuf-src",
         "com.google.protobuf" % "protobuf-java" % "3.17.3" % "protobuf",
         "io.kalix" %% "kalix-scala-sdk-protobuf-testkit" % KalixSdkVersion % Test),
-
-      // -------------------------------------------------------------------------------------------
-      // expose Akka version (so that users may refer to it when depending on the Akka Stream testkit)
-      akkaVersion := BuildInfo.akkaVersion,
 
       // -------------------------------------------------------------------------------------------
       // run task


### PR DESCRIPTION
The Akka version should not be a exposed as a setting but just be a boring value.

References
- #2125 
