### PR TITLE
ci: revert sdk 1.5.0 bump and disable ci release plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
           SDK_VERSION="$(cat ~/kalix-sdk-version.txt)"
           echo "SDK version: '${SDK_VERSION}'"
 
-      - name: sbt ci-release
+      - name: sbt publishSigned
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -33,7 +33,7 @@ jobs:
         id: determine_sdk_version
         run: |-
           .github/determine-sdk-version.sh
-          SDK_VERSION="$(cat sdk-version.txt)"
+          SDK_VERSION="$(cat kalix-sdk-version.txt)"
           echo "SDK version: '${SDK_VERSION}'"
           echo "sdk_version=${SDK_VERSION}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -33,7 +33,7 @@ jobs:
         id: determine_sdk_version
         run: |-
           .github/determine-sdk-version.sh
-          SDK_VERSION="$(cat kalix-sdk-version.txt)"
+          SDK_VERSION="$(cat sdk-version.txt)"
           echo "SDK version: '${SDK_VERSION}'"
           echo "sdk_version=${SDK_VERSION}" >> $GITHUB_OUTPUT
 

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,9 @@ lazy val scala213Options = scala212Options ++
 // -Wconf configs will be available once https://github.com/scala/scala3/pull/20282 is merged and 3.3.4 is released
 lazy val scala3Options = sharedScalacOptions ++ Seq("-Wunused:imports,privates,locals")
 
+// we use publishSigned, but use a pgp utility from CiReleasePlugin
+disablePlugins(CiReleasePlugin)
+
 def disciplinedScalacSettings: Seq[Setting[_]] = {
   if (sys.props.get("kalix.no-discipline").isEmpty) {
     Seq(Compile / scalacOptions ++= {

--- a/maven-java/kalix-java-protobuf-parent/pom.xml
+++ b/maven-java/kalix-java-protobuf-parent/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.5.0</version>
+        <version>1.4.1</version>
     </parent>
     
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
     <packaging>pom</packaging>
 
 
@@ -39,7 +39,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
     
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kalix-sdk.version>1.5.0</kalix-sdk.version>
+        <kalix-sdk.version>1.4.1</kalix-sdk.version>
         <akka-grpc.version>2.1.6</akka-grpc.version>
 
         <!-- plugin versions -->

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-maven-archetype-event-sourced-entity</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.5.0</version>
+        <version>1.4.1</version>
     </parent>
 
     <name>Kalix Maven Archetype (Event Sourced entity)</name>

--- a/maven-java/kalix-maven-archetype-value-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-maven-archetype</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.5.0</version>
+        <version>1.4.1</version>
     </parent>
 
     <name>Kalix Maven Archetype (Value entity)</name>

--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-maven-java</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <artifactId>kalix-maven-plugin</artifactId>

--- a/maven-java/kalix-spring-boot-archetype/pom.xml
+++ b/maven-java/kalix-spring-boot-archetype/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-spring-boot-archetype</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.5.0</version>
+        <version>1.4.1</version>
     </parent>
 
     <name>Kalix Maven Archetype (Java SDK)</name>

--- a/maven-java/kalix-spring-boot-kotlin-archetype/pom.xml
+++ b/maven-java/kalix-spring-boot-kotlin-archetype/pom.xml
@@ -2,12 +2,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kalix-spring-boot-kotlin-archetype</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
     <packaging>maven-archetype</packaging>
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.5.0</version>
+        <version>1.4.1</version>
     </parent>
 
     <name>Kalix Maven Archetype (Java SDK)</name>

--- a/maven-java/kalix-spring-boot-parent/pom.xml
+++ b/maven-java/kalix-spring-boot-parent/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>io.kalix</groupId>
         <artifactId>kalix-maven-java</artifactId>
-        <version>1.5.0</version>
+        <version>1.4.1</version>
     </parent>
     
     <!-- it has spring-boot-starter as parent, but groupId remains io.kalix -->
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
     <packaging>pom</packaging>
 
 
@@ -38,7 +38,7 @@
         <java.version>21</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kalix-sdk.version>1.5.0</kalix-sdk.version>
+        <kalix-sdk.version>1.4.1</kalix-sdk.version>
         <skip.docker>false</skip.docker>
 
 

--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.kalix</groupId>
   <artifactId>kalix-maven-java</artifactId>
-  <version>1.5.0</version>
+  <version>1.4.1</version>
   <packaging>pom</packaging>
 
   <name>Kalix Java Maven parent pom</name>

--- a/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-kafka-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>customer</groupId>

--- a/samples/java-protobuf-customer-registry-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>customer</groupId>

--- a/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-protobuf-customer-registry-views-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>customer</groupId>

--- a/samples/java-protobuf-doc-snippets/pom.xml
+++ b/samples/java-protobuf-doc-snippets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-eventsourced-counter/pom.xml
+++ b/samples/java-protobuf-eventsourced-counter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry-subscriber/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>io.kalix.samples</groupId>

--- a/samples/java-protobuf-eventsourced-customer-registry/pom.xml
+++ b/samples/java-protobuf-eventsourced-customer-registry/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>io.kalix.samples</groupId>

--- a/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-protobuf-eventsourced-shopping-cart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-fibonacci-action/pom.xml
+++ b/samples/java-protobuf-fibonacci-action/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-first-service/pom.xml
+++ b/samples/java-protobuf-first-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-reliable-timers/pom.xml
+++ b/samples/java-protobuf-reliable-timers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-replicatedentity-examples/pom.xml
+++ b/samples/java-protobuf-replicatedentity-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-replicatedentity-shopping-cart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-shopping-cart-quickstart/pom.xml
+++ b/samples/java-protobuf-shopping-cart-quickstart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>shop</groupId>

--- a/samples/java-protobuf-tracing/pom.xml
+++ b/samples/java-protobuf-tracing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-transfer-workflow-compensation/pom.xml
+++ b/samples/java-protobuf-transfer-workflow-compensation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-transfer-workflow/pom.xml
+++ b/samples/java-protobuf-transfer-workflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-valueentity-counter-spring-client/pom.xml
+++ b/samples/java-protobuf-valueentity-counter-spring-client/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.example</groupId>
     <artifactId>java-protobuf-valueentity-counter-spring-client</artifactId>
-    <version>1.5.0</version>
+    <version>0.0.1</version>
     <packaging>jar</packaging>
 
     <name>java-protobuf-valueentity-counter-spring-client</name>

--- a/samples/java-protobuf-valueentity-counter/pom.xml
+++ b/samples/java-protobuf-valueentity-counter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-valueentity-customer-registry/pom.xml
+++ b/samples/java-protobuf-valueentity-customer-registry/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>io.kalix.samples</groupId>

--- a/samples/java-protobuf-valueentity-shopping-cart/pom.xml
+++ b/samples/java-protobuf-valueentity-shopping-cart/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-protobuf-view-store/pom.xml
+++ b/samples/java-protobuf-view-store/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>io.kalix.samples</groupId>

--- a/samples/java-protobuf-web-resources/pom.xml
+++ b/samples/java-protobuf-web-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-java-sdk-protobuf-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-choreography-saga-quickstart/pom.xml
+++ b/samples/java-spring-choreography-saga-quickstart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>java-spring-choreography-saga-quickstart</groupId>

--- a/samples/java-spring-customer-registry-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-quickstart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-spring-customer-registry-views-quickstart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-doc-snippets/pom.xml
+++ b/samples/java-spring-doc-snippets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-eventsourced-counter/pom.xml
+++ b/samples/java-spring-eventsourced-counter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry-subscriber/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>customer</groupId>

--- a/samples/java-spring-eventsourced-customer-registry/pom.xml
+++ b/samples/java-spring-eventsourced-customer-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-spring-eventsourced-shopping-cart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-fibonacci-action/pom.xml
+++ b/samples/java-spring-fibonacci-action/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-reliable-timers/pom.xml
+++ b/samples/java-spring-reliable-timers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-shopping-cart-quickstart/pom.xml
+++ b/samples/java-spring-shopping-cart-quickstart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>shopping.cart</groupId>

--- a/samples/java-spring-tracing/pom.xml
+++ b/samples/java-spring-tracing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-transfer-workflow-compensation/pom.xml
+++ b/samples/java-spring-transfer-workflow-compensation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-transfer-workflow/pom.xml
+++ b/samples/java-spring-transfer-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-valueentity-counter/pom.xml
+++ b/samples/java-spring-valueentity-counter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-valueentity-customer-registry/pom.xml
+++ b/samples/java-spring-valueentity-customer-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-valueentity-shopping-cart/pom.xml
+++ b/samples/java-spring-valueentity-shopping-cart/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/java-spring-view-store/pom.xml
+++ b/samples/java-spring-view-store/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-spring-boot-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.4.1</version>
   </parent>
 
   <groupId>com.example</groupId>

--- a/samples/scala-protobuf-customer-registry-quickstart/project/plugins.sbt
+++ b/samples/scala-protobuf-customer-registry-quickstart/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-doc-snippets/project/plugins.sbt
+++ b/samples/scala-protobuf-doc-snippets/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-eventsourced-counter/project/plugins.sbt
+++ b/samples/scala-protobuf-eventsourced-counter/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-eventsourced-customer-registry-subscriber/project/plugins.sbt
+++ b/samples/scala-protobuf-eventsourced-customer-registry-subscriber/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-eventsourced-customer-registry/project/plugins.sbt
+++ b/samples/scala-protobuf-eventsourced-customer-registry/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-eventsourced-shopping-cart/project/plugins.sbt
+++ b/samples/scala-protobuf-eventsourced-shopping-cart/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-fibonacci-action/project/plugins.sbt
+++ b/samples/scala-protobuf-fibonacci-action/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-first-service/project/plugins.sbt
+++ b/samples/scala-protobuf-first-service/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-reliable-timers/project/plugins.sbt
+++ b/samples/scala-protobuf-reliable-timers/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-replicatedentity-examples/project/plugins.sbt
+++ b/samples/scala-protobuf-replicatedentity-examples/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-replicatedentity-shopping-cart/project/plugins.sbt
+++ b/samples/scala-protobuf-replicatedentity-shopping-cart/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-tracing/project/plugins.sbt
+++ b/samples/scala-protobuf-tracing/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-transfer-workflow-compensation/project/plugins.sbt
+++ b/samples/scala-protobuf-transfer-workflow-compensation/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-transfer-workflow/project/plugins.sbt
+++ b/samples/scala-protobuf-transfer-workflow/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-validated/project/plugins.sbt
+++ b/samples/scala-protobuf-validated/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-valueentity-counter/project/plugins.sbt
+++ b/samples/scala-protobuf-valueentity-counter/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-valueentity-customer-registry/project/plugins.sbt
+++ b/samples/scala-protobuf-valueentity-customer-registry/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-valueentity-shopping-cart/project/plugins.sbt
+++ b/samples/scala-protobuf-valueentity-shopping-cart/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-view-store/project/plugins.sbt
+++ b/samples/scala-protobuf-view-store/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/samples/scala-protobuf-web-resources/project/plugins.sbt
+++ b/samples/scala-protobuf-web-resources/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
-addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.5.0"))
+addSbtPlugin("io.kalix" % "sbt-kalix" % System.getProperty("kalix-sdk.version", "1.4.1"))
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/updateSdkVersions.sh
+++ b/updateSdkVersions.sh
@@ -9,13 +9,6 @@ if [[ -z "$SDK_VERSION" ]]; then
     exit 1
 fi
 
-
-updateDocs() {
-  echo ">>> Update references in docs"
-  sed -i.bak "s/<kalix-sdk.version>\(.*\)<\/kalix-sdk.version>/<kalix-sdk.version>$SDK_VERSION<\/kalix-sdk.version>/" ./docs/src/modules/java/pages/spring-client.adoc
-  rm docs/src/modules/java/pages/spring-client.adoc.bak
-}
-
 updateJavaSamples() {
   echo ">>> Updating pom versions to $SDK_VERSION"
   PROJS=$(find $1 -type f -name "pom.xml")

--- a/updateSdkVersions.sh
+++ b/updateSdkVersions.sh
@@ -9,6 +9,13 @@ if [[ -z "$SDK_VERSION" ]]; then
     exit 1
 fi
 
+
+updateDocs() {
+  echo ">>> Update references in docs"
+  sed -i.bak "s/<kalix-sdk.version>\(.*\)<\/kalix-sdk.version>/<kalix-sdk.version>$SDK_VERSION<\/kalix-sdk.version>/" ./docs/src/modules/java/pages/spring-client.adoc
+  rm docs/src/modules/java/pages/spring-client.adoc.bak
+}
+
 updateJavaSamples() {
   echo ">>> Updating pom versions to $SDK_VERSION"
   PROJS=$(find $1 -type f -name "pom.xml")


### PR DESCRIPTION
This partially reverts commit a50949196f5a7863145840aa3fe44cbb19e2af5a.

The revert of the version is that we can have CI passing here. It will be bumped again once release is successful.

Also disables ci release plugin which I hope will fix publishing to internal repo.