### PR TITLE
fix: keep .env during repo sync 3

### DIFF
--- a/.github/workflows/samples-repo-sync.yml
+++ b/.github/workflows/samples-repo-sync.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Copy example
         run: |
           rsync -r --delete kalix-jvm-sdk/samples/${{ matrix.sample }}/* ${{ matrix.public-repo }}
+          # copy .env but continue if it didn't exist 
+          cp kalix-jvm-sdk/samples/${{ matrix.sample }}/.env ${{ matrix.public-repo }} || :
 
       - name: Explicitly add the .env file
         run: |


### PR DESCRIPTION
Explicitly copy `.env`.

References
- #2156
- #2157