### PR TITLE
chore: avoid wrong deprecation message

### DIFF
--- a/codegen/core/src/main/scala/kalix/codegen/ModelBuilder.scala
+++ b/codegen/core/src/main/scala/kalix/codegen/ModelBuilder.scala
@@ -18,6 +18,7 @@ import kalix.View
 import kalix.WorkflowDef
 
 import scala.annotation.nowarn
+import scala.annotation.nowarn
 
 /**
  * Builds a model of entities and their properties from a protobuf descriptor
@@ -709,6 +710,7 @@ object ModelBuilder {
       State(resolveMessageType(workflowDef.getState, protoPackageName, additionalDescriptors)))
   }
 
+  @nowarn("msg=deprecated")
   private def extractValueEntity(
       serviceProtoDescriptor: ServiceDescriptor,
       entityDef: ValueEntityDef,
@@ -716,7 +718,7 @@ object ModelBuilder {
       log: Log,
       messageExtractor: ProtoMessageTypeExtractor): ValueEntity = {
 
-    val typeId = getTypeId(entityDef.getTypeId, entityDef.getTypeId)
+    val typeId = getTypeId(entityDef.getEntityType, entityDef.getTypeId)
     val protoPackageName = serviceProtoDescriptor.getFile.getPackage
     ValueEntity(
       defineStatefulComponentMessageType(entityDef.getName, messageExtractor(serviceProtoDescriptor)),
@@ -724,6 +726,7 @@ object ModelBuilder {
       State(resolveMessageType(entityDef.getState, protoPackageName, additionalDescriptors)))
   }
 
+  @nowarn("msg=deprecated")
   private def extractReplicatedEntity(
       serviceProtoDescriptor: ServiceDescriptor,
       entityDef: ReplicatedEntityDef,
@@ -779,7 +782,7 @@ object ModelBuilder {
           throw new IllegalArgumentException("Replicated data type not set")
       }
 
-    val typeId = getTypeId(entityDef.getTypeId, entityDef.getTypeId)
+    val typeId = getTypeId(entityDef.getEntityType, entityDef.getTypeId)
     ReplicatedEntity(
       defineStatefulComponentMessageType(entityDef.getName, messageExtractor(serviceProtoDescriptor)),
       typeId,

--- a/docs/config/validate-links.json
+++ b/docs/config/validate-links.json
@@ -3,6 +3,7 @@
     { "pattern": "^https://mvnrepository\\.com" },
     { "pattern": "^http://127.0.0.1:8080" },
     { "pattern": "^http://jaeger:4317"},
-    { "pattern": "^http://localhost:16686"}
+    { "pattern": "^http://localhost:16686"},
+    { "pattern": "^https://supertokens.com/blog/are-you-using-jwts-for-user-sessions-in-the-correct-way"}
   ]
 }


### PR DESCRIPTION
To avoid `[WARNING] Using 'entity_type: "counter"' is deprecated, replace it with 'type_id: "counter"` on `mvn compile`

on the following .proto without `entity_type` defined.
```
service CounterService {
  option (kalix.codegen) = {
    value_entity: {
      name: "com.westpac.domain.Counter"
      type_id: "counter"
      state: "com.westpac.domain.CounterState"
    }
  };
  option (kalix.service).acl.allow = { principal: ALL };

  rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
  rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);
  rpc Reset(ResetValue) returns (google.protobuf.Empty);
  rpc GetCurrentCounter(GetCounter) returns (CurrentCounter);
}
```
