### PR TITLE
feat: passing through metadata traceparent

### DIFF
--- a/sdk/java-sdk-protobuf-testkit/src/test/scala/kalix/javasdk/testkit/impl/ActionResultSpec.scala
+++ b/sdk/java-sdk-protobuf-testkit/src/test/scala/kalix/javasdk/testkit/impl/ActionResultSpec.scala
@@ -17,7 +17,8 @@ class ActionResultSpec extends AnyWordSpec with Matchers {
   "Action Results" must {
     "extract side effects" in {
       val replyWithSideEffectResult = new ActionResultImpl[String](
-        new ActionEffectImpl.Builder(Metadata.EMPTY)
+        ActionEffectImpl
+          .builder(Metadata.EMPTY)
           .reply("reply")
           .addSideEffect(SideEffectImpl(
             GrpcDeferredCall[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", _ => ???),
@@ -28,8 +29,9 @@ class ActionResultSpec extends AnyWordSpec with Matchers {
     }
 
     "extract forward details" in {
-      val forwardResult = new ActionResultImpl[String](
-        new ActionEffectImpl.Builder(Metadata.EMPTY).forward(
+      val forwardResult = new ActionResultImpl[String](ActionEffectImpl
+        .builder(Metadata.EMPTY)
+        .forward(
           GrpcDeferredCall[String, String]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", _ => ???)))
 
       forwardResult.isForward() should ===(true)

--- a/sdk/java-sdk-protobuf-testkit/src/test/scala/kalix/javasdk/testkit/impl/ActionResultSpec.scala
+++ b/sdk/java-sdk-protobuf-testkit/src/test/scala/kalix/javasdk/testkit/impl/ActionResultSpec.scala
@@ -4,6 +4,7 @@
 
 package kalix.javasdk.testkit.impl
 
+import kalix.javasdk.Metadata
 import kalix.javasdk.impl.GrpcDeferredCall
 import kalix.javasdk.impl.MetadataImpl
 import kalix.javasdk.impl.action.ActionEffectImpl
@@ -16,7 +17,7 @@ class ActionResultSpec extends AnyWordSpec with Matchers {
   "Action Results" must {
     "extract side effects" in {
       val replyWithSideEffectResult = new ActionResultImpl[String](
-        ActionEffectImpl.Builder
+        new ActionEffectImpl.Builder(Metadata.EMPTY)
           .reply("reply")
           .addSideEffect(SideEffectImpl(
             GrpcDeferredCall[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", _ => ???),
@@ -28,12 +29,13 @@ class ActionResultSpec extends AnyWordSpec with Matchers {
 
     "extract forward details" in {
       val forwardResult = new ActionResultImpl[String](
-        ActionEffectImpl.Builder.forward(
+        new ActionEffectImpl.Builder(Metadata.EMPTY).forward(
           GrpcDeferredCall[String, String]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", _ => ???)))
 
       forwardResult.isForward() should ===(true)
       forwardResult.getForward().getMessage should ===("request")
     }
+
   }
 
 }

--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/Action.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/action/Action.java
@@ -81,7 +81,7 @@ public abstract class Action {
   }
 
   public final Effect.Builder effects() {
-    return ActionEffectImpl.builder();
+    return ActionEffectImpl.builder(actionContext().metadata());
   }
 
   /**

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/action/ActionsImpl.scala
@@ -189,14 +189,13 @@ private[javasdk] final class ActionsImpl(_system: ActorSystem, services: Map[Str
           } catch {
             case NonFatal(ex) =>
               // command handler threw an "unexpected" error
+              span.foreach(_.end())
               Future.successful(handleUnexpectedException(service, in, ex))
           } finally {
             MDC.remove(Telemetry.TRACE_ID)
           }
         fut.andThen { case _ =>
-          span.foreach { s =>
-            s.end()
-          }
+          span.foreach(_.end())
         }
       case None =>
         Future.successful(

--- a/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/action/ReflectiveActionRouter.scala
+++ b/sdk/java-sdk-spring/src/main/scala/kalix/javasdk/impl/action/ReflectiveActionRouter.scala
@@ -7,12 +7,10 @@ package kalix.javasdk.impl.action
 import akka.NotUsed
 import akka.stream.javadsl.Source
 import com.google.protobuf.any.{ Any => ScalaPbAny }
-import kalix.javasdk.action.Action
-import kalix.javasdk.action.MessageEnvelope
+import kalix.javasdk.action.{ Action, MessageEnvelope }
 import kalix.javasdk.impl.AnySupport.ProtobufEmptyTypeUrl
-import kalix.javasdk.impl.CommandHandler
-import kalix.javasdk.impl.InvocationContext
 import kalix.javasdk.impl.reflection.Reflect
+import kalix.javasdk.impl.{ CommandHandler, InvocationContext }
 
 // TODO: abstract away reactor dependency
 import reactor.core.publisher.Flux
@@ -56,7 +54,8 @@ class ReflectiveActionRouter[A <: Action](
               .invoke(action, invocationContext)
               .asInstanceOf[Action.Effect[_]]
         }
-      case None if ignoreUnknown => ActionEffectImpl.Builder.ignore()
+      case None if ignoreUnknown =>
+        new ActionEffectImpl.Builder(invocationContext.metadata).ignore()
       case None =>
         throw new NoSuchElementException(
           s"Couldn't find any method with input type [$inputTypeUrl] in Action [$action].")


### PR DESCRIPTION
feat to automatially passing the traceparent in the metadata on 'reply' or 'asyncReply'

In the java-spring-eventsourced-counter (slightly modified, see modification* below) we were getting this if we didn't pass explicitly the metadata 


<img width="625" alt="Screenshot 2024-07-06 at 15 49 13" src="https://github.com/lightbend/kalix-jvm-sdk/assets/1381621/e199c82d-f035-43b9-b828-c83da2902216">

instead of the expected

<img width="622" alt="Screenshot 2024-07-06 at 15 39 48" src="https://github.com/lightbend/kalix-jvm-sdk/assets/1381621/59f4ed5b-8969-4776-b3f0-c63a2fd375d2">

*the `modification` involved to make the action`CounterCommandFromTopicAction` consume from the same topic that `CounterJournalToTopicAction` was publishing to, such when consuming events that would reply to the ESE that originated the event `CounterJournalToTopicAction` was consuming in the first place. There's no circularity here because the ESE was initially called with `increase` while the second call to the ESE was `multiply`. 