### PR TITLE
fix: mirror the correct example

### DIFF
--- a/.github/workflows/samples-repo-sync.yml
+++ b/.github/workflows/samples-repo-sync.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sample: java-protobuf-shopping-cart-quickstart, public-repo: user-registry-choreography-saga }
+          - { sample: java-spring-choreography-saga-quickstart, public-repo: user-registry-choreography-saga }
 
     steps:
       - name: Checkout JVM SDK


### PR DESCRIPTION
As it turns out, we mirrored to totally wrong quickstart into the kalix-io org. 🤦 

References
- #1985 
- https://github.com/kalix-io/user-registry-choreography-saga/pull/6
- https://github.com/lightbend/kalix-jvm-sdk/tree/main/samples/java-spring-choreography-saga-quickstart
