### PR TITLE
fix: remove Akka snapshot repos

### DIFF
--- a/maven-java/kalix-java-protobuf-parent/pom.xml
+++ b/maven-java/kalix-java-protobuf-parent/pom.xml
@@ -60,12 +60,6 @@
             <id>akka-repository</id>
             <url>https://repo.akka.io/maven</url>
         </pluginRepository>
-
-        <!-- remove snapshots before final release -->
-        <pluginRepository>
-            <id>akka-repository-snapshots</id>
-            <url>https://repo.akka.io/snapshots</url>
-        </pluginRepository>
     </pluginRepositories>
 
     <repositories>
@@ -73,12 +67,6 @@
             <id>akka-repository</id>
             <name>Akka library repository</name>
             <url>https://repo.akka.io/maven</url>
-        </repository>
-
-        <!-- remove snapshots before final release -->
-        <repository>
-            <id>akka-repository-snapshots</id>
-            <url>https://repo.akka.io/snapshots</url>
         </repository>
     </repositories>
 

--- a/maven-java/kalix-spring-boot-parent/pom.xml
+++ b/maven-java/kalix-spring-boot-parent/pom.xml
@@ -62,12 +62,6 @@
             <id>akka-repository</id>
             <url>https://repo.akka.io/maven</url>
         </pluginRepository>
-
-        <!-- remove snapshots before final release -->
-        <pluginRepository>
-            <id>akka-repository-snapshots</id>
-            <url>https://repo.akka.io/snapshots</url>
-        </pluginRepository>
     </pluginRepositories>
 
     <repositories>
@@ -75,12 +69,6 @@
             <id>akka-repository</id>
             <name>Akka library repository</name>
             <url>https://repo.akka.io/maven</url>
-        </repository>
-
-        <!-- remove snapshots before final release -->
-        <repository>
-            <id>akka-repository-snapshots</id>
-            <url>https://repo.akka.io/snapshots</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
These should have been dropped when all Akka 24.05 releases were final.