### PR TITLE
Add akka-repository for Maven dependencies and plugins

### DIFF
--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -117,6 +117,22 @@
     </profile>
   </profiles>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>akka-repository</id>
+      <name>Akka library repository</name>
+      <url>https://repo.akka.io/maven</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <repositories>
+    <repository>
+      <id>akka-repository</id>
+      <name>Akka library repository</name>
+      <url>https://repo.akka.io/maven</url>
+    </repository>
+  </repositories>
+
   <modules>
     <module>kalix-maven-plugin</module>
 


### PR DESCRIPTION
Kalix Runtime libraries are now being published to the akka-repository.

Refs
- https://github.com/lightbend/kalix-jvm-sdk/pull/2173