### PR TITLE
fix: getClientGrpc, back to originally leveraging `javaSdkContext`

### DIFF
--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/action/ActionAdapters.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/action/ActionAdapters.scala
@@ -145,9 +145,8 @@ private[scalasdk] final case class ScalaActionContextAdapter(javaSdkContext: jav
   def getComponentGrpcClient[T](serviceClass: Class[T]): T = javaSdkContext match {
     case ctx: javasdk.impl.AbstractContext => ctx.getComponentGrpcClient(serviceClass)
   }
-  override def getGrpcClient[T](clientClass: Class[T], service: String): T = {
-    getComponentGrpcClient(clientClass)
-  }
+  override def getGrpcClient[T](clientClass: Class[T], service: String): T =
+    javaSdkContext.getGrpcClient(clientClass, service)
 
   override def materializer(): Materializer = javaSdkContext.materializer()
 


### PR DESCRIPTION
https://github.com/lightbend/kalix-runtime/issues/2708

