### PR TITLE
feat: support scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,35 +757,19 @@ jobs:
           cd
           tar -xf dependencies.tar.gz
 
-      - name: sbt Test/compile Scala 2.13
+      - name: sbt Test/compile
         env:
           DIR: ${{ matrix.sample }}
         run: |-
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
+          echo "==== Testing with Scala 2.13 ===="
           sbt --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! Test/compile'
-
-      - name: sbt test Scala 2.13
-        env:
-          DIR: ${{ matrix.sample }}
-          PRE_CMD: ${{ matrix.pre_cmd }}
-        run: |-
-          export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
-          cd samples/${DIR}
-          ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! test'
-
-      - name: sbt Test/compile Scala 3
-        env:
-          DIR: ${{ matrix.sample }}
-        run: |-
-          export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
-          cd samples/${DIR}
-          echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
+          echo "==== Testing with Scala 3 ===="
           sbt --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! Test/compile'
 
-      - name: sbt test Scala 3
+      - name: sbt test
         if: matrix.test
         env:
           DIR: ${{ matrix.sample }}
@@ -794,6 +778,9 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
+          echo "==== Testing with Scala 2.13 ===="
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! test'
+          echo "==== Testing with Scala 3 ===="
           sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! test'
 
       - name: rm & sbt Test/compile
@@ -802,7 +789,8 @@ jobs:
         run: |-
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
-          echo "==== Verifying that generated unmanaged sources compile ===="
+          echo "==== Verifying that generated unmanaged sources compile with Scala 2.13 ===="
           rm -rf src/main/scala src/test/scala src/it/scala
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! Test/compile'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION +Test/compile
+          echo "==== Verifying that generated unmanaged sources compile with Scala 3 ===="
           sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! Test/compile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,7 +770,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
-          sbt --client -Dkalix-sdk.version=$SDK_VERSION '++${SCALA_213_VERSION}! Test/compile'
+          sbt --client -Dkalix-sdk.version=$SDK_VERSION '++$SCALA_213_VERSION! Test/compile'
 
       - name: sbt test Scala 2.13
         if: matrix.test
@@ -781,7 +781,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++${SCALA_213_VERSION}! test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++$SCALA_213_VERSION! test'
 
       - name: sbt Test/compile Scala 3
         env:
@@ -790,7 +790,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
-          sbt --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++${SCALA_3_VERSION}! Test/compile'
+          sbt --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++$SCALA_3_VERSION! Test/compile'
 
       - name: sbt test Scala 3
         if: matrix.test
@@ -801,7 +801,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++${SCALA_3_VERSION}! test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++$SCALA_3_VERSION! test'
 
       - name: rm & sbt Test/compile
         env:
@@ -811,5 +811,5 @@ jobs:
           cd samples/${DIR}
           echo "==== Verifying that generated unmanaged sources compile ===="
           rm -rf src/main/scala src/test/scala src/it/scala
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++${SCALA_213_VERSION}! Test/compile'
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++${SCALA_3_VERSION}! Test/compile'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++$SCALA_213_VERSION! Test/compile'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++$SCALA_3_VERSION! Test/compile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Build and publish artifacts and plugins
         id: build_sdk
         run: |-
-          sbt -Ddisable.apidocs=true publishM2 publishLocal
+          sbt -Ddisable.apidocs=true publishM2 +publishLocal
           # the SDK_VERSION is later used to run the maven tests (see below)
           .github/determine-sdk-version.sh
           SDK_VERSION="$(cat ~/kalix-sdk-version.txt)"
@@ -777,6 +777,17 @@ jobs:
           cd samples/${DIR}
           ${PRE_CMD}
           sbt  --client -Dkalix-sdk.version=$SDK_VERSION test
+
+      - name: sbt test scala 3
+        if: matrix.test
+        env:
+          DIR: ${{ matrix.sample }}
+          PRE_CMD: ${{ matrix.pre_cmd }}
+        run: |-
+          export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
+          cd samples/${DIR}
+          ${PRE_CMD}
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3!; test'
 
       - name: rm & sbt Test/compile
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,7 +787,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3 test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! test'
 
       - name: rm & sbt Test/compile
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -767,7 +767,7 @@ jobs:
           echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
           sbt --client -Dkalix-sdk.version=$SDK_VERSION Test/compile
 
-      - name: sbt test
+      - name: sbt test scala 2.13
         if: matrix.test
         env:
           DIR: ${{ matrix.sample }}
@@ -776,7 +776,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION test
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! test'
 
       - name: sbt test scala 3
         if: matrix.test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,6 @@ concurrency:
   group: samples-${{ github.ref }}
   cancel-in-progress: true
 
-# variable to be reused in jobs
-env:
-  SCALA_213_VERSION: 2.13.14
-  SCALA_3_VERSION: 3.3.3
-
 jobs:
   checks:
     name: Basic checks
@@ -681,7 +676,9 @@ jobs:
     name: sbt
     needs: check-samples-in-ci
     runs-on: ubuntu-22.04
-
+    env:
+      SCALA_213_VERSION: "2.13.14"
+      SCALA_3_VERSION: "3.3.3"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,9 +676,6 @@ jobs:
     name: sbt
     needs: check-samples-in-ci
     runs-on: ubuntu-22.04
-    env:
-      SCALA_213_VERSION: "2.13.14"
-      SCALA_3_VERSION: "3.3.3"
     strategy:
       fail-fast: false
       matrix:
@@ -767,10 +764,9 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
-          sbt --client -Dkalix-sdk.version=$SDK_VERSION '++$SCALA_213_VERSION! Test/compile'
+          sbt --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! Test/compile'
 
       - name: sbt test Scala 2.13
-        if: matrix.test
         env:
           DIR: ${{ matrix.sample }}
           PRE_CMD: ${{ matrix.pre_cmd }}
@@ -778,7 +774,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++$SCALA_213_VERSION! test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! test'
 
       - name: sbt Test/compile Scala 3
         env:
@@ -787,7 +783,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
-          sbt --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++$SCALA_3_VERSION! Test/compile'
+          sbt --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! Test/compile'
 
       - name: sbt test Scala 3
         if: matrix.test
@@ -798,7 +794,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++$SCALA_3_VERSION! test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! test'
 
       - name: rm & sbt Test/compile
         env:
@@ -808,5 +804,5 @@ jobs:
           cd samples/${DIR}
           echo "==== Verifying that generated unmanaged sources compile ===="
           rm -rf src/main/scala src/test/scala src/it/scala
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++$SCALA_213_VERSION! Test/compile'
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++$SCALA_3_VERSION! Test/compile'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! Test/compile'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! Test/compile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,7 @@ jobs:
           tar -xf dependencies.tar.gz
 
       - name: sbt Test/compile
+        if: matrix.test == false # only run this if not running the next step
         env:
           DIR: ${{ matrix.sample }}
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ concurrency:
   group: samples-${{ github.ref }}
   cancel-in-progress: true
 
+# variable to be reused in jobs
+env:
+  SCALA_213_VERSION: 2.13.14
+  SCALA_3_VERSION: 3.3.3
+
 jobs:
   checks:
     name: Basic checks
@@ -758,16 +763,16 @@ jobs:
           cd
           tar -xf dependencies.tar.gz
 
-      - name: sbt Test/compile
+      - name: sbt Test/compile Scala 2.13
         env:
           DIR: ${{ matrix.sample }}
         run: |-
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
-          sbt --client -Dkalix-sdk.version=$SDK_VERSION Test/compile
+          sbt --client -Dkalix-sdk.version=$SDK_VERSION '++${SCALA_213_VERSION}! Test/compile'
 
-      - name: sbt test scala 2.13
+      - name: sbt test Scala 2.13
         if: matrix.test
         env:
           DIR: ${{ matrix.sample }}
@@ -776,9 +781,18 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++${SCALA_213_VERSION}! test'
 
-      - name: sbt test scala 3
+      - name: sbt Test/compile Scala 3
+        env:
+          DIR: ${{ matrix.sample }}
+        run: |-
+          export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
+          cd samples/${DIR}
+          echo "Running sbt on ${DIR} with SDK version: '$SDK_VERSION'"
+          sbt --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++${SCALA_3_VERSION}! Test/compile'
+
+      - name: sbt test Scala 3
         if: matrix.test
         env:
           DIR: ${{ matrix.sample }}
@@ -787,7 +801,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++${SCALA_3_VERSION}! test'
 
       - name: rm & sbt Test/compile
         env:
@@ -797,4 +811,5 @@ jobs:
           cd samples/${DIR}
           echo "==== Verifying that generated unmanaged sources compile ===="
           rm -rf src/main/scala src/test/scala src/it/scala
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION Test/compile
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++${SCALA_213_VERSION}! Test/compile'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++${SCALA_3_VERSION}! Test/compile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,6 +791,6 @@ jobs:
           cd samples/${DIR}
           echo "==== Verifying that generated unmanaged sources compile with Scala 2.13 ===="
           rm -rf src/main/scala src/test/scala src/it/scala
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION +Test/compile
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION '++2.13.14! Test/compile'
           echo "==== Verifying that generated unmanaged sources compile with Scala 3 ===="
           sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3! Test/compile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,7 +787,7 @@ jobs:
           export SDK_VERSION=$(cat ~/kalix-sdk-version.txt)
           cd samples/${DIR}
           ${PRE_CMD}
-          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3!; test'
+          sbt  --client -Dkalix-sdk.version=$SDK_VERSION 'clean; ++3.3.3 test'
 
       - name: rm & sbt Test/compile
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,9 @@ def commonCompilerSettings: Seq[Setting[_]] =
 
 lazy val sharedScalacOptions =
   Seq("-feature",
-    "-unchecked",
+    "-unchecked")
    //FIXME re-add when we have fixed all warnings
-   "-Wunused:imports,privates,locals")
+   //"-Wunused:imports,privates,locals")
 
 lazy val scala2Options = sharedScalacOptions ++
   Seq("-Xfatal-warnings", // discipline only in Scala 2 for now

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val coreSdk = project
   .settings(disciplinedScalacSettings)
   .settings(
     name := "kalix-jvm-core-sdk",
-    crossPaths := false,
+    crossPaths := scalaVersion.value.startsWith("3."),
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
     crossScalaVersions := Dependencies.CrossScalaVersions,
@@ -87,7 +87,7 @@ lazy val javaSdkProtobuf = project
   .settings(disciplinedScalacSettings)
   .settings(
     name := "kalix-java-sdk-protobuf",
-    crossPaths := false,
+    crossPaths := scalaVersion.value.startsWith("3."),
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
     buildInfoKeys := Seq[BuildInfoKey](
@@ -136,7 +136,7 @@ lazy val javaSdkProtobufTestKit = project
   .settings(commonCompilerSettings)
   .settings(
     name := "kalix-java-sdk-protobuf-testkit",
-    crossPaths := false,
+    crossPaths := scalaVersion.value.startsWith("3."),
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
     buildInfoKeys := Seq[BuildInfoKey](
@@ -211,9 +211,6 @@ lazy val javaSdkSpring = project
       "java.lang"))
   .settings(inConfig(IntegrationTest)(JupiterPlugin.scopedSettings): _*)
   .settings(Dependencies.javaSdkSpring)
-//.settings(
-//  dependencyOverrides += "com.typesafe.akka" % "akka-http-core_3" % "10.6.1"
-//)
 
 lazy val javaSdkSpringTestKit = project
   .in(file("sdk/java-sdk-spring-testkit"))

--- a/build.sbt
+++ b/build.sbt
@@ -31,10 +31,14 @@ def commonCompilerSettings: Seq[Setting[_]] =
 lazy val sharedScalacOptions =
   Seq("-feature",
     "-unchecked",
-    "-Wunused:imports,privates,locals")
+   //FIXME re-add when we have fixed all warnings
+   "-Wunused:imports,privates,locals")
 
 lazy val scala2Options = sharedScalacOptions ++
   Seq("-Xfatal-warnings", // discipline only in Scala 2 for now
+    //"-Ytasty-reader",
+    //"-Xsource:3.0-migration",
+    //"-Xsource-features:case-apply-copy-access",
     "-Wconf:src=.*/target/.*:s",
     // silence warnings from generated sources
     "-Wconf:src=.*/src_managed/.*:s",
@@ -65,7 +69,7 @@ lazy val coreSdk = project
     crossPaths := false,
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
-    crossScalaVersions := Seq(Dependencies.ScalaVersion, Dependencies.Scala3Version),
+    crossScalaVersions := Dependencies.CrossScalaVersions,
     // Generate javadocs by just including non generated Java sources
     Compile / doc / sources := {
       val javaSourceDir = (Compile / javaSource).value.getAbsolutePath
@@ -93,7 +97,7 @@ lazy val javaSdkProtobuf = project
       "scalaVersion" -> scalaVersion.value,
       "akkaVersion" -> Dependencies.AkkaVersion),
     buildInfoPackage := "kalix.javasdk",
-    crossScalaVersions := Seq(Dependencies.ScalaVersion, Dependencies.Scala3Version),
+    crossScalaVersions := Dependencies.CrossScalaVersions,
     // Generate javadocs by just including non generated Java sources
     Compile / doc / sources := {
       val javaSourceDir = (Compile / javaSource).value.getAbsolutePath
@@ -139,6 +143,7 @@ lazy val javaSdkProtobufTestKit = project
       "runtimeVersion" -> Kalix.RuntimeVersion,
       "scalaVersion" -> scalaVersion.value),
     buildInfoPackage := "kalix.javasdk.testkit",
+    crossScalaVersions := Dependencies.CrossScalaVersions,
     // Generate javadocs by just including non generated Java sources
     Compile / doc / sources := {
       val javaSourceDir = (Compile / javaSource).value.getAbsolutePath
@@ -171,6 +176,8 @@ lazy val javaSdkSpring = project
     crossPaths := false,
     Compile / javacOptions ++= Seq("--release", "17"),
     Compile / scalacOptions ++= Seq("-release", "17"),
+    //crossScalaVersions := Dependencies.CrossScalaVersions,
+    scalaVersion := Dependencies.ScalaVersion,
     buildInfoKeys := Seq[BuildInfoKey](
       name,
       version,
@@ -202,6 +209,9 @@ lazy val javaSdkSpring = project
       "java.lang"))
   .settings(inConfig(IntegrationTest)(JupiterPlugin.scopedSettings): _*)
   .settings(Dependencies.javaSdkSpring)
+  //.settings(
+  //  dependencyOverrides += "com.typesafe.akka" % "akka-http-core_3" % "10.6.1"
+  //)
 
 lazy val javaSdkSpringTestKit = project
   .in(file("sdk/java-sdk-spring-testkit"))
@@ -332,7 +342,7 @@ lazy val scalaSdkProtobuf = project
       "protocolMinorVersion" -> Kalix.ProtocolVersionMinor,
       "scalaVersion" -> scalaVersion.value,
       "akkaVersion" -> Dependencies.AkkaVersion),
-    crossScalaVersions := Seq(Dependencies.ScalaVersion, Dependencies.Scala3Version),
+    crossScalaVersions := Dependencies.CrossScalaVersions,
     buildInfoPackage := "kalix.scalasdk",
     Compile / akkaGrpcGeneratedSources := Seq(AkkaGrpc.Server),
     Compile / akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Scala),
@@ -362,6 +372,7 @@ lazy val scalaSdkProtobufTestKit = project
       "protocolMajorVersion" -> Kalix.ProtocolVersionMajor,
       "protocolMinorVersion" -> Kalix.ProtocolVersionMinor,
       "scalaVersion" -> scalaVersion.value),
+    crossScalaVersions := Dependencies.CrossScalaVersions,
     buildInfoPackage := "kalix.scalasdk.testkit",
     inTask(doc)(
       Seq(
@@ -461,6 +472,7 @@ lazy val javaTck = project
     name := "kalix-tck-java-sdk",
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
+    crossScalaVersions := Dependencies.CrossScalaVersions,
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
     ReflectiveCodeGen.copyUnmanagedSources := true,
     Compile / mainClass := Some("kalix.javasdk.tck.JavaSdkTck"),
@@ -478,6 +490,7 @@ lazy val scalaTck = project
     name := "kalix-tck-scala-sdk",
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
+    crossScalaVersions := Dependencies.CrossScalaVersions,
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Scala),
     libraryDependencies ++= Seq(Dependencies.kalixSdkProtocol % "protobuf-src"),
     ReflectiveCodeGen.copyUnmanagedSources := true,
@@ -542,6 +555,7 @@ lazy val codegenJavaCompilationTest = project
   .settings(disciplinedScalacSettings)
   .settings(libraryDependencies ++= Seq(Dependencies.junit4))
   .settings(
+    scalaVersion := Dependencies.ScalaVersion,
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
     (publish / skip) := true,
     name := "kalix-codegen-java-compilation-tests",

--- a/build.sbt
+++ b/build.sbt
@@ -30,33 +30,29 @@ def commonCompilerSettings: Seq[Setting[_]] =
 
 lazy val sharedScalacOptions =
   Seq("-feature", "-unchecked")
-//FIXME re-add when we have fixed all warnings
-//"-Wunused:imports,privates,locals")
 
-lazy val scala2Options = sharedScalacOptions ++
-  Seq(
-    "-Xfatal-warnings", // discipline only in Scala 2 for now
-    //"-Ytasty-reader",
-    //"-Xsource:3.0-migration",
-    //"-Xsource-features:case-apply-copy-access",
-    "-Wconf:src=.*/target/.*:s",
-    // silence warnings from generated sources
-    "-Wconf:src=.*/src_managed/.*:s",
-    // silence warnings from deprecated protobuf fields
-    "-Wconf:src=.*/akka-grpc/.*:s")
+lazy val fatalWarnings = Seq(
+  "-Xfatal-warnings", // discipline only in Scala 2 for now
+  "-Wconf:src=.*/target/.*:s",
+  // silence warnings from generated sources
+  "-Wconf:src=.*/src_managed/.*:s",
+  // silence warnings from deprecated protobuf fields
+  "-Wconf:src=.*/akka-grpc/.*:s")
 
-lazy val scala213Options = scala2Options ++
-  Seq("-Ytasty-reader")
+lazy val scala212Options = sharedScalacOptions ++ fatalWarnings
+
+lazy val scala213Options = scala212Options ++
+  Seq("-Wunused:imports,privates,locals")
 
 // -Wconf configs will be available once https://github.com/scala/scala3/pull/20282 is merged and 3.3.4 is released
-lazy val scala3Options = sharedScalacOptions ++ Seq("-explain")
+lazy val scala3Options = sharedScalacOptions ++ Seq("-Wunused:imports,privates,locals")
 
 def disciplinedScalacSettings: Seq[Setting[_]] = {
   if (sys.props.get("kalix.no-discipline").isEmpty) {
     Seq(Compile / scalacOptions ++= {
       if (scalaVersion.value.startsWith("3.")) scala3Options
       else if (scalaVersion.value.startsWith("2.13")) scala213Options
-      else scala2Options
+      else scala212Options
     })
   } else Seq.empty
 }
@@ -69,6 +65,8 @@ lazy val coreSdk = project
   .settings(disciplinedScalacSettings)
   .settings(
     name := "kalix-jvm-core-sdk",
+    // only packages that are to be released with scala 3 should have the _3 appended
+    // i.e. java sdk package names should remain without suffix
     crossPaths := scalaVersion.value.startsWith("3."),
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
@@ -87,6 +85,8 @@ lazy val javaSdkProtobuf = project
   .settings(disciplinedScalacSettings)
   .settings(
     name := "kalix-java-sdk-protobuf",
+    // only packages that are to be released with scala 3 should have the _3 appended
+    // i.e. java sdk package names should remain without suffix
     crossPaths := scalaVersion.value.startsWith("3."),
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),
@@ -136,6 +136,8 @@ lazy val javaSdkProtobufTestKit = project
   .settings(commonCompilerSettings)
   .settings(
     name := "kalix-java-sdk-protobuf-testkit",
+    // only packages that are to be released with scala 3 should have the _3 appended
+    // i.e. java sdk package names should remain without suffix
     crossPaths := scalaVersion.value.startsWith("3."),
     Compile / javacOptions ++= Seq("--release", "11"),
     Compile / scalacOptions ++= Seq("-release", "11"),

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/KalixGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/KalixGenerator.scala
@@ -15,9 +15,5 @@ object KalixGenerator extends AbstractKalixGenerator {
 
   // FIXME #382 add reference to the runtime lib here
   override def suggestedDependencies: Seq[Artifact] = Seq(
-    Artifact(
-      BuildInfo.organization,
-      "kalix-scala-sdk-protobuf",
-      BuildInfo.version,
-      crossVersion = true))
+    Artifact(BuildInfo.organization, "kalix-scala-sdk-protobuf", BuildInfo.version, crossVersion = true))
 }

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/KalixGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/KalixGenerator.scala
@@ -17,7 +17,7 @@ object KalixGenerator extends AbstractKalixGenerator {
   override def suggestedDependencies: Seq[Artifact] = Seq(
     Artifact(
       BuildInfo.organization,
-      // FIXME determine scala version properly
-      "kalix-scala-sdk-protobuf" + "_2.13",
-      BuildInfo.version))
+      "kalix-scala-sdk-protobuf",
+      BuildInfo.version,
+      crossVersion = true))
 }

--- a/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/KalixGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/kalix/codegen/scalasdk/KalixGenerator.scala
@@ -15,5 +15,9 @@ object KalixGenerator extends AbstractKalixGenerator {
 
   // FIXME #382 add reference to the runtime lib here
   override def suggestedDependencies: Seq[Artifact] = Seq(
-    Artifact(BuildInfo.organization, "kalix-scala-sdk-protobuf", BuildInfo.version, crossVersion = true))
+    Artifact(
+      BuildInfo.organization,
+      "kalix-scala-sdk-protobuf",
+      BuildInfo.version,
+      crossVersion = true))
 }

--- a/devtools/src/main/scala/kalix/devtools/impl/TracingPortExtractor.scala
+++ b/devtools/src/main/scala/kalix/devtools/impl/TracingPortExtractor.scala
@@ -41,6 +41,7 @@ object TracingPortExtractor {
             .map(removeColon)
             .filter(isValidPort)
             .map(_.toInt)
+        case _ => None
       }
       .filter(_ > 0)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,16 +14,16 @@ object Dependencies {
   }
 
   // changing the Scala version of the Java SDK affects end users
-  val CrossScalaVersions = Seq("2.13.14", "3.3.3")
-  val ScalaVersion = CrossScalaVersions.head
+  val ScalaVersion = "2.13.14"
   val ScalaVersionForTooling = "2.12.19"
   val Scala3Version = "3.3.3"
+  val CrossScalaVersions = Seq(ScalaVersion, Scala3Version)
 
   val ProtobufVersion = // akka.grpc.gen.BuildInfo.googleProtobufVersion
     "3.21.12" // explicitly overriding the 3.21.1 version from Akka gRPC 2.1.6 (even though its build says 3.20.1)
 
-  val AkkaVersion = "2.9.2"
-  val AkkaHttpVersion = "10.6.1" // Note: should at least the Akka HTTP version required by Akka gRPC
+  val AkkaVersion = "2.9.3"
+  val AkkaHttpVersion = "10.6.3" // Note: should at least the Akka HTTP version required by Akka gRPC
   val ScalaTestVersion = "3.2.14"
   // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L31
   val JacksonVersion = "2.15.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,8 +14,10 @@ object Dependencies {
   }
 
   // changing the Scala version of the Java SDK affects end users
-  val ScalaVersion = "2.13.14"
+  val CrossScalaVersions = Seq("2.13.14", "3.3.3")
+  val ScalaVersion = CrossScalaVersions.head
   val ScalaVersionForTooling = "2.12.19"
+  val Scala3Version = "3.3.3"
 
   val ProtobufVersion = // akka.grpc.gen.BuildInfo.googleProtobufVersion
     "3.21.12" // explicitly overriding the 3.21.1 version from Akka gRPC 2.1.6 (even though its build says 3.20.1)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
-//addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 // even updated `akka-grpc.version` in pom.xml files
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.3")
@@ -13,6 +12,3 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
-// FIXME remove this
-addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.6.4")
-addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,11 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
+//addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 // even updated `akka-grpc.version` in pom.xml files
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.1")
+//addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.1")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.3")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
@@ -12,3 +14,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
+// FIXME remove this
+addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.6.4")
+addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,6 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 //addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 // even updated `akka-grpc.version` in pom.xml files
-//addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.1")
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.4.3")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/samples/scala-protobuf-customer-registry-quickstart/build.sbt
+++ b/samples/scala-protobuf-customer-registry-quickstart/build.sbt
@@ -4,7 +4,7 @@ organization := "customer"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-doc-snippets/build.sbt
+++ b/samples/scala-protobuf-doc-snippets/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-doc-snippets/src/test/scala/com/example/JwtIntegrationSpec.scala
+++ b/samples/scala-protobuf-doc-snippets/src/test/scala/com/example/JwtIntegrationSpec.scala
@@ -66,13 +66,13 @@ class JwtIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
 
   private def bearerTokenWith(claims: Map[String, String]): String = {
     // setting algorithm to none
-    val alg = Base64.getEncoder.encodeToString("""{"alg":"none"}""".getBytes); // <4>
+    val alg = Base64.getEncoder.encodeToString(s"""{"alg":"none"}""".getBytes); // <4>
 
     import spray.json.DefaultJsonProtocol._
-    val claimsJson: JsValue = claims.toJson
+    val claimsJson = s"${claims.toJson}"
 
     // no validation is done for integration tests, thus no valid signature required
-    s"$alg.${Base64.getEncoder.encodeToString(claimsJson.toString().getBytes)}" // <5>
+    s"$alg.${Base64.getEncoder.encodeToString(claimsJson.getBytes)}" // <5>
   }
   // end::jwt-util[]
 

--- a/samples/scala-protobuf-eventsourced-counter/build.sbt
+++ b/samples/scala-protobuf-eventsourced-counter/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-eventsourced-counter/build.sbt
+++ b/samples/scala-protobuf-eventsourced-counter/build.sbt
@@ -29,7 +29,8 @@ dockerBuildCommand := {
 ThisBuild / dynverSeparator := "-"
 
 Compile / scalacOptions ++= Seq(
-  "-release:21",
+  //FIXME why does this need to be removed?
+  //"-release:21",
   "-deprecation",
   "-feature",
   "-unchecked",

--- a/samples/scala-protobuf-eventsourced-counter/build.sbt
+++ b/samples/scala-protobuf-eventsourced-counter/build.sbt
@@ -29,8 +29,7 @@ dockerBuildCommand := {
 ThisBuild / dynverSeparator := "-"
 
 Compile / scalacOptions ++= Seq(
-  //FIXME why does this need to be removed?
-  //"-release:21",
+  "-release:21",
   "-deprecation",
   "-feature",
   "-unchecked",

--- a/samples/scala-protobuf-eventsourced-counter/src/main/scala/com/example/domain/Counter.scala
+++ b/samples/scala-protobuf-eventsourced-counter/src/main/scala/com/example/domain/Counter.scala
@@ -31,7 +31,7 @@ class Counter(context: EventSourcedEntityContext) extends AbstractCounter {
     if (increaseValue.value < 0) {
       effects.error("Value must be a zero or a positive number")
     } else {
-      val valIncrease = if (commandContext.metadata.get("myKey") == Some("myValue")){
+      val valIncrease = if (commandContext().metadata.get("myKey").contains("myValue")){
         ValueIncreased(2 * increaseValue.value) 
       } else {
         ValueIncreased(increaseValue.value)

--- a/samples/scala-protobuf-eventsourced-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
+++ b/samples/scala-protobuf-eventsourced-counter/src/test/scala/com/example/CounterServiceIntegrationSpec.scala
@@ -96,7 +96,7 @@ class CounterServiceIntegrationSpec
       counter.value shouldBe 15
 
       // verify message published to topic
-      val Message(decEvent, md): Message[Decreased] = eventsTopic.expectOneTyped
+      val Message(decEvent, md) = eventsTopic.expectOneTyped[Decreased]
       decEvent shouldBe Decreased(15)
       md.get("ce-type") should contain(classOf[Decreased].getName)
       md.get("Content-Type") should contain("application/protobuf")
@@ -107,8 +107,8 @@ class CounterServiceIntegrationSpec
       commandsTopic.publish(IncreaseValue(counterId, 4), counterId) // <4>
       commandsTopic.publish(DecreaseValue(counterId, 1), counterId)
 
-      val Message(incEvent, _): Message[Increased] = eventsTopic.expectOneTyped // <5>
-      val Message(decEvent, _): Message[Decreased] = eventsTopic.expectOneTyped
+      val Message(incEvent, _) = eventsTopic.expectOneTyped[Increased] // <5>
+      val Message(decEvent, _) = eventsTopic.expectOneTyped[Decreased]
       incEvent shouldBe Increased(4) // <6>
       decEvent shouldBe Decreased(1)
     }
@@ -127,7 +127,7 @@ class CounterServiceIntegrationSpec
 
       commandsTopic.publish(Message(increaseCmd, md)) // <4>
 
-      val Message(incEvent, actualMd): Message[Increased] = eventsTopicWithMeta.expectOneTyped // <5>
+      val Message(incEvent, actualMd) = eventsTopicWithMeta.expectOneTyped[Increased] // <5>
       incEvent shouldBe Increased(4)
       actualMd.get("Content-Type") should contain("application/protobuf") // <6>
       actualMd.asCloudEvent.subject should contain(counterId)

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/build.sbt
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-eventsourced-customer-registry/build.sbt
+++ b/samples/scala-protobuf-eventsourced-customer-registry/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-eventsourced-shopping-cart/build.sbt
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-fibonacci-action/build.sbt
+++ b/samples/scala-protobuf-fibonacci-action/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-first-service/build.sbt
+++ b/samples/scala-protobuf-first-service/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.example"
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-reliable-timers/build.sbt
+++ b/samples/scala-protobuf-reliable-timers/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-replicatedentity-examples/build.sbt
+++ b/samples/scala-protobuf-replicatedentity-examples/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/build.sbt
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-tracing/build.sbt
+++ b/samples/scala-protobuf-tracing/build.sbt
@@ -48,5 +48,5 @@ Compile / javacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M11" % Compile,
   "org.json4s" %% "json4s-native" % "4.1.0-M5"% Compile,
-  "org.scalatest" %% "scalatest" % "3.2.7" % Test
+  "org.scalatest" %% "scalatest" % "3.2.18" % Test
 )

--- a/samples/scala-protobuf-tracing/build.sbt
+++ b/samples/scala-protobuf-tracing/build.sbt
@@ -5,7 +5,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-tracing/src/main/scala/com/example/ControllerAction.scala
+++ b/samples/scala-protobuf-tracing/src/main/scala/com/example/ControllerAction.scala
@@ -47,6 +47,7 @@ class ControllerAction(creationContext: ActionCreationContext) extends AbstractC
     val request = quickRequest.get(uri"${url}/1")
     val response = request.send(Main.backend)
     response.map { response =>
+      import org.json4s.jvalue2extractable
       val post = JsonMethods.parse(response.body).extract[Post]
       MessageResponse(post.title)
     }

--- a/samples/scala-protobuf-tracing/src/main/scala/com/example/Main.scala
+++ b/samples/scala-protobuf-tracing/src/main/scala/com/example/Main.scala
@@ -24,7 +24,8 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     log.info("starting the Kalix service")
-    Runtime.getRuntime.addShutdownHook { new Thread(() => backend.close()) }
+    def close: Runnable = () => backend.close()
+    Runtime.getRuntime.addShutdownHook { new Thread(close) }
     createKalix().start()
   }
 }

--- a/samples/scala-protobuf-transfer-workflow-compensation/build.sbt
+++ b/samples/scala-protobuf-transfer-workflow-compensation/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-transfer-workflow-compensation/build.sbt
+++ b/samples/scala-protobuf-transfer-workflow-compensation/build.sbt
@@ -52,4 +52,4 @@ Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.12" % Test,
-  "org.scalamock" %% "scalamock" % "5.2.0" % Test)
+  "org.scalamock" %% "scalamock" % "6.0.0" % Test)

--- a/samples/scala-protobuf-transfer-workflow-compensation/src/main/scala/com/example/transfer/api/TransferWorkflow.scala
+++ b/samples/scala-protobuf-transfer-workflow-compensation/src/main/scala/com/example/transfer/api/TransferWorkflow.scala
@@ -40,7 +40,7 @@ class TransferWorkflow(context: WorkflowContext) extends AbstractTransferWorkflo
   override def definition: AbstractWorkflow.WorkflowDef[TransferState] = {
 
     val withdraw = step("withdraw")
-      .asyncCall { withdraw: Withdraw =>
+      .asyncCall { (withdraw: Withdraw) =>
         logger.info("Running withdraw step: " + withdraw)
         timers
           .cancel("acceptationTimout-" + currentState().transferId)
@@ -68,7 +68,7 @@ class TransferWorkflow(context: WorkflowContext) extends AbstractTransferWorkflo
 
     // tag::compensation[]
     val deposit = step("deposit")
-      .call { deposit: Deposit =>
+      .call { (deposit: Deposit) =>
         // end::compensation[]
         logger.info("Running deposit step: " + deposit)
         // tag::compensation[]

--- a/samples/scala-protobuf-transfer-workflow/build.sbt
+++ b/samples/scala-protobuf-transfer-workflow/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-transfer-workflow/build.sbt
+++ b/samples/scala-protobuf-transfer-workflow/build.sbt
@@ -52,4 +52,4 @@ Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.12" % Test,
-  "org.scalamock" %% "scalamock" % "5.2.0" % Test)
+  "org.scalamock" %% "scalamock" % "6.0.0" % Test)

--- a/samples/scala-protobuf-transfer-workflow/src/main/scala/com/example/transfer/api/TransferWorkflow.scala
+++ b/samples/scala-protobuf-transfer-workflow/src/main/scala/com/example/transfer/api/TransferWorkflow.scala
@@ -21,7 +21,7 @@ class TransferWorkflow(context: WorkflowContext) extends AbstractTransferWorkflo
   override def definition: AbstractWorkflow.WorkflowDef[TransferState] = {
 
     val withdraw = step("withdraw") // <1>
-      .call { withdraw: Withdraw =>
+      .call { (withdraw: Withdraw) =>
         val withdrawRequest = WithdrawRequest(withdraw.from, withdraw.amount)
         components.walletEntity.withdraw(withdrawRequest)
       } // <2>
@@ -33,7 +33,7 @@ class TransferWorkflow(context: WorkflowContext) extends AbstractTransferWorkflo
       }
 
     val deposit = step("deposit") // <1>
-      .call { deposit: Deposit =>
+      .call { (deposit: Deposit) =>
         val depositRequest = DepositRequest(deposit.to, deposit.amount)
         components.walletEntity.deposit(depositRequest)
       } // <4>

--- a/samples/scala-protobuf-validated/build.sbt
+++ b/samples/scala-protobuf-validated/build.sbt
@@ -6,7 +6,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-valueentity-counter/build.sbt
+++ b/samples/scala-protobuf-valueentity-counter/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-valueentity-counter/build.sbt
+++ b/samples/scala-protobuf-valueentity-counter/build.sbt
@@ -52,4 +52,4 @@ Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.12" % Test,
-  "org.scalamock" %% "scalamock" % "5.2.0" % Test)
+  "org.scalamock" %% "scalamock" % "6.0.0" % Test)

--- a/samples/scala-protobuf-valueentity-counter/src/main/scala/com/example/domain/Counter.scala
+++ b/samples/scala-protobuf-valueentity-counter/src/main/scala/com/example/domain/Counter.scala
@@ -35,7 +35,7 @@ class Counter(context: ValueEntityContext) extends AbstractCounter { // <1>
     if (command.value < 0) // <1>
       effects.error(s"Increase requires a positive value. It was [${command.value}].", Code.INVALID_ARGUMENT)
     else {
-      if (commandContext.metadata.get("myKey").contains("myValue")) {
+      if (commandContext().metadata.get("myKey").contains("myValue")) {
       val newState = currentState.copy(value = currentState.value + command.value*2)
       effects
         .updateState(newState) 

--- a/samples/scala-protobuf-valueentity-customer-registry/build.sbt
+++ b/samples/scala-protobuf-valueentity-customer-registry/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-valueentity-shopping-cart/build.sbt
+++ b/samples/scala-protobuf-valueentity-shopping-cart/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-valueentity-shopping-cart/build.sbt
+++ b/samples/scala-protobuf-valueentity-shopping-cart/build.sbt
@@ -52,4 +52,4 @@ Global / cancelable := false // ctrl-c
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.12" % Test,
-  "org.scalamock" %% "scalamock" % "5.2.0" % Test)
+  "org.scalamock" %% "scalamock" % "6.0.0" % Test)

--- a/samples/scala-protobuf-valueentity-shopping-cart/src/main/scala/com/example/shoppingcart/domain/ShoppingCart.scala
+++ b/samples/scala-protobuf-valueentity-shopping-cart/src/main/scala/com/example/shoppingcart/domain/ShoppingCart.scala
@@ -77,7 +77,7 @@ class ShoppingCart(context: ValueEntityContext) extends AbstractShoppingCart {
 
   override def removeCart(currentState: Cart, removeShoppingCart: shoppingcart.RemoveShoppingCart): ValueEntity.Effect[Empty] = {
     commandContext().metadata.get("Role") match {
-      case Some("Admin") => effects.deleteEntity.thenReply(Empty.defaultInstance)
+      case Some("Admin") => effects.deleteEntity().thenReply(Empty.defaultInstance)
       case any => effects.error("Only admin can remove the cart")
     }
   }

--- a/samples/scala-protobuf-valueentity-shopping-cart/src/test/scala/com/example/shoppingcart/ShoppingCartActionImplSpec.scala
+++ b/samples/scala-protobuf-valueentity-shopping-cart/src/test/scala/com/example/shoppingcart/ShoppingCartActionImplSpec.scala
@@ -44,7 +44,7 @@ class ShoppingCartActionImplSpec
         .when(*)
         .returns(Future.successful(Empty.defaultInstance))
       (mockShoppingCart.addItem _)
-        .when(where { li: AddLineItem => li.name == "eggplant"})
+        .when(where { (li: AddLineItem) => li.name == "eggplant"})
         .returns(Future.successful(Empty.defaultInstance))
       val mockRegistry = MockRegistry.withMock(mockShoppingCart) // <3>
 
@@ -55,10 +55,10 @@ class ShoppingCartActionImplSpec
       // end::createPrePopulated[]
       cartId.map { newCart =>
         (mockShoppingCart.create _)
-          .verify(where { c: CreateCart => c.cartId == newCart.reply.cartId })
+          .verify(where { (c: CreateCart) => c.cartId == newCart.reply.cartId })
           .once()
         (mockShoppingCart.addItem _)
-          .verify(where { li: AddLineItem => li.cartId == newCart.reply.cartId })
+          .verify(where { (li: AddLineItem) => li.cartId == newCart.reply.cartId })
           .once()
         succeed
       }

--- a/samples/scala-protobuf-view-store/build.sbt
+++ b/samples/scala-protobuf-view-store/build.sbt
@@ -4,7 +4,7 @@ organization := "io.kalix.samples"
 organizationHomepage := Some(url("https://kalix.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-web-resources/build.sbt
+++ b/samples/scala-protobuf-web-resources/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.example"
 
-scalaVersion := "2.13.14"
+scalaVersion := "3.3.3"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 

--- a/samples/scala-protobuf-web-resources/build.sbt
+++ b/samples/scala-protobuf-web-resources/build.sbt
@@ -40,5 +40,5 @@ Compile / javacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.7" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.18" % Test,
   "com.google.api.grpc" % "proto-google-common-protos" % "2.15.0" % Test)

--- a/sbt-plugin/src/main/scala/kalix/sbt/KalixPlugin.scala
+++ b/sbt-plugin/src/main/scala/kalix/sbt/KalixPlugin.scala
@@ -59,7 +59,7 @@ object KalixPlugin extends AutoPlugin {
     Def.settings(
       libraryDependencies ++= Seq(
         "io.kalix" % "kalix-sdk-protocol" % KalixProtocolVersion % "protobuf-src",
-        "com.google.protobuf" % "protobuf-java" % "3.17.3" % "protobuf",
+        "com.google.protobuf" % "protobuf-java" % "3.25.3" % "protobuf",
         "io.kalix" %% "kalix-scala-sdk-protobuf-testkit" % KalixSdkVersion % Test),
 
       // -------------------------------------------------------------------------------------------

--- a/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/ActionResultImpl.scala
+++ b/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/ActionResultImpl.scala
@@ -100,6 +100,6 @@ final class ActionResultImpl[T](effect: ActionEffectImpl.PrimaryEffect[T]) exten
   }
 
   override def getSideEffects(): JList[DeferredCallDetails[_, _]] =
-    toDeferredCallDetails(effect.internalSideEffects())
+    toDeferredCallDetails(effect.internalSideEffects)
 
 }

--- a/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitActionContext.scala
+++ b/sdk/java-sdk-protobuf-testkit/src/main/scala/kalix/javasdk/testkit/impl/TestKitActionContext.scala
@@ -16,7 +16,7 @@ import java.util.Optional
 /**
  * INTERNAL API Used by the generated testkit
  */
-final class TestKitActionContext(metadata: Metadata, mockRegistry: MockRegistry = MockRegistry.EMPTY)
+final class TestKitActionContext(override val metadata: Metadata, mockRegistry: MockRegistry = MockRegistry.EMPTY)
     extends AbstractTestKitContext(mockRegistry)
     with ActionContext
     with ActionCreationContext
@@ -30,7 +30,7 @@ final class TestKitActionContext(metadata: Metadata, mockRegistry: MockRegistry 
     this(metadata, MockRegistry.EMPTY)
   }
 
-  override def metadata() = metadata
+  //override def metadata() = metadata
 
   override def eventSubject() = metadata.get("ce-subject")
 

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/TraceContext.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/TraceContext.java
@@ -4,8 +4,6 @@
 
 package kalix.javasdk;
 
-import io.opentelemetry.context.Context;
-
 import java.util.Optional;
 
 /** Utility interface for trace context helper methods. */
@@ -17,7 +15,7 @@ public interface TraceContext {
    *
    * @return the trace context as an OpenTelemetry context.
    */
-  Context asOpenTelemetryContext();
+  io.opentelemetry.context.Context asOpenTelemetryContext();
 
   /**
    * Allows retrieving the trace parent for easier injection in external calls (e.g. HTTP request

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/TraceContext.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/TraceContext.java
@@ -4,6 +4,8 @@
 
 package kalix.javasdk;
 
+import io.opentelemetry.context.Context;
+
 import java.util.Optional;
 
 /** Utility interface for trace context helper methods. */
@@ -15,7 +17,7 @@ public interface TraceContext {
    *
    * @return the trace context as an OpenTelemetry context.
    */
-  io.opentelemetry.context.Context asOpenTelemetryContext();
+  Context asOpenTelemetryContext();
 
   /**
    * Allows retrieving the trace parent for easier injection in external calls (e.g. HTTP request

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/AnySupport.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/AnySupport.scala
@@ -41,29 +41,29 @@ object AnySupport {
   private val log = LoggerFactory.getLogger(classOf[AnySupport])
 
   sealed abstract class Primitive[T: ClassTag] {
-    val name = fieldType.name().toLowerCase(Locale.ROOT)
-    val fullName = KalixPrimitive + name
-    final val clazz = implicitly[ClassTag[T]].runtimeClass
+    val name: String = fieldType.name().toLowerCase(Locale.ROOT)
+    val fullName: String = KalixPrimitive + name
+    final val clazz: Class[_] = implicitly[ClassTag[T]].runtimeClass
     def write(stream: CodedOutputStream, t: T): Unit
     def read(stream: CodedInputStream): T
     def fieldType: WireFormat.FieldType
     def defaultValue: T
-    val tag = (KalixPrimitiveFieldNumber << 3) | fieldType.getWireType
+    val tag: Int = (KalixPrimitiveFieldNumber << 3) | fieldType.getWireType
   }
 
-  private final object StringPrimitive extends Primitive[String] {
+  private object StringPrimitive extends Primitive[String] {
     override def fieldType = WireFormat.FieldType.STRING
     override def defaultValue = ""
-    override def write(stream: CodedOutputStream, t: String) = stream.writeString(KalixPrimitiveFieldNumber, t)
-    override def read(stream: CodedInputStream) = stream.readString()
+    override def write(stream: CodedOutputStream, t: String): Unit = stream.writeString(KalixPrimitiveFieldNumber, t)
+    override def read(stream: CodedInputStream): String = stream.readString()
   }
 
-  final object BytesPrimitive extends Primitive[ByteString] {
+  object BytesPrimitive extends Primitive[ByteString] {
     override def fieldType = WireFormat.FieldType.BYTES
     override def defaultValue = ByteString.EMPTY
-    override def write(stream: CodedOutputStream, t: ByteString) =
+    override def write(stream: CodedOutputStream, t: ByteString): Unit =
       stream.writeBytes(KalixPrimitiveFieldNumber, t)
-    override def read(stream: CodedInputStream) = stream.readBytes()
+    override def read(stream: CodedInputStream): ByteString = stream.readBytes()
   }
 
   private final val Primitives = Seq(
@@ -155,7 +155,7 @@ object AnySupport {
    * should be preferred.
    */
   sealed trait Prefer
-  final object Prefer {
+  object Prefer {
     case object Java extends Prefer
     case object Scala extends Prefer
   }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ComponentOptions.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/ComponentOptions.scala
@@ -10,7 +10,7 @@ trait ComponentOptions {
    * @return
    *   the headers requested to be forwarded as metadata (cannot be mutated, use withForwardHeaders)
    */
-  def forwardHeaders(): java.util.Set[String]
+  def forwardHeaders: java.util.Set[String]
 
   /**
    * Ask Kalix to forward these headers from the incoming request as metadata headers for the incoming commands. By

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
@@ -83,9 +83,7 @@ class DiscoveryImpl(
 
     // possibly filtered or hidden env, passed along for substitution in descriptor options
     val env: Map[String, String] = system.settings.config.getAnyRef("kalix.discovery.pass-along-env-allow") match {
-      // FIXME: how to do this better?
-      case obj if !obj.asInstanceOf[Boolean] => Map.empty
-      case obj if obj.asInstanceOf[Boolean]  => sys.env
+      case bool: Boolean => if (bool) sys.env else Map.empty
       case allowed: util.ArrayList[String @unchecked] =>
         allowed.asScala.flatMap(name => sys.env.get(name).map(value => name -> value)).toMap
       case unexpected =>

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
@@ -83,7 +83,7 @@ class DiscoveryImpl(
 
     // possibly filtered or hidden env, passed along for substitution in descriptor options
     val env: Map[String, String] = system.settings.config.getAnyRef("kalix.discovery.pass-along-env-allow") match {
-      case bool: Boolean => if (bool) sys.env else Map.empty
+      case bool: java.lang.Boolean => if (bool) sys.env else Map.empty
       case allowed: util.ArrayList[String @unchecked] =>
         allowed.asScala.flatMap(name => sys.env.get(name).map(value => name -> value)).toMap
       case unexpected =>

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DocLinks.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DocLinks.scala
@@ -10,12 +10,12 @@ case class DocLinks(sdkName: String) {
   // sdkName is of format e.g. kalix-java-sdk-protobuf
   private val sdkPath = if (sdkName.endsWith("-protobuf")) "java-protobuf" else "java"
 
-  val errorCodes = Map(
+  private val errorCodes = Map(
     "KLX-00112" -> "views.html#changing",
     "KLX-00415" -> "publishing-subscribing.html#_subscribing_to_state_changes_from_a_value_entity")
 
   // fallback if not defined in errorCodes
-  val errorCodeCategories = Map(
+  private val errorCodeCategories = Map(
     "KLX-001" -> "views.html",
     "KLX-002" -> "value-entity.html",
     "KLX-003" -> "event-sourced-entities.html",

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/EntityExceptions.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/EntityExceptions.scala
@@ -4,8 +4,8 @@
 
 package kalix.javasdk.impl
 
-import kalix.javasdk.eventsourcedentity
-import kalix.javasdk.valueentity
+import kalix.javasdk.eventsourcedentity.{ CommandContext => ESECommandContext }
+import kalix.javasdk.valueentity.{ CommandContext => VECommandContext }
 import kalix.protocol.entity.Command
 import kalix.protocol.event_sourced_entity.EventSourcedInit
 import kalix.protocol.replicated_entity.ReplicatedEntityInit
@@ -37,16 +37,16 @@ object EntityExceptions {
     def apply(command: Command, message: String, cause: Option[Throwable]): EntityException =
       EntityException(command.entityId, command.id, command.name, message, cause)
 
-    def apply(context: valueentity.CommandContext, message: String): EntityException =
+    def apply(context: VECommandContext, message: String): EntityException =
       EntityException(context.entityId, context.commandId, context.commandName, message, None)
 
-    def apply(context: valueentity.CommandContext, message: String, cause: Option[Throwable]): EntityException =
+    def apply(context: VECommandContext, message: String, cause: Option[Throwable]): EntityException =
       EntityException(context.entityId, context.commandId, context.commandName, message, cause)
 
-    def apply(context: eventsourcedentity.CommandContext, message: String): EntityException =
+    def apply(context: ESECommandContext, message: String): EntityException =
       EntityException(context.entityId, context.commandId, context.commandName, message, None)
 
-    def apply(context: eventsourcedentity.CommandContext, message: String, cause: Option[Throwable]): EntityException =
+    def apply(context: ESECommandContext, message: String, cause: Option[Throwable]): EntityException =
       EntityException(context.entityId, context.commandId, context.commandName, message, cause)
   }
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
@@ -274,7 +274,7 @@ object MetadataImpl {
     (key, attr)
   }.toMap
 
-  val Empty = MetadataImpl.of(Vector.empty)
+  val Empty: MetadataImpl = MetadataImpl.of(Vector.empty)
 
   val JwtClaimPrefix = "_kalix-jwt-claim-"
 

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionEffectImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionEffectImpl.scala
@@ -67,7 +67,7 @@ object ActionEffectImpl {
     def isEmpty: Boolean = true
     override def canHaveSideEffects: Boolean = false
 
-    override def internalSideEffects = Nil
+    override def internalSideEffects: Seq[SideEffect] = Nil
 
     protected def withSideEffects(sideEffect: Seq[SideEffect]): PrimaryEffect[Nothing] = {
       throw new IllegalArgumentException("adding side effects to 'ignore' is not allowed.")

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionEffectImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionEffectImpl.scala
@@ -23,11 +23,11 @@ import kalix.javasdk.HttpResponse
 object ActionEffectImpl {
   sealed abstract class PrimaryEffect[T] extends Action.Effect[T] {
     override def addSideEffect(sideEffects: SideEffect*): Action.Effect[T] =
-      withSideEffects(internalSideEffects() ++ sideEffects)
+      withSideEffects(internalSideEffects ++ sideEffects)
     override def addSideEffects(sideEffects: util.Collection[SideEffect]): Action.Effect[T] =
-      withSideEffects(internalSideEffects() ++ sideEffects.asScala)
+      withSideEffects(internalSideEffects ++ sideEffects.asScala)
     override def canHaveSideEffects: Boolean = true
-    def internalSideEffects(): Seq[SideEffect]
+    def internalSideEffects: Seq[SideEffect]
     protected def withSideEffects(sideEffects: Seq[SideEffect]): Action.Effect[T]
   }
 
@@ -67,7 +67,7 @@ object ActionEffectImpl {
     def isEmpty: Boolean = true
     override def canHaveSideEffects: Boolean = false
 
-    override def internalSideEffects() = Nil
+    override def internalSideEffects = Nil
 
     protected def withSideEffects(sideEffect: Seq[SideEffect]): PrimaryEffect[Nothing] = {
       throw new IllegalArgumentException("adding side effects to 'ignore' is not allowed.")

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -96,7 +96,7 @@ final class EventSourcedEntitiesImpl(
     // FIXME overlay configuration provided by _system
     (name, if (service.snapshotEvery == 0) service.withSnapshotEvery(configuration.snapshotEvery) else service)
   }.toMap
-  val telemetry = Telemetry(system)
+  val telemetry: Telemetry = Telemetry(system)
   lazy val instrumentations: Map[String, Instrumentation] = services.values.map { s =>
     (s.serviceName, telemetry.traceInstrumentation(s.serviceName, EventSourcedEntityCategory))
   }.toMap

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedCounterImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedCounterImpl.scala
@@ -35,6 +35,6 @@ private[kalix] final class ReplicatedCounterImpl(value: Long = 0, delta: Long = 
       new ReplicatedCounterImpl(value + increment)
   }
 
-  override def toString = s"ReplicatedCounter($value)"
+  override def toString: String = s"ReplicatedCounter($value)"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedCounterMapImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedCounterMapImpl.scala
@@ -94,6 +94,6 @@ private[kalix] final class ReplicatedCounterMapImpl[K](
       new ReplicatedCounterMapImpl(anySupport, updatedCounters)
   }
 
-  override def toString = s"ReplicatedCounterMap(${counters.map { case (k, v) => s"$k->$v" }.mkString(",")})"
+  override def toString: String = s"ReplicatedCounterMap(${counters.map { case (k, v) => s"$k->$v" }.mkString(",")})"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntitiesImpl.scala
@@ -135,7 +135,7 @@ object ReplicatedEntitiesImpl {
       initialData: Option[InternalReplicatedData],
       system: ActorSystem) {
 
-    val router = {
+    val router: ReplicatedEntityRouter[_ <: Object, _ <: Object] = {
       val context = new ReplicatedEntityCreationContext(entityId, system)
       try {
         service.factory.create(context)

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntityRouter.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedEntityRouter.scala
@@ -52,7 +52,7 @@ abstract class ReplicatedEntityRouter[D <: ReplicatedData, E <: ReplicatedEntity
     data = internalData.applyDelta
       .applyOrElse(
         delta.delta,
-        { noMatch: ReplicatedEntityDelta.Delta =>
+        { (noMatch: ReplicatedEntityDelta.Delta) =>
           throw ProtocolException(
             entityId,
             s"Received delta ${noMatch.value.getClass} which doesn't match the expected replicated data type: ${internalData.name}")

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedMapImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedMapImpl.scala
@@ -153,6 +153,6 @@ private[kalix] final class ReplicatedMapImpl[K, V <: ReplicatedData](
       new ReplicatedMapImpl(anySupport, newEntries)
   }
 
-  override def toString = s"ReplicatedMap(${entries.map { case (k, v) => s"$k->$v" }.mkString(",")})"
+  override def toString: String = s"ReplicatedMap(${entries.map { case (k, v) => s"$k->$v" }.mkString(",")})"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedMultiMapImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedMultiMapImpl.scala
@@ -109,6 +109,6 @@ private[kalix] final class ReplicatedMultiMapImpl[K, V](
       new ReplicatedMultiMapImpl(anySupport, updatedEntries)
   }
 
-  override def toString = s"ReplicatedMultiMap(${entries.map { case (k, v) => s"$k->$v" }.mkString(",")})"
+  override def toString: String = s"ReplicatedMultiMap(${entries.map { case (k, v) => s"$k->$v" }.mkString(",")})"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedRegisterImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedRegisterImpl.scala
@@ -57,6 +57,6 @@ private[kalix] final class ReplicatedRegisterImpl[T](
         ReplicatedEntityClock.REPLICATED_ENTITY_CLOCK_CUSTOM_AUTO_INCREMENT
     }
 
-  override def toString = s"ReplicatedRegister($value)"
+  override def toString: String = s"ReplicatedRegister($value)"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedRegisterMapImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedRegisterMapImpl.scala
@@ -94,6 +94,6 @@ private[kalix] final class ReplicatedRegisterMapImpl[K, V](
       new ReplicatedRegisterMapImpl(anySupport, updatedRegisters)
   }
 
-  override def toString = s"ReplicatedRegisterMap(${registers.map { case (k, v) => s"$k->$v" }.mkString(",")})"
+  override def toString: String = s"ReplicatedRegisterMap(${registers.map { case (k, v) => s"$k->$v" }.mkString(",")})"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedSetImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedSetImpl.scala
@@ -119,6 +119,6 @@ private[kalix] class ReplicatedSetImpl[E](
       new ReplicatedSetImpl(anySupport, updatedValue)
   }
 
-  override def toString = s"ReplicatedSet(${values.mkString(",")})"
+  override def toString: String = s"ReplicatedSet(${values.mkString(",")})"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedVoteImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/replicatedentity/ReplicatedVoteImpl.scala
@@ -45,6 +45,6 @@ private[kalix] final class ReplicatedVoteImpl(
       new ReplicatedVoteImpl(selfVote, votesFor, voters)
   }
 
-  override def toString = s"Vote($selfVote)"
+  override def toString: String = s"Vote($selfVote)"
 
 }

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/telemetry/Telemetry.scala
@@ -107,7 +107,7 @@ private[kalix] object TraceInstrumentation {
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  lazy val otelGetter = new TextMapGetter[Metadata]() {
+  lazy val otelGetter: TextMapGetter[Metadata] = new TextMapGetter[Metadata]() {
     override def get(carrier: Metadata, key: String): String = {
       if (logger.isTraceEnabled) logger.trace("For the key [{}] the value is [{}]", key, carrier.get(key))
       carrier.get(key).toScala.getOrElse("")

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -79,7 +79,7 @@ final class ValueEntitiesImpl(
 
   private final val log = LoggerFactory.getLogger(this.getClass)
 
-  val telemetry = Telemetry(system)
+  val telemetry: Telemetry = Telemetry(system)
   lazy val instrumentations: Map[String, Instrumentation] = services.values.map { s =>
     (s.serviceName, telemetry.traceInstrumentation(s.serviceName, ValueEntityCategory))
   }.toMap

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/GrpcClientsSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/GrpcClientsSpec.scala
@@ -21,6 +21,7 @@ import scala.concurrent.Promise
 import scala.jdk.FutureConverters.FutureOps
 
 import akka.actor.ClassicActorSystemProvider
+import com.typesafe.config.Config
 
 // dummy instead of depending on actual generated Akka gRPC client to keep it simple
 trait PretendService {}
@@ -40,7 +41,7 @@ class PretendServiceClient(val settings: GrpcClientSettings) extends PretendServ
 }
 
 object GrpcClientsSpec {
-  def config = ConfigFactory.parseString("""
+  def config: Config = ConfigFactory.parseString("""
      |akka.grpc.client.c {
      |  service-discovery {
      |    service-name = "my-service"

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/workflow/WorkflowImplSpec.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/javasdk/impl/workflow/WorkflowImplSpec.scala
@@ -249,10 +249,10 @@ object WorkflowImplSpec {
     def testWorkflow: TestWorkflow =
       TestWorkflow.service(TransferWorkflowProvider.of(_ => new TransferWorkflow()));
 
-    def owner(name: String) =
+    def owner(name: String): MoneyTransferApi.Owner =
       MoneyTransferApi.Owner.newBuilder().setName(name).build()
 
-    def transfer(workflowId: String, from: String, to: String, amount: Double) =
+    def transfer(workflowId: String, from: String, to: String, amount: Double): MoneyTransferApi.Transfer =
       MoneyTransferApi.Transfer
         .newBuilder()
         .setWorkflowId(workflowId)

--- a/sdk/java-sdk-protobuf/src/test/scala/kalix/testkit/workflow/WorkflowMessages.scala
+++ b/sdk/java-sdk-protobuf/src/test/scala/kalix/testkit/workflow/WorkflowMessages.scala
@@ -97,7 +97,7 @@ object WorkflowMessages extends EntityMessages {
     Some(WorkflowClientAction(WorkflowClientAction.Action.Reply(component.Reply(payload, None))))
   }
 
-  def stepTransition(stepName: String) =
+  def stepTransition(stepName: String): WorkflowEffect.Transition.StepTransition =
     WorkflowEffect.Transition.StepTransition(StepTransition(stepName))
 
   def reply(id: Long, payload: ScalaPbAny): OutMessage =

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/http/HttpEndpointMethodDefinition.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/http/HttpEndpointMethodDefinition.scala
@@ -64,13 +64,12 @@ object HttpEndpointMethodDefinition {
 
   // This is used to support the "*" custom pattern
   val ANY_METHOD =
-    HttpMethod.custom(
+    HttpMethod(
       "ANY",
-      safe = false,
-      idempotent = false,
+      isSafe = false,
+      isIdempotent = false,
       requestEntityAcceptance = RequestEntityAcceptance.Tolerated,
-      contentLengthAllowed = false
-    ) // FIXME get his back: (forStatus: StatusCode) => forStatus.intValue < 200 || forStatus.intValue >= 300)
+      contentLengthAllowed = (forStatus: StatusCode) => forStatus.intValue < 200 || forStatus.intValue >= 300)
 
   /**
    * INTERNAL API

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/http/HttpEndpointMethodDefinition.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/http/HttpEndpointMethodDefinition.scala
@@ -64,12 +64,13 @@ object HttpEndpointMethodDefinition {
 
   // This is used to support the "*" custom pattern
   val ANY_METHOD =
-    HttpMethod(
+    HttpMethod.custom(
       "ANY",
-      isSafe = false,
-      isIdempotent = false,
+      safe = false,
+      idempotent = false,
       requestEntityAcceptance = RequestEntityAcceptance.Tolerated,
-      contentLengthAllowed = (forStatus: StatusCode) => forStatus.intValue < 200 || forStatus.intValue >= 300)
+      contentLengthAllowed = false
+    ) // FIXME get his back: (forStatus: StatusCode) => forStatus.intValue < 200 || forStatus.intValue >= 300)
 
   /**
    * INTERNAL API

--- a/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ComponentDescriptorSuite.scala
+++ b/sdk/java-sdk-spring/src/test/scala/kalix/javasdk/impl/ComponentDescriptorSuite.scala
@@ -40,7 +40,7 @@ trait ComponentDescriptorSuite extends Matchers {
 
   def assertFieldIsProto3Optional(method: CommandHandler, fieldName: String): Assertion = {
     val field: Descriptors.FieldDescriptor = findField(method, fieldName)
-    field.hasOptionalKeyword shouldBe true
+    field.isOptional shouldBe true
     val oneofDesc = field.getContainingOneof
     oneofDesc.getName shouldBe "_" + fieldName
     method.requestMessageDescriptor.getOneofs should contain(oneofDesc)

--- a/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/EventingTestKit.scala
+++ b/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/EventingTestKit.scala
@@ -78,7 +78,7 @@ trait IncomingMessages {
 
 @InternalApi
 object IncomingMessages {
-  def apply(delegate: JEventingTestKit.IncomingMessages): IncomingMessages = IncomingMessagesImpl(delegate)
+  def apply(delegate: JEventingTestKit.IncomingMessages): IncomingMessages = IncomingMessagesImpl.apply(delegate)
 }
 
 /**
@@ -213,7 +213,7 @@ trait OutgoingMessages {
 @InternalApi
 object OutgoingMessages {
   def apply(delegate: JEventingTestKit.OutgoingMessages, codec: MessageCodec): OutgoingMessages =
-    OutgoingMessagesImpl(delegate, codec)
+    OutgoingMessagesImpl.apply(delegate, codec)
 }
 
 @ApiMayChange

--- a/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/impl/ActionResultImpl.scala
+++ b/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/impl/ActionResultImpl.scala
@@ -28,7 +28,7 @@ final class ActionResultImpl[T](val effect: ActionEffectImpl.PrimaryEffect[T]) e
   }
 
   override def sideEffects: Seq[DeferredCallDetails[_, _]] =
-    EffectUtils.toDeferredCallDetails(effect.toJavaSdk.asInstanceOf[JavaPrimaryEffect[_]].internalSideEffects())
+    EffectUtils.toDeferredCallDetails(effect.toJavaSdk.asInstanceOf[JavaPrimaryEffect[_]].internalSideEffects)
 
   override def isForward: Boolean = effect.isInstanceOf[ActionEffectImpl.ForwardEffect[_]]
 
@@ -42,7 +42,7 @@ final class ActionResultImpl[T](val effect: ActionEffectImpl.PrimaryEffect[T]) e
 
   override def asyncResult: Future[ActionResult[T]] = effect match {
     case a: ActionEffectImpl.AsyncEffect[T] =>
-      a.effect.map { case p: ActionEffectImpl.PrimaryEffect[T] =>
+      a.effect.map { case p: ActionEffectImpl.PrimaryEffect[T @unchecked] =>
         new ActionResultImpl[T](p)
       }(ExecutionContext.global)
     case _ => throw new IllegalStateException(s"The effect was not an async effect but [$effectName]")

--- a/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/impl/EventingTestKitImpl.scala
+++ b/sdk/scala-sdk-protobuf-testkit/src/main/scala/kalix/scalasdk/testkit/impl/EventingTestKitImpl.scala
@@ -24,8 +24,7 @@ import scala.reflect.ClassTag
 import kalix.scalasdk.testkit.IncomingMessages
 import kalix.scalasdk.testkit.OutgoingMessages
 
-private[testkit] case class IncomingMessagesImpl private (delegate: JEventingTestKit.IncomingMessages)
-    extends IncomingMessages {
+private[testkit] case class IncomingMessagesImpl(delegate: JEventingTestKit.IncomingMessages) extends IncomingMessages {
 
   override def publish(message: ByteString): Unit = delegate.publish(message)
 
@@ -44,9 +43,7 @@ private[testkit] case class IncomingMessagesImpl private (delegate: JEventingTes
   override def publishDelete(subject: String): Unit = delegate.publishDelete(subject)
 }
 
-private[testkit] case class OutgoingMessagesImpl private (
-    delegate: JEventingTestKit.OutgoingMessages,
-    codec: MessageCodec)
+private[testkit] case class OutgoingMessagesImpl(delegate: JEventingTestKit.OutgoingMessages, codec: MessageCodec)
     extends OutgoingMessages {
 
   override def expectNone(): Unit = delegate.expectNone()

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/view/ViewAdapters.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/view/ViewAdapters.scala
@@ -62,7 +62,7 @@ private[scalasdk] class JavaViewRouterAdapter[S](
 
   override def handleUpdate(commandName: String, state: S, event: Any): javasdk.view.View.UpdateEffect[S] = {
     scalaSdkRouter.handleUpdate(commandName, state, event) match {
-      case effect: ViewUpdateEffectImpl.PrimaryUpdateEffect[S] => effect.toJavaSdk
+      case effect: ViewUpdateEffectImpl.PrimaryUpdateEffect[S @unchecked] => effect.toJavaSdk
     }
   }
 }

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowAdapters.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowAdapters.scala
@@ -166,7 +166,7 @@ private[scalasdk] final class JavaWorkflowRouterAdapter[S >: Null](
 private[scalasdk] final class JavaWorkflowOptionsAdapter(scalaSdkWorkflowOptions: WorkflowOptions)
     extends javasdk.workflow.WorkflowOptions {
 
-  def forwardHeaders(): java.util.Set[String] = scalaSdkWorkflowOptions.forwardHeaders.asJava
+  def forwardHeaders: java.util.Set[String] = scalaSdkWorkflowOptions.forwardHeaders.asJava
 
   def withForwardHeaders(headers: java.util.Set[String]): javasdk.workflow.WorkflowOptions =
     new JavaWorkflowOptionsAdapter(scalaSdkWorkflowOptions.withForwardHeaders(Set.from(headers.asScala)))


### PR DESCRIPTION
Refs #2133 

This PR:
 - adds cross-compilations for the modules required to offer scala 3 support for scala protocol-first sdk 
 - bumps samples to scala 3.3.3 by default
 - configs CI to run all samples both with scala 2.13 and scala 3 so we keep them compatible with both versions