### PR TITLE
ci: adding javadocs and sources to archetypes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,16 +44,16 @@ jobs:
           SDK_VERSION="$(cat ~/kalix-sdk-version.txt)"
           echo "SDK version: '${SDK_VERSION}'"
 
-      #- name: sbt publishSigned
-      #  env:
-      #    PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-      #    PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      #    PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
-      #    PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
-      #  run: sbt +publishSigned
+      - name: sbt publishSigned
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
+          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+        run: sbt +publishSigned
 
-      #- name: sbt publishM2
-      #  run: sbt +publishM2
+      - name: sbt publishM2
+        run: sbt +publishM2
 
       - name: mvn deploy
         run: |-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,16 +44,16 @@ jobs:
           SDK_VERSION="$(cat ~/kalix-sdk-version.txt)"
           echo "SDK version: '${SDK_VERSION}'"
 
-      - name: sbt publishSigned
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
-        run: sbt +publishSigned
+      #- name: sbt publishSigned
+      #  env:
+      #    PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+      #    PGP_SECRET: ${{ secrets.PGP_SECRET }}
+      #    PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
+      #    PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+      #  run: sbt +publishSigned
 
-      - name: sbt publishM2
-        run: sbt +publishM2
+      #- name: sbt publishM2
+      #  run: sbt +publishM2
 
       - name: mvn deploy
         run: |-

--- a/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/pom.xml
@@ -48,6 +48,35 @@
                     <addDefaultExcludes>false</addDefaultExcludes>
                 </configuration>
             </plugin>
+            <!-- Source Jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Javadoc Jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.11.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <extensions>

--- a/maven-java/kalix-maven-archetype-value-entity/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/pom.xml
@@ -49,6 +49,34 @@
                     <addDefaultExcludes>false</addDefaultExcludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Javadoc Jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.11.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <extensions>

--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-maven-java</artifactId>
-    <version>1.5.10</version>
+    <version>1.5.14-96784f1-2-956de631-dev</version>
   </parent>
 
   <artifactId>kalix-maven-plugin</artifactId>
@@ -202,6 +202,34 @@
                 <arg>${project.build.directory}/.scala_dependencies</arg>
               </args>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Javadoc Jar -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.11.2</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/maven-java/kalix-maven-plugin/pom.xml
+++ b/maven-java/kalix-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.kalix</groupId>
     <artifactId>kalix-maven-java</artifactId>
-    <version>1.5.14-96784f1-2-956de631-dev</version>
+    <version>1.5.10</version>
   </parent>
 
   <artifactId>kalix-maven-plugin</artifactId>


### PR DESCRIPTION
New plugin `central-publishing-maven-plugin` requires sources and javadocs to be added when uploading a .jar, see [here](https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources).

Thus, adding config to produce those on the archetypes. This seems to fix the issue, as it can be seen with [this successful](https://github.com/lightbend/kalix-jvm-sdk/actions/runs/16807554821) publish.

Refs https://github.com/lightbend/kalix/issues/13949