### PR TITLE
build: fix duplicate publishing

### DIFF
--- a/project/PublishPlugin.scala
+++ b/project/PublishPlugin.scala
@@ -25,9 +25,7 @@ object DefaultPublishSettings extends AutoPlugin {
   override def projectSettings = Seq(
     publish / skip := true,
     publishTo := None,
-    pomIncludeRepository := (_ => false),
-    // Note: need to use the new s01.oss.sonatype.org host
-    sonatypeCredentialHost := Sonatype.sonatype01)
+    pomIncludeRepository := (_ => false))
 }
 
 /**


### PR DESCRIPTION
Refs https://github.com/lightbend/kalix-jvm-sdk/issues/2139

Don't think his solves all but we should need this to avoid duplication for the 2.12_1.0 packages.
