### PR TITLE
fix: keep .env during repo sync

### DIFF
--- a/.github/workflows/samples-repo-sync.yml
+++ b/.github/workflows/samples-repo-sync.yml
@@ -41,8 +41,17 @@ jobs:
         run: |
           rsync -r --delete kalix-jvm-sdk/samples/${{ matrix.sample }}/* ${{ matrix.public-repo }}
 
+      - name: Explicitly add the .env file
+        run: |
+          git config user.name 'Kalix Bot'
+          git config user.email 'noreply@github.com'
+          git add .env
+          git commit -m "Keep .env"
+
       - name: Create Pull Request - ${{ matrix.public-repo }}
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        # https://github.com/peter-evans/create-pull-request
+        # v6.0.5
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
         with:
           path: ${{ matrix.public-repo }}
           title: Changes from JVM SDK repo


### PR DESCRIPTION
The new `.env` file need to be explicitly added to the PR.

Also bumps the pull request action to the current version.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
References
- https://github.com/peter-evans/create-pull-request/releases
