### PR TITLE
Revert "fix: change format for logMessage mkString (#2219)"

### DIFF
--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/DiscoveryImpl.scala
@@ -189,7 +189,7 @@ class DiscoveryImpl(
     val detail = if (in.detail.isEmpty) Nil else List(in.detail)
     val seeDocs = DocLinks(sdkName).forErrorCode(in.code).map(link => s"See documentation: $link").toList
     val messages = message :: detail ::: seeDocs ::: sourceMsgs
-    val logMessage = messages.mkString("\t|\t")
+    val logMessage = messages.mkString("\n\n")
 
     // ignoring waring for runtime version
     // TODO: remove it once we remove this check in the runtime


### PR DESCRIPTION
This reverts commit 119e48553aa309e25ea3073a9acf6912a85da48d.

The problem was probably that json log format wasn't used, and this is anyway not a complete solution for replacing newlines. For local development we want these messages to be readable.