### PR TITLE
chore: disable virtual threads by default

### DIFF
--- a/sdk/java-sdk-protobuf/src/main/resources/reference.conf
+++ b/sdk/java-sdk-protobuf/src/main/resources/reference.conf
@@ -110,9 +110,5 @@ kalix {
     # Virtual threads usage can be enabled by changing the executor to be "virtual-thread-executor"
     # by default, using the fork join executor for now due to existing issue: https://openjdk.org/jeps/491
     executor = "fork-join-executor"
-    virtual-thread-executor {
-      # if not on JDK 21
-      fallback="fork-join-executor"
-    }
   }
 }

--- a/sdk/java-sdk-protobuf/src/main/resources/reference.conf
+++ b/sdk/java-sdk-protobuf/src/main/resources/reference.conf
@@ -107,7 +107,9 @@ kalix {
   }
 
   sdk-dispatcher {
-    executor = "virtual-thread-executor"
+    # Virtual threads usage can be enabled by changing the executor to be "virtual-thread-executor"
+    # by default, using the fork join executor for now due to existing issue: https://openjdk.org/jeps/491
+    executor = "fork-join-executor"
     virtual-thread-executor {
       # if not on JDK 21
       fallback="fork-join-executor"


### PR DESCRIPTION
Not using virtual threads by default until jdk 25 is out, which fixes [this issue](https://openjdk.org/jeps/491).

Refs https://github.com/lightbend/kalix/issues/13949