### PR TITLE
fix(docs): fail deploy.sh on error in script

### DIFF
--- a/docs/bin/deploy.sh
+++ b/docs/bin/deploy.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -e
+
 #
 # Deploy doc sources to another branch.
 #


### PR DESCRIPTION
Attempt to fail the bash script if `git push` fails if no permissions.