### PR TITLE
fix: updating sdk version

### DIFF
--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -1,17 +1,25 @@
 name: SDK version update
 
 on:
-  workflow_dispatch: # for testing
+  workflow_dispatch: # to trigger manually
   workflow_run:
     workflows: ["Publish"]
     types:
       - completed
 
 jobs:
-  open-pr-update-sample:
+  debug:
+    if: github.event.name != 'workflow_dispatch'
     runs-on: ubuntu-22.04
-    # run only when publish workflow is successful and it's a tag
-    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Debugging
+        run: |
+          echo "Conclusion from `Publish` workflow: ${{ github.event.workflow_run.conclusion }}
+          echo "Tag created from `Publish` workflow: ${{ github.ref }}
+  open-pr-update-sample:
+    # run only when publish workflow is successful and it's a tag like `v[xyz]`
+    if: (github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         # https://github.com/actions/checkout/releases

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -18,7 +18,7 @@ jobs:
           echo "Tag created from `Publish` workflow: ${{ github.ref }}
   open-pr-update-sample:
     # run only when publish workflow is successful and it's a tag like `v[xyz]`
-    if: (github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v'))
+    if: (github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This jobs haven't work for a while. See https://github.com/lightbend/kalix-jvm-sdk/actions/workflows/update-sdk-version.yml

For now I'd like to allow manual triggering and I added some debug logging for the next trigger from `Publish` event. 

Manual trigger was there before but it gets `skipped` each time I trigger it. Hence this PR. 
